### PR TITLE
Adding shortest paths util

### DIFF
--- a/src/oaklib/implementations/ubergraph/ubergraph_implementation.py
+++ b/src/oaklib/implementations/ubergraph/ubergraph_implementation.py
@@ -227,8 +227,8 @@ class UbergraphImplementation(
             graph=graph,
             where=[
                 "?s ?p ?o",
-                self._sparql_values("s", subject_uris),
-                self._sparql_values("p", predicate_uris),
+                _sparql_values("s", subject_uris),
+                _sparql_values("p", predicate_uris),
             ]
             + where,
         )

--- a/src/oaklib/io/streaming_csv_writer.py
+++ b/src/oaklib/io/streaming_csv_writer.py
@@ -39,16 +39,7 @@ class StreamingCsvWriter(StreamingWriter):
             obj_as_dict = self._get_dict(obj)
         else:
             obj_as_dict = vars(obj)
-        if label_fields and self.autolabel:
-            for f in label_fields:
-                curie = obj_as_dict.get(f, None)
-                if curie:
-                    if isinstance(curie, list):
-                        labels = [self.ontology_interface.get_label_by_curie(c) for c in curie]
-                        label = " | ".join(labels)
-                    else:
-                        label = self.ontology_interface.get_label_by_curie(curie)
-                    obj_as_dict[f"{f}_label"] = label
+        self.add_labels(obj_as_dict, label_fields)
         if self.writer is None:
             # TODO: option to delay writing header, as not all keys may be populated in advance
             self.keys = list(obj_as_dict)

--- a/src/oaklib/io/streaming_csv_writer.py
+++ b/src/oaklib/io/streaming_csv_writer.py
@@ -43,7 +43,11 @@ class StreamingCsvWriter(StreamingWriter):
             for f in label_fields:
                 curie = obj_as_dict.get(f, None)
                 if curie:
-                    label = self.ontology_interface.get_label_by_curie(curie)
+                    if isinstance(curie, list):
+                        labels = [self.ontology_interface.get_label_by_curie(c) for c in curie]
+                        label = " | ".join(labels)
+                    else:
+                        label = self.ontology_interface.get_label_by_curie(curie)
                     obj_as_dict[f"{f}_label"] = label
         if self.writer is None:
             # TODO: option to delay writing header, as not all keys may be populated in advance

--- a/src/oaklib/io/streaming_yaml_writer.py
+++ b/src/oaklib/io/streaming_yaml_writer.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Union
 
+import yaml
 from linkml_runtime import CurieNamespace
-from linkml_runtime.dumpers import yaml_dumper
+from linkml_runtime.dumpers import json_dumper
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
 from oaklib.io.streaming_writer import StreamingWriter
@@ -23,6 +24,14 @@ class StreamingYamlWriter(StreamingWriter):
     A writer that emits one document at a time in one stream
     """
 
-    def emit(self, obj: YAMLRoot):
-        self.file.write(yaml_dumper.dumps(obj))
+    def emit(self, obj: Union[YAMLRoot, dict], label_fields=None):
+        if isinstance(obj, YAMLRoot):
+            obj_as_dict = json_dumper.to_dict(obj)
+            # self.file.write(yaml_dumper.dumps(obj))
+        elif isinstance(obj, dict):
+            obj_as_dict = obj
+        else:
+            raise ValueError(f"Not a dict or YAMLRoot: {obj}")
+        self.add_labels(obj_as_dict, label_fields)
+        self.file.write(yaml.dump(obj_as_dict))
         self.file.write("\n---\n")

--- a/src/oaklib/utilities/obograph_utils.py
+++ b/src/oaklib/utilities/obograph_utils.py
@@ -282,11 +282,15 @@ def shortest_paths(
         logging.info(f"Calculating distances for {start_curie}")
         for end_curie in set(this_end_curies):
             logging.debug(f"COMPUTING {start_curie} to {end_curie}")
-            paths = nx.all_shortest_paths(
-                dg, source=start_curie, target=end_curie, weight="weight", method="bellman-ford"
-            )
-            for path in paths:
-                yield start_curie, end_curie, path
+            try:
+                paths = nx.all_shortest_paths(
+                    dg, source=start_curie, target=end_curie, weight="weight", method="bellman-ford"
+                )
+                for path in paths:
+                    yield start_curie, end_curie, path
+            except nx.NetworkXNoPath:
+                logging.info(f"No path between {start_curie} and {end_curie}")
+
 
 
 def remove_nodes_from_graph(graph: Graph, node_ids: List[CURIE]):

--- a/src/oaklib/utilities/obograph_utils.py
+++ b/src/oaklib/utilities/obograph_utils.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TextIO, Tuple, Iterator
+from typing import Any, Dict, Iterator, List, Optional, TextIO, Tuple
 
 import networkx as nx
 import yaml
@@ -197,10 +197,11 @@ def as_digraph(
 
 
 def as_graph(
-        graph: Graph, reverse: bool = True,
-        filter_reflexive: bool = True,
-        predicate_weights: PREDICATE_WEIGHT_MAP = None,
-        default_weight = 1.0
+    graph: Graph,
+    reverse: bool = True,
+    filter_reflexive: bool = True,
+    predicate_weights: PREDICATE_WEIGHT_MAP = None,
+    default_weight=1.0,
 ) -> nx.MultiDiGraph:
     """
     Convert to a networkx :class:`.DiGraph`
