### PR TITLE
Tidy up tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ These interfaces are *separated* from any particular [backend](https://incatools
 ## Example
 
 ```python
+from src.oaklib.resource import OntologyResource
+from src.oaklib.implementations.sqldb.sql_implementation import SqlImplementation
+
 resource = OntologyResource(slug='tests/input/go-nucleus.db', local=True)
 oi = SqlImplementation(resource)
 for curie in oi.basic_search("cell"):
     print(f'{curie} ! {oi.get_label_by_curie(curie)}')
-    for rel, fillers in oi.get_outgoing_relationships().items():
+    for rel, fillers in oi.get_outgoing_relationships_by_curie(curie).items():
         print(f'  RELATION: {rel} ! {oi.get_label_by_curie(rel)}')
         for filler in fillers:
             print(f'     * {filler} ! {oi.get_label_by_curie(filler)}')

--- a/docs/intro/tutorial01.rst
+++ b/docs/intro/tutorial01.rst
@@ -1,12 +1,13 @@
-Part 1
-=======
+Part 1: Getting Started
+=======================
 
-First we will install the package and then we will try some command line examples querying the fruitfly anatomy ontology.
+First we will install the package and then we will try some command line examples
+querying the Drosophila anatomy ontology (`fbbt <http://obofoundry.org/ontology/fbbt>`_).
 
 Installation
 -------------
 
-Create a directory
+First, create a directory:
 
 .. code-block::
 
@@ -14,7 +15,7 @@ Create a directory
     mkdir oak-tutorial
     cd oak-tutorial
 
-First create a virtual environment
+Then create a virtual environment:
 
 .. code-block::
 
@@ -22,7 +23,7 @@ First create a virtual environment
     source venv/bin/activate
     export PYTHONPATH=.:$PYTHONPATH
 
-Make sure you have Python 3.9 or higher
+.. note:: Make sure you have Python 3.9 or higher
 
 Then install:
 
@@ -30,11 +31,14 @@ Then install:
 
     pip install oaklib
 
+After successful installation, try invoking OAK via ``runoak``:
+
 .. code-block::
 
     runoak --help
 
-You should see a list of all commands.
+
+You should see a list of all commands that are supported by OAK.
 
 You can get help on a specific command:
 
@@ -44,20 +48,23 @@ You can get help on a specific command:
 
 See also the :ref:`cli` section of this documentation
 
+
 Query the OBO Library
 ---------------------
 
 Next try using the "search" command to search for a term in the Drosophila anatomy ontology (`fbbt <http://obofoundry.org/ontology/fbbt>`_).
 
-The base command takes an :code:`--input` (or just :code:`-i`) option that specifies the input implementation. We will return to the full syntax later,
-but one pattern that is useful to know is :code:`obolibrary:<ontology-file>`.
+The base command takes an ``--input`` (or just ``-i``) option that specifies the input
+implementation. We will return to the full syntax later, but one pattern that is
+useful to know is ``obolibrary:<ontology-file>``.
+
 
 .. code-block::
 
-    runoak -i obolibrary:fbbt.obo search 'wing vein'
+    runoak --input obolibrary:fbbt.obo search 'wing vein'
 
-The first time you run this there will be a lag as the file is downloaded, but after that it will be cached. (This is using the Pronto
-library under the hood)
+The first time you run this there will be a lag as the file is downloaded,
+but after that it will be cached. (This is using the Pronto library under the hood)
 
 After the lag you will get results like:
 
@@ -68,35 +75,63 @@ After the lag you will get results like:
     FBbt:00004759 ! wing vein L1
     FBbt:00004760 ! wing vein L2
 
+
 Working with local files
 ------------------------
+
+To work with a local ontology file, you can provide the filename as input:
 
 .. code-block::
 
     wget http://purl.obolibrary.org/obo/fbbt.obo
-    runoak -i fbbt.obo search 'wing vein'
+    runoak --input fbbt.obo search 'wing vein'
+
 
 Fetching ancestors
 ------------------
 
 Next we will try a different command, plugging in an ID we got from the previous search.
 
-We will use the :code:`ancestors` command to find all rdfs:subClassOf and part-of (BFO:0000050) ancestors of 'wing vein'.
+We will use the :ref:`ancestors` command to find all subclass-of (``rdfs:subClassOf``) and part-of (``BFO:0000050``) ancestors of 'wing vein'.
 
 .. code-block::
 
-    runoak -i obolibrary:fbbt.obo ancestors FBbt:00004751 -p i,p
+    runoak --input obolibrary:fbbt.obo ancestors FBbt:00004751 --predicates i,p
 
-*Here we are using built-in shorthands, but you can get the same effect with the full :ref:`CURIE`s, rdfs:subClassOf and BFO:0000050)
+You should see body parts such as cuticle, wing, etc, alongside their ID.
 
