### PR TITLE
Fix for #166

### DIFF
--- a/src/oaklib/__init__.py
+++ b/src/oaklib/__init__.py
@@ -6,5 +6,6 @@ __version__ = "0.1.0"
 
 from oaklib.interfaces import BasicOntologyInterface  # noqa:F401
 from oaklib.resource import OntologyResource  # noqa:F401
+from oaklib.selector import get_implementation_from_shorthand  # noqa:F401
 
 schemes = {}

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -97,6 +97,7 @@ class ProntoImplementation(
     def __post_init__(self):
         if self.wrapped_ontology is None:
             resource = self.resource
+            logging.info(f"Pronto using resource: {resource}")
             if resource is None:
                 ontology = Ontology()
             elif resource.local:

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -201,7 +201,7 @@ class SqlImplementation(
                 db_path = OAKLIB_MODULE.ensure(url=url)
                 # Option 2 uses botocore to interface with the S3 API directly:
                 # db_path = OAKLIB_MODULE.ensure_from_s3(s3_bucket="bbop-sqlite", s3_key=f"{prefix}.db")
-                locator = f"sqlite:///{db_path.as_uri()}"
+                locator = f"sqlite:///{db_path}"
             if locator.endswith(".owl"):
                 # this is currently an "Easter Egg" feature. It allows you to specify a locator
                 # such as sqlite:/path/to/my.owl
@@ -216,6 +216,7 @@ class SqlImplementation(
             else:
                 path = Path(locator.replace("sqlite:", "")).absolute()
                 locator = f"sqlite:///{path}"
+            logging.info(f"Locator, post-processed: {locator}")
             self.engine = create_engine(locator)
 
     @property

--- a/src/oaklib/selector.py
+++ b/src/oaklib/selector.py
@@ -44,6 +44,7 @@ SCHEME_DICT = {
     "ontobee": OntobeeImplementation,
     "lov": LovImplementation,
     "sparql": SparqlImplementation,
+    "rdflib": SparqlImplementation,
     "bioportal": BioportalImplementation,
     "agroportal": AgroportalImplementation,
     "wikidata": WikidataImplementation,
@@ -135,30 +136,11 @@ def get_resource_from_shorthand(descriptor: str, format: str = None) -> Ontology
             elif impl_class == SparqlImplementation:
                 resource.url = rest
                 resource.slug = None
-            elif scheme == "rdflib":
-                impl_class = SparqlImplementation
-            elif scheme == "bioportal":
-                impl_class = BioportalImplementation
-            elif scheme == "agroportal":
-                impl_class = AgroportalImplementation
-            elif scheme == "wikidata":
-                impl_class = WikidataImplementation
-            elif scheme == "ols":
-                impl_class = OlsImplementation
-            elif scheme == "funowl":
-                impl_class = FunOwlImplementation
-            elif scheme == "pronto":
-                impl_class = ProntoImplementation
+            elif scheme == ProntoImplementation:
                 if resource.slug.endswith(".obo"):
                     resource.format = "obo"
                 resource.local = True
                 resource.slug = rest
-            elif scheme == "obolibrary" or scheme == "prontolib":
-                impl_class = ProntoImplementation
-                if resource.slug.endswith(".obo"):
-                    resource.format = "obo"
-                resource.slug = rest
-                resource.local = scheme == "pronto"
             else:
                 for ext_name, ext_module in discovered_plugins.items():
                     try:
@@ -172,24 +154,9 @@ def get_resource_from_shorthand(descriptor: str, format: str = None) -> Ontology
         else:
             logging.info(f"No schema: assuming file path {descriptor}")
             suffix = descriptor.split(".")[-1]
-            # TODO: use get_resource_imp_class_from_suffix_descriptor
-            if suffix == "db" or (format and format == "sqlite"):
-                impl_class = SqlImplementation
-                resource.slug = f"sqlite:///{Path(descriptor).absolute()}"
-            elif format and format in RDF_SUFFIX_TO_FORMAT.values():
-                impl_class = SparqlImplementation
-            elif suffix == "ofn":
-                impl_class = FunOwlImplementation
-            elif suffix in RDF_SUFFIX_TO_FORMAT:
-                impl_class = SparqlImplementation
-                resource.format = RDF_SUFFIX_TO_FORMAT[suffix]
-            elif suffix == "owl":
-                impl_class = SparqlImplementation
-                resource.format = "xml"
-                logging.warning("Using rdflib rdf/xml parser; this behavior may change in future")
-            else:
-                resource.local = True
-                impl_class = ProntoImplementation
+            impl_class, resource = get_resource_imp_class_from_suffix_descriptor(
+                suffix, resource, descriptor
+            )
     else:
         raise ValueError("No descriptor")
 

--- a/src/oaklib/selector.py
+++ b/src/oaklib/selector.py
@@ -136,10 +136,13 @@ def get_resource_from_shorthand(descriptor: str, format: str = None) -> Ontology
             elif impl_class == SparqlImplementation:
                 resource.url = rest
                 resource.slug = None
-            elif scheme == ProntoImplementation:
+            elif impl_class == ProntoImplementation:
                 if resource.slug.endswith(".obo"):
                     resource.format = "obo"
-                resource.local = True
+                if scheme == "prontolib":
+                    resource.local = False
+                else:
+                    resource.local = True
                 resource.slug = rest
             else:
                 for ext_name, ext_module in discovered_plugins.items():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,7 +305,7 @@ class TestCommandLineInterface(unittest.TestCase):
     def test_search_pronto_obolibrary(self):
         to_out = ["-o", str(TEST_OUT)]
         result = self.runner.invoke(
-            main, ["-i", "obolibrary:pato.obo", "search", "t~shape"] + to_out
+            main, ["-i", "prontolib:pato.obo", "search", "t~shape"] + to_out
         )
         out = self._out()
         err = result.stderr
@@ -314,7 +314,7 @@ class TestCommandLineInterface(unittest.TestCase):
         self.assertIn("PATO:0002021", out)  # conical - matches a synonym
         self.assertEqual("", err)
         result = self.runner.invoke(
-            main, ["-i", "obolibrary:pato.obo", "search", "l=shape"] + to_out
+            main, ["-i", "prontolib:pato.obo", "search", "l=shape"] + to_out
         )
         out = self._out()
         err = result.stderr
@@ -322,7 +322,7 @@ class TestCommandLineInterface(unittest.TestCase):
         self.assertIn(SHAPE, out)
         self.assertNotIn("PATO:0002021", out)  # conical - matches a synonym
         self.assertEqual("", err)
-        result = self.runner.invoke(main, ["-i", "obolibrary:pato.obo", "search", "shape"] + to_out)
+        result = self.runner.invoke(main, ["-i", "prontolib:pato.obo", "search", "shape"] + to_out)
         out = self._out()
         err = result.stderr
         self.assertEqual(0, result.exit_code)


### PR DESCRIPTION
- When using pystow, do not use as_uri as this prepends `file:` breaking sqlite locator. Fixes #166
- comvenience path
- More graceful merge of #164 and #152
