### PR TITLE
Add missing param flag for set-apikey in tutorial

### DIFF
--- a/docs/intro/tutorial01.rst
+++ b/docs/intro/tutorial01.rst
@@ -115,7 +115,7 @@ You will then need to set it:
 
 .. code-block::
 
-    runoak set-apikey bioportal YOUR-API-KEY
+    runoak set-apikey -e bioportal YOUR-API-KEY
 
 This stores it in an OS-dependent folder
 


### PR DESCRIPTION
A very small tutorial edit.