-You should see body parts such as cuticle, wing, etc, alongside their ID
+.. note:: Here we are providing the predicates to traverse via the ``-p/--predicates`` argument.
+   The values ``i`` and ``p`` for the predicates argument are short-hand names for
+   ``rdfs:subClassOf`` and ``BFO:0000050``, respectively.
+
+   You can get the same effect with the full predicate CURIEs, ``rdfs:subClassOf` and ``BFO:0000050``.
+
+   .. code-block::
+
+      runoak --input obolibrary:fbbt.obo ancestors FBbt:00004751 --predicates rdfs:subClassOf,BFO:0000050
+
+
+   Possible short-hand names are:
+    - ``i`` for the ``rdfs:subClassOf`` predicate
+    - ``p`` for the ``BFO:0000050`` predicate
+    - ``e`` for the ``owl:equivalentClass`` predicate
+
 
 Later on we will see how we can make images like:
 
 .. image:: wing-vein.png
 
+
 Using other backends
 --------------------
+
+You can use OAK to query other backends that provides one (or more ontologies) as a graph.
+
+
+Using Ubergraph
+~~~~~~~~~~~~~~~
+
+Ubergraph is an integrated ontology store that contains a merged set of mutually referential OBO ontologies.
 
 .. code-block::
 
@@ -106,24 +141,31 @@ This searches the :ref:`ubergraph` backend using the blazegraph search interface
 of ontologies, this returns a ranked list that might include matches only to "wing" or "vein". Currently each backend implements
 search a little differently, but this will be more unified and controllable in the future.
 
-Using BioPortal
---------------------
 
-First you will need to go to `BioPortal <https://bioportal.bioontology.org/>`_ and get an API key, if you don't already have one.
+Using BioPortal
+~~~~~~~~~~~~~~~
+
+BioPortal is a comprehensive repository of biomedical ontologies.
+
+To query BioPortal, first you will need to go to `BioPortal <https://bioportal.bioontology.org/>`_ and get an API key (if you don't already have one).
+
+
+.. note:: The API Key is assigned to each user upon creating an account on BioPortal.
+
 
 You will then need to set it:
 
 .. code-block::
 
-    runoak set-apikey -e bioportal YOUR-API-KEY
+    runoak set-apikey --endpoint bioportal YOUR-API-KEY
 
-This stores it in an OS-dependent folder
+This stores it in an OS-dependent folder, which is then accessed by OAK for performing API queries.
 
 .. code-block::
 
     runoak -i bioportal: search 'wing vein'
 
-Again the results are relevance ranked, and there are a lot of them, as this includes multiple ontologies, you may want to ctrl-C to kill before the end
+Again the results are relevance ranked, and there are a lot of them, as this includes multiple ontologies, you may want to ctrl-C to kill before the end.
 
 Next steps
 ----------

--- a/docs/intro/tutorial02.rst
+++ b/docs/intro/tutorial02.rst
@@ -1,7 +1,7 @@
 Part 2: Basic Python
 =====================
 
-Some basic Python knowledge is assumed
+For this tutorial some basic Python knowledge is assumed.
 
 Install Poetry
 --------------
@@ -24,13 +24,13 @@ Code the first example
 
 We are going to use an example from the :ref:`BasicOntologyInterface`, using a :ref:`ProntoImplementation`
 
-We will use a Jupyter notebook for the running example. As preparation, we expect `fbbt.obo` to exist
-in the same directory as the python notebook. fbbt.obo can be downloaded here:
+We will use a Jupyter notebook for the running example. As preparation, we expect :code:`fbbt.obo` to exist
+in the same directory as the python notebook.
 
-http://purl.obolibrary.org/obo/fbbt.obo
+:code:`fbbt.obo` can be downloaded here: http://purl.obolibrary.org/obo/fbbt.obo
 
 
-``my_oak_demo/demo.ipynb``
+Then create a Notebook: ``my_oak_demo/demo.ipynb`` and add the following:
 
 .. code-block:: python
 
@@ -39,10 +39,10 @@ http://purl.obolibrary.org/obo/fbbt.obo
     resource = OntologyResource(slug='fbbt.obo', local=True)
     oi = ProntoImplementation(resource)
 
-We first import the general `OntologyResource` implementation which allows us to declare where to get the ontology from.
-We then load this resource using the `ProntoImplementation`, which allows us to perform all operations on the resource 
-that we could do with [pronto](https://github.com/althonos/pronto). Next, let us use `pronto` to actually
-query the ontology:
+- We first import the general ``OntologyResource`` implementation which allows us to declare where to get the ontology from.
+- We then load this resource using the ``ProntoImplementation``, which allows us to perform all operations on the resource that we could do with `pronto <https://github.com/althonos/pronto>`_.
+
+Next, let us use `pronto` to actually query the ontology:
 
 .. code-block:: python
 
@@ -54,11 +54,12 @@ query the ontology:
             print(f'    {parent} ! {oi.get_label_by_curie(parent)}')
 
 We first obtain all of the outgoing relationships from the 
-FBbt class for "wing vein", which has the id of `FBbt:00004751`.
+FBbt class for "wing vein", which has the id of ``FBbt:00004751``.
 
 Next, we iterate through all the relationships, and print the labels for 
-both the relationship and the connected entities (here named `parents`) using
-the `get_label_by_curie()` method of the `ProntoImplementation` object.
+both the relationship and the connected entities (here named ``parents``) using
+the ``get_label_by_curie()`` method of the ``ProntoImplementation`` object.
+
 
 You should see something similar to:
 

--- a/docs/intro/tutorial04.rst
+++ b/docs/intro/tutorial04.rst
@@ -33,7 +33,7 @@ OboGraph Interface
 -----------
 
 Like most datamodels in OAK, the OboGraph datamodel follows a Data Access Object (DAO) pattern - the objects are intentionally limited
-in their behavior. For example, you cannot ask a node what edges come out or go in; these is stored at the top level graph object.
+in their behavior. For example, you cannot ask a node what edges come out or go in; these are stored at the top level graph object.
 
 "Smarter" operations are provided by the interface
 

--- a/docs/intro/tutorial05.rst
+++ b/docs/intro/tutorial05.rst
@@ -1,27 +1,49 @@
 Part 5: Graph Visualization
 =====================
 
+This section of the tutorial requires two dependencies that are outside OAK.
+
+- Graphviz
+- OBOGraphViz
+
+Install Graphviz
+----------------
+
+Graphviz is an open-source graph visualization software that provides a way to
+represent information about graphs and networks.
+
+For installation refer to `Graphviz.org/download/ <https://graphviz.org/download/>`_.
+
+
 Install OBOGraphViz
---------------
+-------------------
+
+OBOGraphViz is a Javascript package that allows you to visualize OBOGraphs using Graphviz.
+
+You can use ``npm`` or ``yarn`` to install the OBOGraphViz package.
 
 .. code-block::
 
     npm install obographviz
 
+
 Command Line Usage
 -----------------
+
+Using OAK, you can generate graph visualizations directly from the command line as follows:
 
 .. code-block::
 
     runoak -i obolibrary:fbbt.obo viz FBbt:00004751 -p i,p -o wing-vein.png
 
-Then open the file wing-vein.png using a tool such as Preview, or in a web browser.
+Then open the file ``wing-vein.png`` using a tool such as Preview, or in a web browser.
 
-If you omit the --output option then the png will be written to a temp file and immediately opened:
+If you omit the ``-o/--output`` option then the png will be written to a temp file and immediately opened:
 
 .. code-block::
 
     runoak -i obolibrary:fbbt.obo viz FBbt:00004751 -p i,p
+
 
 How this works
 ---------------
@@ -29,6 +51,7 @@ How this works
  - First, the :ref:`OboGraphInterface` is invoked to query all ancestors of the term
  - in this case the implementation is :ref:`pronto` plus graph walking code
  - after an obograph is generated this is passed to the obographviz library
+
 
 Programmatic usage
 ---------------

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,8 @@
 
 ## Introduction
 
+Ontology Access Toolkit (OAK) is a Python library for common ontology operations over a variety of backends.
+
 This library provides a collection of different interfaces for different kinds of ontology operations, including:
 
  - lookup of basic features of an ontology element, such as it's label, definition, relationships, or aliases.
@@ -16,13 +18,15 @@ These interfaces are *separated* from any particular backend. This means the sam
  - is queried from a remote database, including SPARQL endpoints, A SQL database, a Solr/ES endpoint.
 
 ```python
-# alternate implementations commented out
-resource = OntologyResource(slug='tests/input/go-nucleus.obo', local=True)
-ont = SqlDatabaseBasicImpl.create(resource)
-for curie in ont.basic_search("cell"):
-    print(f'{curie} ! {impl.get_label_by_curie(curie)}')
-    for rel, fillers in ont.get_outgoing_relationships().items():
-        print(f'  RELATION:: {rel} ! {impl.get_label_by_curie(rel)}')
+from src.oaklib.resource import OntologyResource
+from src.oaklib.implementations.sqldb.sql_implementation import SqlImplementation
+
+resource = OntologyResource(slug='tests/input/go-nucleus.db', local=True)
+si = SqlImplementation(resource)
+for curie in si.basic_search("cell"):
+    print(f'{curie} ! {si.get_label_by_curie(curie)}')
+    for rel, fillers in si.get_outgoing_relationships_by_curie(curie).items():
+        print(f'  RELATION:: {rel} ! {si.get_label_by_curie(rel)}')
         for filler in fillers:
-            print(f'     * {filler} ! {impl.get_label_by_curie(filler)}')
+            print(f'     * {filler} ! {si.get_label_by_curie(filler)}')
 ```

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -112,7 +112,7 @@ class SqlImplementation(RelationGraphInterface, OboGraphInterface, ValidatorInte
                 # they should be running through ODK docker
                 locator = locator.replace('.owl', '.db').replace('sqlite:', '')
                 semsql_builder.make(locator)
-                locator = f'sqlite:///{locator}'
+            locator = f'sqlite:///{locator}'
             self.engine = create_engine(locator)
 
     @property

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -112,7 +112,7 @@ class SqlImplementation(RelationGraphInterface, OboGraphInterface, ValidatorInte
                 # they should be running through ODK docker
                 locator = locator.replace('.owl', '.db').replace('sqlite:', '')
                 semsql_builder.make(locator)
-            locator = f'sqlite:///{locator}'
+                locator = f'sqlite:///{locator}'
             self.engine = create_engine(locator)
 
     @property


### PR DESCRIPTION
This PR is a first pass at tidying up the tutorials after going through most of them.

This PR also fixes a bug in `SqlImplementation.__post_init__()` method, without which the examples in the tutorial (`README.md` and `introduction.md`) wouldn't work.

Questions:
- I see we are using Sphinx for documentation. Are we committed to Sphinx/reST?
- Can we look into MkDocs, since it has typically been used in most of our Python projects?