### PR TITLE
[WIP] Pass flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,5 +26,5 @@ deps =
     flake8-black
     flake8-isort
 commands =
-    flake8 --select D300,I001,I002,I003,I004,I005,BLK100 src/ tests/
+    flake8 --ignore E501,W503 src/ tests/
 description = Run the flake8 tool with several plugins (bandit, docstrings, import order, pep8 naming).


### PR DESCRIPTION
This PR turns on `flake8` in earnest. It adds two ignores - E501 (line too long) and W503 (line break after operator). These are okay since flake8 is actually wrong about W503 and E501 is taken care of by `black`. Additional ignores can be used to reduce the scope of this PR, if desired, but eventually it makes sense to pass flake8 in its entirety.