### PR TITLE
Add get_sssom_mappings_by_curie to BioportalImplementation class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 __pycache__
 .ipynb_checkpoints/
 docs/_build/

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -4,7 +4,7 @@ Ontology Concepts
 =================
 
 Here we describe some of the over-arching concepts in this library. Note that distinct :ref:`datamodels` may impose
-their own specific views of the world, but the concepts here are intended as a kind of lingua-franca
+their own specific views of the world, but the concepts here are intended as a kind of lingua-franca.
 
 Ontology
 --------
@@ -16,15 +16,15 @@ paper from 2000, a collection of thousands of inter-related terms. However, the 
 very flexible and malleable, and might include things like:
 
 * things that are more "schema-like", such as schema.org or PROV
-* formal logical artefacts like BFO
+* formal logical artifacts like BFO
 * an "instance graph" for example of countries and their connections
 * a knowledge base encoded in RDF
 * the entirety of wikidata
 * in OWL, an ontology is just a collection of axioms
 
 We try to be as pluralistic as possible and provide a way to access all of the above using
-the appropriate abstractions. However, the main community served in "classic" ontologies such
-as those found in the OBO library or those encoded in OWL
+the appropriate abstractions. However, the main community served is "classic" ontologies such
+as those found in the OBO library or those encoded in OWL.
 
 Ontology Element
 ----------------
@@ -55,7 +55,7 @@ When working with a specific datamodel these may be partitioned more strictly. F
 - AnnotationProperties
 - DatatypeProperties
 
-The BasicOntologyInterface does not discriminate between different kinds of element. This can be confusing,
+The BasicOntologyInterface does not discriminate between different kinds of elements. This can be confusing,
 if you ask for all elements thinking you might get back only the "terms" but you would also get elements for
 relationship types, subsets, etc.
 
@@ -70,7 +70,7 @@ what appears to be one ontology has pieces of other ontologies incorporated in.
 
 This library is designed to handle all of these scenarios. In the BasicOntologyInterface, you don't have to worry about imports,
 you just get a view where everything appears as if it were in a single ontologies (even this ontologies actually a combination of
-ontologies). Other interfaces let you explore the compositional structure in more detail
+ontologies). Other interfaces let you explore the compositional structure in more detail.
 
 URIs and CURIEs and identifiers
 -------------------------------
@@ -86,14 +86,14 @@ Most methods in the interfaces in this library accept CURIEs, but these can alwa
 Prefix Maps
 -----------
 
-A prefix map maps between prefixes and their URI base expansions
+A prefix map maps between prefixes and their URI base expansions.
 
 Relationships / Edges
 ---------------------
 
 .. note ::
 
-   It may seem surprising but the Owl standard has no construct that directly corresponds to what we call
+   It may seem surprising but the OWL standard has no construct that directly corresponds to what we call
    a relationship here.
 
 Mappings
@@ -107,7 +107,7 @@ Statements and Axioms
 
 .. note ::
 
-   You only need to understand this if you are working with the OwlInterface or the RdfInterface
+   You only need to understand this if you are working with the OwlInterface or the RdfInterface.
 
 Subsets
 -------

--- a/tests/test_implementations/test_bioportal.py
+++ b/tests/test_implementations/test_bioportal.py
@@ -2,32 +2,36 @@ import itertools
 import logging
 import unittest
 
+from linkml_runtime.dumpers import yaml_dumper
 from oaklib.implementations.bioportal.bioportal_implementation import BioportalImplementation
 
-from tests import HUMAN, NEURON
+from tests import DIGIT, HUMAN, NEURON
 
 class TestBioportal(unittest.TestCase):
 
     def setUp(self) -> None:
         oi = BioportalImplementation()
-        self.has_apikey = True
         try:
             oi.load_bioportal_api_key()
         except ValueError:
-            logging.info('Skipping bioportal tests, no API key set')
-            self.has_apikey = False
+            self.skipTest('Skipping bioportal tests, no API key set')
         self.oi = oi
 
     def test_text_annotator(self):
-        if self.has_apikey:
-            results = list(self.oi.annotate_text('hippocampal neuron from human'))
-            for ann in results:
-                logging.info(ann)
-            assert any(r for r in results if r.object_id == HUMAN)
-            assert any(r for r in results if r.object_id == NEURON)
+        results = list(self.oi.annotate_text('hippocampal neuron from human'))
+        for ann in results:
+            logging.info(ann)
+        assert any(r for r in results if r.object_id == HUMAN)
+        assert any(r for r in results if r.object_id == NEURON)
 
 
     def test_search(self):
-        if self.has_apikey:
-            results = list(itertools.islice(self.oi.basic_search('tentacle pocket'), 20))
-            assert 'CEPH:0000259' in results
+        results = list(itertools.islice(self.oi.basic_search('tentacle pocket'), 20))
+        assert 'CEPH:0000259' in results
+
+
+    def test_mappings(self):
+        mappings = list(self.oi.get_sssom_mappings_by_curie(DIGIT))
+        for m in mappings:
+            print(yaml_dumper.dumps(m))
+        assert any(m for m in mappings if m.object_id == 'http://purl.obolibrary.org/obo/NCIT_C73791')


### PR DESCRIPTION
This method uses the [`/ontologies/:ontology/classes/:cls/mappings` endpoint](https://data.bioontology.org/documentation#Mapping) to get mappings and reformats them in SSSOM format.

Caveats:
* The BioPortal API has an [issue](https://github.com/ncbo/ontologies_linked_data/issues/117) where a lot of duplicate mappings are reported. We are not trying to resolve that duplication here and instead just passing the results through.
* The BioPortal API reports a `source` field for each mapping and we are manually translating that to a SKOS term, but this may be up for refinement
* The method will accept a CURIE as defined by the `MappingProviderInterface` but since the BioPortal API generally deals with URIs and not CURIEs the SSSOM `subject_id` and `predicate_id` fields will be URIs