### PR TITLE
Centralizing get_curie_prefix

### DIFF
--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -24,7 +24,6 @@ from kgcl_schema.datamodel import kgcl
 from linkml_runtime import SchemaView
 from linkml_runtime.utils.introspection import package_schemaview
 from linkml_runtime.utils.metamodelcore import URIorCURIE
-from oaklib.utilities.basic_utils import get_curie_prefix
 from semsql.sqla.semsql import (
     AnnotationPropertyNode,
     ClassNode,
@@ -90,6 +89,7 @@ from oaklib.interfaces.search_interface import SearchInterface
 from oaklib.interfaces.semsim_interface import SemanticSimilarityInterface
 from oaklib.interfaces.validator_interface import ValidatorInterface
 from oaklib.types import CURIE, SUBSET_CURIE
+from oaklib.utilities.basic_utils import get_curie_prefix
 
 __all__ = [
     "get_range_xsd_type",

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -24,6 +24,7 @@ from kgcl_schema.datamodel import kgcl
 from linkml_runtime import SchemaView
 from linkml_runtime.utils.introspection import package_schemaview
 from linkml_runtime.utils.metamodelcore import URIorCURIE
+from oaklib.utilities.basic_utils import get_curie_prefix
 from semsql.sqla.semsql import (
     AnnotationPropertyNode,
     ClassNode,
@@ -97,13 +98,6 @@ __all__ = [
 ]
 
 
-def _curie_prefix(curie: CURIE) -> Optional[str]:
-    if ":" in curie:
-        return curie.split(":")[0]
-    else:
-        return None
-
-
 def _is_blank(curie: CURIE) -> bool:
     return curie.startswith("_:")
 
@@ -111,8 +105,8 @@ def _is_blank(curie: CURIE) -> bool:
 def _mapping(m: Mapping):
     # enhances a mapping with sources
     # TODO: move to sssom utils
-    m.subject_source = _curie_prefix(m.subject_id)
-    m.object_source = _curie_prefix(m.object_id)
+    m.subject_source = get_curie_prefix(m.subject_id)
+    m.object_source = get_curie_prefix(m.object_id)
     return m
 
 

--- a/src/oaklib/interfaces/basic_ontology_interface.py
+++ b/src/oaklib/interfaces/basic_ontology_interface.py
@@ -188,7 +188,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         predicates: List[PRED_CURIE] = None,
         ignore_owl_thing=True,
         filter_obsoletes=True,
-        id_prefixes: List[CURIE] = None
+        id_prefixes: List[CURIE] = None,
     ) -> Iterable[CURIE]:
         """
         All root nodes, where root is defined as any node that is not the subject of
@@ -200,7 +200,8 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :param id_prefixes: limit search to specific prefixes
         :return:
         """
-        logging.warning(f"Using naive cross-backend method for root detection, may be slow")
+        # this interface-level method should be replaced by specific implementations
+        logging.info("Using naive approach for root detection, may be slow")
         candidates = []
         for curie in self.all_entity_curies(owl_type=OWL_CLASS):
             if id_prefixes is None or get_curie_prefix(curie) in id_prefixes:
@@ -211,7 +212,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
                 continue
             if ignore_owl_thing and object == OWL_THING:
                 continue
-            if not(id_prefixes is None or get_curie_prefix(object) in id_prefixes):
+            if not (id_prefixes is None or get_curie_prefix(object) in id_prefixes):
                 continue
             # if object not in all_curies:
             #    continue

--- a/src/oaklib/interfaces/basic_ontology_interface.py
+++ b/src/oaklib/interfaces/basic_ontology_interface.py
@@ -13,6 +13,7 @@ from oaklib.datamodels.vocabulary import (
 )
 from oaklib.interfaces.ontology_interface import OntologyInterface
 from oaklib.types import CURIE, PRED_CURIE, SUBSET_CURIE, URI
+from oaklib.utilities.basic_utils import get_curie_prefix
 
 NC_NAME = str
 PREFIX_MAP = Dict[NC_NAME, URI]
@@ -183,7 +184,11 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         raise NotImplementedError
 
     def roots(
-        self, predicates: List[PRED_CURIE] = None, ignore_owl_thing=True, filter_obsoletes=True
+        self,
+        predicates: List[PRED_CURIE] = None,
+        ignore_owl_thing=True,
+        filter_obsoletes=True,
+        id_prefixes: List[CURIE] = None
     ) -> Iterable[CURIE]:
         """
         All root nodes, where root is defined as any node that is not the subject of
@@ -192,15 +197,21 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :param predicates:
         :param ignore_owl_thing: do not consider artificial/trivial owl:Thing when calculating (default=True)
         :param filter_obsoletes: do not include obsolete/deprecated nodes in results (default=True)
+        :param id_prefixes: limit search to specific prefixes
         :return:
         """
-        all_curies = set(list(self.all_entity_curies(owl_type=OWL_CLASS)))
-        candidates = all_curies
+        logging.warning(f"Using naive cross-backend method for root detection, may be slow")
+        candidates = []
+        for curie in self.all_entity_curies(owl_type=OWL_CLASS):
+            if id_prefixes is None or get_curie_prefix(curie) in id_prefixes:
+                candidates.append(curie)
         logging.info(f"Candidates: {len(candidates)}")
         for subject, pred, object in self.all_relationships():
             if subject == object:
                 continue
             if ignore_owl_thing and object == OWL_THING:
+                continue
+            if not(id_prefixes is None or get_curie_prefix(object) in id_prefixes):
                 continue
             # if object not in all_curies:
             #    continue

--- a/src/oaklib/utilities/basic_utils.py
+++ b/src/oaklib/utilities/basic_utils.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Tuple, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from oaklib.types import CURIE
 

--- a/src/oaklib/utilities/basic_utils.py
+++ b/src/oaklib/utilities/basic_utils.py
@@ -1,9 +1,35 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple, Optional
+
+from oaklib.types import CURIE
 
 
 def pairs_as_dict(pairs: Iterable[Tuple[Any, Any]]) -> Dict[Any, List[Any]]:
+    """
+    Translates a collection of key-value pairs into a key-values dictionary
+
+    :param pairs:
+    :return:
+    """
     d = defaultdict(list)
     for p in pairs:
         d[p[0]].append(d[1])
     return d
+
+
+def get_curie_prefix(curie: CURIE) -> Optional[str]:
+    """
+    Extract the prefix from a CURIE.
+
+    A CURIE is a string typically of the form PREFIX : LOCALNAME
+
+    We allow simple strings as CURIEs, if the input does not conform to the prefix-localname
+    syntax then None is returned
+
+    :param curie:
+    :return: prefix
+    """
+    if ":" in curie:
+        return curie.split(":")[0]
+    else:
+        return None


### PR DESCRIPTION
This moves the method to get curie prefixes from the sql implementation to a general method that can be used everywhere