@@ -219,7 +220,7 @@ def as_graph(
                 w = predicate_weights[edge.pred]
             else:
                 w = default_weight
-            edge_attrs['weight'] = w
+            edge_attrs["weight"] = w
         dg.add_edge(edge.sub, edge.obj, **edge_attrs)
     return dg
 
@@ -257,11 +258,11 @@ def ancestors_with_stats(graph: Graph, curies: List[CURIE]) -> Dict[CURIE, Dict[
 
 
 def shortest_paths(
-        graph: Graph,
-        start_curies: List[CURIE],
-        end_curies: Optional[List[CURIE]] = None,
-        predicate_weights: Optional[PREDICATE_WEIGHT_MAP] = None,
-    ) -> Iterator[Tuple[CURIE, CURIE, List[CURIE]]]:
+    graph: Graph,
+    start_curies: List[CURIE],
+    end_curies: Optional[List[CURIE]] = None,
+    predicate_weights: Optional[PREDICATE_WEIGHT_MAP] = None,
+) -> Iterator[Tuple[CURIE, CURIE, List[CURIE]]]:
     """
     Finds all shortest paths from a set of start nodes to a set of end nodes
 
@@ -272,7 +273,7 @@ def shortest_paths(
     :return:
     """
     dg = as_graph(graph, predicate_weights=predicate_weights)
-    logging.info("Calculating visits")
+    logging.info(f"Calculating paths, starts={start_curies}")
     for start_curie in start_curies:
         if end_curies:
             this_end_curies = end_curies
@@ -281,8 +282,9 @@ def shortest_paths(
         logging.info(f"Calculating distances for {start_curie}")
         for end_curie in set(this_end_curies):
             logging.debug(f"COMPUTING {start_curie} to {end_curie}")
-            paths = nx.all_shortest_paths(dg, source=start_curie, target=end_curie,
-                                          weight="weight", method="bellman-ford")
+            paths = nx.all_shortest_paths(
+                dg, source=start_curie, target=end_curie, weight="weight", method="bellman-ford"
+            )
             for path in paths:
                 yield start_curie, end_curie, path
 

--- a/src/oaklib/utilities/obograph_utils.py
+++ b/src/oaklib/utilities/obograph_utils.py
@@ -292,7 +292,6 @@ def shortest_paths(
                 logging.info(f"No path between {start_curie} and {end_curie}")
 
 
-
 def remove_nodes_from_graph(graph: Graph, node_ids: List[CURIE]):
     """
     Remove the specified nodes from the graph, and cascade to any edges

--- a/tests/test_utilities/test_obograph_utils.py
+++ b/tests/test_utilities/test_obograph_utils.py
@@ -128,9 +128,8 @@ class TestOboGraphUtils(unittest.TestCase):
                 start_curie, end_curie, preds, weights, includes, excludes = ex
                 g = oi.ancestor_graph([start_curie, end_curie], predicates=preds)
                 paths = shortest_paths(g, [start_curie], [end_curie], predicate_weights=weights)
-                # print(f"TEST={ex}")
                 for s, o, path in paths:
-                    # print(path)
+                    logging.debug(f"{s} -> {o} == {path}")
                     for x in includes:
                         self.assertIn(x, path)
                     for x in excludes:

--- a/tests/test_utilities/test_obograph_utils.py
+++ b/tests/test_utilities/test_obograph_utils.py
@@ -11,10 +11,21 @@ from oaklib.utilities.obograph_utils import (
     filter_by_predicates,
     graph_as_dict,
     graph_to_tree,
-    trim_graph, shortest_paths,
+    shortest_paths,
+    trim_graph,
 )
-from tests import CELLULAR_ORGANISMS, HUMAN, IMBO, INPUT_DIR, OUTPUT_DIR, VACUOLE, NUCLEUS, CYTOPLASM, \
-    CELLULAR_ANATOMICAL_ENTITY, INTRACELLULAR
+from tests import (
+    CELLULAR_ANATOMICAL_ENTITY,
+    CELLULAR_ORGANISMS,
+    CYTOPLASM,
+    HUMAN,
+    IMBO,
+    INPUT_DIR,
+    INTRACELLULAR,
+    NUCLEUS,
+    OUTPUT_DIR,
+    VACUOLE,
+)
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"
 TEST_OUT = OUTPUT_DIR / "go-nucleus.saved.owl"
@@ -102,7 +113,14 @@ class TestOboGraphUtils(unittest.TestCase):
         expected_list = [
             (NUCLEUS, VACUOLE, both, None, [], []),
             (NUCLEUS, CYTOPLASM, both, None, [], []),
-            (NUCLEUS, CYTOPLASM, both, {IS_A: hi, PART_OF: lo}, [INTRACELLULAR], [CELLULAR_ANATOMICAL_ENTITY]),
+            (
+                NUCLEUS,
+                CYTOPLASM,
+                both,
+                {IS_A: hi, PART_OF: lo},
+                [INTRACELLULAR],
+                [CELLULAR_ANATOMICAL_ENTITY],
+            ),
             (NUCLEUS, CYTOPLASM, both, {IS_A: lo, PART_OF: hi}, [CELLULAR_ANATOMICAL_ENTITY], []),
         ]
         if isinstance(oi, OboGraphInterface):
@@ -110,13 +128,10 @@ class TestOboGraphUtils(unittest.TestCase):
                 start_curie, end_curie, preds, weights, includes, excludes = ex
                 g = oi.ancestor_graph([start_curie, end_curie], predicates=preds)
                 paths = shortest_paths(g, [start_curie], [end_curie], predicate_weights=weights)
-                #print(f"TEST={ex}")
+                # print(f"TEST={ex}")
                 for s, o, path in paths:
-                    #print(path)
+                    # print(path)
                     for x in includes:
                         self.assertIn(x, path)
                     for x in excludes:
                         self.assertNotIn(x, path)
-
-
-


### PR DESCRIPTION
Example:

```
✗ go paths  -p i,p --no-autolabel 'nuclear membrane' --target cytoplasm
subject object  paths
GO:0031965      GO:0005737      ['GO:0031965', 'GO:0005635', 'GO:0012505', 'GO:0110165', 'GO:0005737']
GO:0031965      GO:0005737      ['GO:0031965', 'GO:0031090', 'GO:0016020', 'GO:0110165', 'GO:0005737']
```

```
✗ go paths  -p i,p 'nuclear membrane' --target cytoplasm
subject object  paths   subject_label   object_label    paths_label
GO:0031965      GO:0005737      ['GO:0031965', 'GO:0005635', 'GO:0012505', 'GO:0110165', 'GO:0005737']  nuclear membrane        cytoplasm       nuclear membrane | nuclear envelope | endomembrane system | cellular anatomical entity | cytoplasm
GO:0031965      GO:0005737      ['GO:0031965', 'GO:0031090', 'GO:0016020', 'GO:0110165', 'GO:0005737']  nuclear membrane        cytoplasm       nuclear membrane | organelle membrane | membrane | cellular anatomical entity | cytoplasm
```

with weights
```
✗ go paths  -p i,p 'nuclear membrane' --target cytoplasm --predicate-weights "{i: 0.0001, p: 999}"
subject object  paths   subject_label   object_label    paths_label
GO:0031965      GO:0005737      ['GO:0031965', 'GO:0005635', 'GO:0012505', 'GO:0110165', 'GO:0005737']  nuclear membrane        cytoplasm       nuclear membrane | nuclear envelope | endomembrane system | cellular anatomical entity | cytoplasm
GO:0031965      GO:0005737      ['GO:0031965', 'GO:0031090', 'GO:0016020', 'GO:0110165', 'GO:0005737']  nuclear membrane        cytoplasm       nuclear membrane | organelle membrane | membrane | cellular anatomical entity | cytoplasm
```

visualizing
```
go paths  -p i,p 'nuclear membrane' --target cytoplasm --flat | go viz -p i,p --gap-fill - 
```
<img width="436" alt="image" src="https://user-images.githubusercontent.com/50745/179631190-355f608b-95b2-4a39-8512-2bb5feb1ea36.png">
