### PR TITLE
Renaming methods to be in line with naming principles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ from src.oaklib.implementations.sqldb.sql_implementation import SqlImplementatio
 resource = OntologyResource(slug='tests/input/go-nucleus.db', local=True)
 oi = SqlImplementation(resource)
 for curie in oi.basic_search("cell"):
-    print(f'{curie} ! {oi.get_label_by_curie(curie)}')
-    for rel, fillers in oi.get_outgoing_relationship_map_by_curie(curie).items():
-        print(f'  RELATION: {rel} ! {oi.get_label_by_curie(rel)}')
+    print(f'{curie} ! {oi.label(curie)}')
+    for rel, fillers in oi.outgoing_relationship_map(curie).items():
+        print(f'  RELATION: {rel} ! {oi.label(rel)}')
         for filler in fillers:
-            print(f'     * {filler} ! {oi.get_label_by_curie(filler)}')
+            print(f'     * {filler} ! {oi.label(filler)}')
 ```
 
 For more examples, see

--- a/docs/best-practice.rst
+++ b/docs/best-practice.rst
@@ -37,6 +37,27 @@ A common pattern is to iterate over a result set and issue a separate call for e
 .. code:: python
 
     >>> for curie in oi.basic_search("cell"):
+            >>>     print(f'MATCH: {curie} ! {oi.label(curie)}')
+
+        This is fine if the implementation has a low latency for individual calls, but if the implementation is backed by
+        a remote service (for example, a SPARQL endpoint like ontobee or ubergraph, or a remote SQL database) then this will
+        issue one network call for each result, which may be inefficient.
+
+        One possibility is to use a dedicated method for retrieving batch results, for example
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is fine if the implementation has a low latency for individual calls, but if the implementation is backed by
+    a remote service (for example, a SPARQL endpoint like ontobee or ubergraph, or a remote SQL database) then this will
+    issue one network call for each result, which may be inefficient.
+
+    One possibility is to use a dedicated method for retrieving batch results, for example
+        >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+    This is fine if the implementation has a low latency for individual calls, but if the implementation is backed by
+    a remote service (for example, a SPARQL endpoint like ontobee or ubergraph, or a remote SQL database) then this will
+    issue one network call for each result, which may be inefficient.
+
+    One possibility is to use a dedicated method for retrieving batch results, for example
     >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
 
 This is fine if the implementation has a low latency for individual calls, but if the implementation is backed by
@@ -48,6 +69,336 @@ One possibility is to use a dedicated method for retrieving batch results, for e
 .. code:: python
 
     >>> curies = oi.basic_search("cell"):
+                >>> for curie, label in oi.labels(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.get_labels_for_curies(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+                >>> for curie, label in oi.labels(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.get_labels_for_curies(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+                >>> for curie, label in oi.labels(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.get_labels_for_curies(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+                >>> for curie, label in oi.labels(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.get_labels_for_curies(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+                >>> for curie, label in oi.labels(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.get_labels_for_curies(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+                >>> for curie, label in oi.labels(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+                >>> for curie, label in oi.get_labels_for_curies(curies):
+                >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+            This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+            A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.get_labels_for_curies(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+            >>> for curie, label in oi.labels(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.get_labels_for_curies(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.labels(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+            >>> for curie, label in oi.get_labels_for_curies(curies):
+            >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+        This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+        A better approach is to
+        >>> for curie, label in oi.labels(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
+        >>> for curie, label in oi.get_labels_for_curies(curies):
+        >>>     print(f'MATCH: {curie} ! {oi.label_by_curie(curie)}')
+
+    This is likely fine if the search results are relatively low in cardinality, but may be less efficient for large numbers of results.
+
+    A better approach is to
     >>> for curie, label in oi.get_labels_for_curies(curies):
     >>>     print(f'MATCH: {curie} ! {oi.get_label_by_curie(curie)}')
 
@@ -63,6 +414,13 @@ The :ref:`.chunk` utility function will chunk iterator calls into sizeable amoun
 .. code:: python
 
     >>> for curie_it in chunk(impl.basic_search(t)):
+        >>>     logging.info('** Next chunk:')
+        >>>     for curie, label in impl.labels(curie_it):
+        >>>         print(f'{curie} ! {label}')
+
+    This is slightly more boilerplate code, and may not be necessary for an in-memory implementation like Pronto. However, this
+    pattern could have considerable advantages for result sets that are potentially large. Even if the external server is
+    slow to return results, users will see batches or results rather than waiting on the external server to produce
     >>>     logging.info('** Next chunk:')
     >>>     for curie, label in impl.get_labels_for_curies(curie_it):
     >>>         print(f'{curie} ! {label}')

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,12 +26,12 @@ from src.oaklib.implementations.sqldb.sql_implementation import SqlImplementatio
 resource = OntologyResource(slug='tests/input/go-nucleus.db', local=True)
 si = SqlImplementation(resource)
 for curie in si.basic_search("cell"):
-    print(f'{curie} ! {si.get_label_by_curie(curie)}')
-    print(f'Definition: {si.get_definition_by_curie(curie)}')
-    for rel, fillers in si.get_outgoing_relationship_map_by_curie(curie).items():
-        print(f'  RELATION: {rel} ! {si.get_label_by_curie(rel)}')
+    print(f'{curie} ! {si.label(curie)}')
+    print(f'Definition: {si.definition(curie)}')
+    for rel, fillers in si.outgoing_relationship_map(curie).items():
+        print(f'  RELATION: {rel} ! {si.label(rel)}')
         for filler in fillers:
-            print(f'     * {filler} ! {si.get_label_by_curie(filler)}')
+            print(f'     * {filler} ! {si.label(filler)}')
 ```
 
 ### Basic Command Line Example

--- a/src/oaklib/implementations/aggregator/aggregator_implementation.py
+++ b/src/oaklib/implementations/aggregator/aggregator_implementation.py
@@ -64,26 +64,26 @@ class AggregatorImplementation(
     def validate(self, configuration: ValidationConfiguration = None) -> Iterable[ValidationResult]:
         return self._delegate_iterator(lambda i: i.validate())
 
-    def all_entity_curies(self) -> Iterable[CURIE]:
-        return self._delegate_iterator(lambda i: i.all_entity_curies())
+    def entities(self) -> Iterable[CURIE]:
+        return self._delegate_iterator(lambda i: i.entities())
 
-    def get_simple_mappings_by_curie(self, curie: CURIE) -> Iterable[Tuple[PRED_CURIE, CURIE]]:
-        return self._delegate_iterator(lambda i: i.get_simple_mappings_by_curie(curie))
+    def simple_mappings_by_curie(self, curie: CURIE) -> Iterable[Tuple[PRED_CURIE, CURIE]]:
+        return self._delegate_iterator(lambda i: i.simple_mappings_by_curie(curie))
 
     def get_sssom_mappings_by_curie(self, curie: CURIE) -> Iterable[Mapping]:
         return self._delegate_iterator(lambda i: i.get_sssom_mappings_by_curie(curie))
 
-    def get_label_by_curie(self, curie: CURIE) -> str:
-        return self._delegate_first(lambda i: i.get_label_by_curie(curie))
+    def label(self, curie: CURIE) -> str:
+        return self._delegate_first(lambda i: i.label(curie))
 
-    def alias_map_by_curie(self, curie: CURIE) -> ALIAS_MAP:
-        return self._delegate_simple_tuple_map(lambda i: i.alias_map_by_curie(curie))
+    def entity_alias_map(self, curie: CURIE) -> ALIAS_MAP:
+        return self._delegate_simple_tuple_map(lambda i: i.entity_alias_map(curie))
 
-    def all_subset_curies(self) -> Iterable[SUBSET_CURIE]:
-        return self._delegate_iterator(lambda i: i.all_subset_curies())
+    def subsets(self) -> Iterable[SUBSET_CURIE]:
+        return self._delegate_iterator(lambda i: i.subsets())
 
-    def curies_by_subset(self, subset: SUBSET_CURIE) -> Iterable[CURIE]:
-        return self._delegate_iterator(lambda i: i.curies_by_subset(subset))
+    def subset_members(self, subset: SUBSET_CURIE) -> Iterable[CURIE]:
+        return self._delegate_iterator(lambda i: i.subset_members(subset))
 
     def node(self, curie: CURIE, strict=False) -> Node:
         # TODO: this implementation is ad-hoc
@@ -96,12 +96,8 @@ class AggregatorImplementation(
                     return node
         return node
 
-    def get_outgoing_relationship_map_by_curie(self, curie: CURIE) -> RELATIONSHIP_MAP:
-        return self._delegate_simple_tuple_map(
-            lambda i: i.get_outgoing_relationship_map_by_curie(curie)
-        )
+    def outgoing_relationship_map(self, curie: CURIE) -> RELATIONSHIP_MAP:
+        return self._delegate_simple_tuple_map(lambda i: i.outgoing_relationship_map(curie))
 
-    def get_incoming_relationship_map_by_curie(self, curie: CURIE) -> RELATIONSHIP_MAP:
-        return self._delegate_simple_tuple_map(
-            lambda i: i.get_incoming_relationship_map_by_curie(curie)
-        )
+    def incoming_relationship_map(self, curie: CURIE) -> RELATIONSHIP_MAP:
+        return self._delegate_simple_tuple_map(lambda i: i.incoming_relationship_map(curie))

--- a/src/oaklib/implementations/bioportal/bioportal_implementation.py
+++ b/src/oaklib/implementations/bioportal/bioportal_implementation.py
@@ -51,7 +51,7 @@ class BioportalImplementation(TextAnnotatorInterface, SearchInterface, MappingPr
             if self.resource:
                 self.focus_ontology = self.resource.slug
 
-    def get_prefix_map(self) -> PREFIX_MAP:
+    def prefix_map(self) -> PREFIX_MAP:
         # TODO
         return {}
 
@@ -76,7 +76,7 @@ class BioportalImplementation(TextAnnotatorInterface, SearchInterface, MappingPr
         #    raise EnvironmentError
         return result
 
-    def all_ontology_curies(self) -> Iterable[CURIE]:
+    def ontologies(self) -> Iterable[CURIE]:
         include = []
         include_str = ",".join(include)
         params = {"include": include_str}
@@ -124,14 +124,14 @@ class BioportalImplementation(TextAnnotatorInterface, SearchInterface, MappingPr
                         m[k] = v
         return m
 
-    def get_labels_for_curies(self, curies: Iterable[CURIE]) -> Iterable[Tuple[CURIE, str]]:
+    def labels(self, curies: Iterable[CURIE]) -> Iterable[Tuple[CURIE, str]]:
         label_cache = self.label_cache
         for curie in curies:
             logging.debug(f"LOOKUP: {curie}")
             if curie in label_cache:
                 yield curie, label_cache[curie]
             else:
-                label = self.get_label_by_curie(curie)
+                label = self.label(curie)
                 label_cache[curie] = label
                 yield curie, label
 

--- a/src/oaklib/implementations/funowl/funowl_implementation.py
+++ b/src/oaklib/implementations/funowl/funowl_implementation.py
@@ -51,7 +51,7 @@ class FunOwlImplementation(OwlInterface):
     def _ontology(self):
         return self.ontology_document.ontology
 
-    def get_prefix_map(self) -> PREFIX_MAP:
+    def prefix_map(self) -> PREFIX_MAP:
         # TODO
         return DEFAULT_PREFIX_MAP
 
@@ -64,7 +64,7 @@ class FunOwlImplementation(OwlInterface):
 
     def uri_to_curie(self, uri: URI, strict=True) -> Optional[CURIE]:
         # TODO: do not hardcode OBO
-        pm = self.get_prefix_map()
+        pm = self.prefix_map()
         for k, v in pm.items():
             if uri.startswith(v):
                 return uri.replace(v, f"{k}:")
@@ -73,7 +73,7 @@ class FunOwlImplementation(OwlInterface):
             return uri.replace("_", ":")
         return uri
 
-    def get_label_by_curie(self, curie: CURIE) -> str:
+    def label(self, curie: CURIE) -> str:
         labels = [
             a.value for a in self.annotation_assertion_axioms(curie, property=LABEL_PREDICATE)
         ]
@@ -87,7 +87,7 @@ class FunOwlImplementation(OwlInterface):
             else:
                 raise ValueError(f"Label must be literal, not {label}")
 
-    def all_entity_curies(self, filter_obsoletes=True, owl_type=None) -> Iterable[CURIE]:
+    def entities(self, filter_obsoletes=True, owl_type=None) -> Iterable[CURIE]:
         for ax in self._ontology.axioms:
             if isinstance(ax, Declaration):
                 uri = ax.v.full_uri(self.functional_writer.g)
@@ -143,7 +143,7 @@ class FunOwlImplementation(OwlInterface):
             elif isinstance(patch, kgcl.NodeDeletion):
                 raise NotImplementedError
             elif isinstance(patch, kgcl.NameBecomesSynonym):
-                label = self.get_label_by_curie(about)
+                label = self.label(about)
                 self.apply_patch(
                     kgcl.NodeRename(id=f"{patch.id}-1", about_node=about, new_value=patch.new_value)
                 )

--- a/src/oaklib/implementations/ols/ols_implementation.py
+++ b/src/oaklib/implementations/ols/ols_implementation.py
@@ -44,7 +44,7 @@ class OlsImplementation(TextAnnotatorInterface, SearchInterface, MappingProvider
     label_cache: Dict[CURIE, str] = field(default_factory=lambda: {})
     base_url = "https://www.ebi.ac.uk/spot/oxo/api/mappings"
     ols_base_url = "https://www.ebi.ac.uk/ols/api"
-    prefix_map: Dict[str, str] = field(default_factory=lambda: {})
+    _prefix_map: Dict[str, str] = field(default_factory=lambda: {})
     focus_ontology: str = None
 
     def __post_init__(self):
@@ -54,13 +54,13 @@ class OlsImplementation(TextAnnotatorInterface, SearchInterface, MappingProvider
 
     def add_prefix(self, curie: str, uri: str):
         [pfx, local] = curie.split(":", 2)
-        if pfx not in self.prefix_map:
-            self.prefix_map[pfx] = uri.replace(local, "")
+        if pfx not in self._prefix_map:
+            self._prefix_map[pfx] = uri.replace(local, "")
 
-    def get_prefix_map(self) -> PREFIX_MAP:
-        return self.prefix_map
+    def prefix_map(self) -> PREFIX_MAP:
+        return self._prefix_map
 
-    def get_labels_for_curies(self, curies: Iterable[CURIE]) -> Iterable[Tuple[CURIE, str]]:
+    def labels(self, curies: Iterable[CURIE]) -> Iterable[Tuple[CURIE, str]]:
         for curie in curies:
             yield curie, self.label_cache[curie]
 

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -83,7 +83,7 @@ class ProntoImplementation(
 
     .. code:: python
 
-        rels = oi.get_outgoing_relationships_by_curie('GO:0005773')
+        rels = oi.outgoing_relationships('GO:0005773')
         for rel, parents in rels.items():
             print(f'  {rel} ! {oi.get_label_by_curie(rel)}')
                 for parent in parents:
@@ -153,7 +153,7 @@ class ProntoImplementation(
     # Implements: BasicOntologyInterface
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    def get_prefix_map(self) -> PREFIX_MAP:
+    def prefix_map(self) -> PREFIX_MAP:
         return {}
 
     def _entity(self, curie: CURIE, strict=False):
@@ -185,7 +185,7 @@ class ProntoImplementation(
         else:
             return self.wrapped_ontology.create_relationship(curie)
 
-    def all_entity_curies(self, filter_obsoletes=True, owl_type=None) -> Iterable[CURIE]:
+    def entities(self, filter_obsoletes=True, owl_type=None) -> Iterable[CURIE]:
         for t in self.wrapped_ontology.terms():
             if filter_obsoletes and t.obsolete:
                 continue
@@ -204,7 +204,7 @@ class ProntoImplementation(
                 continue
             yield t.id
 
-    def all_obsolete_curies(self) -> Iterable[CURIE]:
+    def obsoletes(self) -> Iterable[CURIE]:
         for t in self.wrapped_ontology.terms():
             if t.obsolete:
                 yield t.id
@@ -213,19 +213,19 @@ class ProntoImplementation(
             if t.obsolete:
                 yield t.id
 
-    def all_subset_curies(self) -> Iterable[CURIE]:
+    def subsets(self) -> Iterable[CURIE]:
         subsets = set()
         for t in self.wrapped_ontology.terms():
             subsets.update(t.subsets)
         for subset in subsets:
             yield subset
 
-    def curies_by_subset(self, subset: SUBSET_CURIE) -> Iterable[CURIE]:
+    def subset_members(self, subset: SUBSET_CURIE) -> Iterable[CURIE]:
         for t in self.wrapped_ontology.terms():
             if subset in t.subsets:
                 yield t.id
 
-    def get_label_by_curie(self, curie: CURIE) -> str:
+    def label(self, curie: CURIE) -> str:
         t = self._entity(curie)
         if t:
             return t.name
@@ -235,7 +235,7 @@ class ProntoImplementation(
             else:
                 return None
 
-    def set_label_for_curie(self, curie: CURIE, label: str) -> bool:
+    def set_label(self, curie: CURIE, label: str) -> bool:
         t = self._entity(curie)
         if t:
             curr = t.name
@@ -245,7 +245,7 @@ class ProntoImplementation(
             else:
                 return False
 
-    def get_curies_by_label(self, label: str) -> List[CURIE]:
+    def curies_by_label(self, label: str) -> List[CURIE]:
         return [t.id for t in self.wrapped_ontology.terms() if t.name == label]
 
     def _get_pronto_relationship_type_curie(self, rel_type: pronto.Relationship) -> CURIE:
@@ -254,9 +254,7 @@ class ProntoImplementation(
                 return x.id
         return rel_type.id
 
-    def get_outgoing_relationship_map_by_curie(
-        self, curie: CURIE, isa_only: bool = False
-    ) -> RELATIONSHIP_MAP:
+    def outgoing_relationship_map(self, curie: CURIE, isa_only: bool = False) -> RELATIONSHIP_MAP:
         # See: https://github.com/althonos/pronto/issues/119
         term = self._entity(curie)
         if isinstance(term, Term):
@@ -269,9 +267,7 @@ class ProntoImplementation(
             rels = {}
         return rels
 
-    def get_incoming_relationship_map_by_curie(
-        self, curie: CURIE, isa_only: bool = False
-    ) -> RELATIONSHIP_MAP:
+    def incoming_relationship_map(self, curie: CURIE, isa_only: bool = False) -> RELATIONSHIP_MAP:
         term = self._entity(curie)
         if isinstance(term, Term):
             # only "Terms" in pronto have relationships
@@ -311,10 +307,10 @@ class ProntoImplementation(
                 t.relationships[predicate_term] = []
             t.relationships[predicate_term].add(filler_term)
 
-    def get_definition_by_curie(self, curie: CURIE) -> str:
+    def definition(self, curie: CURIE) -> str:
         return self._entity(curie).definition
 
-    def alias_map_by_curie(self, curie: CURIE) -> ALIAS_MAP:
+    def entity_alias_map(self, curie: CURIE) -> ALIAS_MAP:
         t = self._entity(curie)
         if t is None:
             return {}
@@ -329,7 +325,7 @@ class ProntoImplementation(
             m[pred].append(s.description)
         return m
 
-    def get_simple_mappings_by_curie(self, curie: CURIE) -> Iterable[Tuple[PRED_CURIE, CURIE]]:
+    def simple_mappings_by_curie(self, curie: CURIE) -> Iterable[Tuple[PRED_CURIE, CURIE]]:
         m = defaultdict(list)
         t = self._entity(curie)
         if t is None:
@@ -347,7 +343,7 @@ class ProntoImplementation(
                 elif isinstance(s, ResourcePropertyValue):
                     yield s.property, self.uri_to_curie(s.resource)
 
-    def metadata_map_by_curie(self, curie: CURIE) -> METADATA_MAP:
+    def entity_metadata_map(self, curie: CURIE) -> METADATA_MAP:
         t = self._entity(curie)
         m = defaultdict(list)
         for ann in t.annotations:
@@ -389,7 +385,7 @@ class ProntoImplementation(
                     mapping_justification=SEMAPV.UnspecifiedMatching.value,
                 )
         # TODO: use a cache to avoid re-calculating
-        for e in self.all_entity_curies():
+        for e in self.entities():
             t = self._entity(e)
             if t:
                 for x in t.xrefs:
@@ -431,7 +427,7 @@ class ProntoImplementation(
             return obograph.Node(id=t_id, lbl=t.name, meta=meta)
 
     def as_obograph(self) -> Graph:
-        nodes = [self.node(curie) for curie in self.all_entity_curies()]
+        nodes = [self.node(curie) for curie in self.entities()]
         edges = [Edge(sub=r[0], pred=r[1], obj=r[2]) for r in self.all_relationships()]
         return Graph(id="TODO", nodes=nodes, edges=edges)
 
@@ -489,7 +485,7 @@ class ProntoImplementation(
 
     def apply_patch(self, patch: kgcl.Change) -> None:
         if isinstance(patch, kgcl.NodeRename):
-            self.set_label_for_curie(patch.about_node, patch.new_value)
+            self.set_label(patch.about_node, patch.new_value)
         elif isinstance(patch, kgcl.NodeObsoletion):
             t = self._entity(patch.about_node, strict=True)
             t.obsolete = True

--- a/src/oaklib/implementations/ubergraph/ubergraph_implementation.py
+++ b/src/oaklib/implementations/ubergraph/ubergraph_implementation.py
@@ -131,9 +131,7 @@ class UbergraphImplementation(
             subj = self.uri_to_curie(row["s"]["value"])
             yield pred, subj
 
-    def get_outgoing_relationship_map_by_curie(
-        self, curie: CURIE, isa_only: bool = False
-    ) -> RELATIONSHIP_MAP:
+    def outgoing_relationship_map(self, curie: CURIE, isa_only: bool = False) -> RELATIONSHIP_MAP:
         rmap = defaultdict(list)
         for pred, obj in self._get_outgoing_edges_by_curie(
             curie, graph=RelationGraphEnum.nonredundant
@@ -141,9 +139,7 @@ class UbergraphImplementation(
             rmap[pred].append(obj)
         return rmap
 
-    def get_incoming_relationship_map_by_curie(
-        self, curie: CURIE, isa_only: bool = False
-    ) -> RELATIONSHIP_MAP:
+    def incoming_relationship_map(self, curie: CURIE, isa_only: bool = False) -> RELATIONSHIP_MAP:
         rmap = defaultdict(list)
         for pred, s in self._get_incoming_edges_by_curie(
             curie, graph=RelationGraphEnum.nonredundant
@@ -151,7 +147,7 @@ class UbergraphImplementation(
             rmap[pred].append(s)
         return rmap
 
-    def get_relationships(
+    def relationships(
         self,
         subjects: List[CURIE] = None,
         predicates: List[PRED_CURIE] = None,
@@ -416,7 +412,7 @@ class UbergraphImplementation(
         best_mrcas = [a for a in ics if ics[a] == max_ic]
         mrca = best_mrcas[0]
         sim = TermPairwiseSimilarity(subject_id=subject, object_id=object, ancestor_id=mrca)
-        for curie, label in self.get_labels_for_curies([subject, object, mrca]):
+        for curie, label in self.labels([subject, object, mrca]):
             if label is None:
                 continue
             # print(f'C={curie} L={label}')

--- a/src/oaklib/implementations/wikidata/wikidata_implementation.py
+++ b/src/oaklib/implementations/wikidata/wikidata_implementation.py
@@ -158,17 +158,13 @@ class WikidataImplementation(
             subj = self.uri_to_curie(row["s"]["value"])
             yield pred, subj
 
-    def get_outgoing_relationship_map_by_curie(
-        self, curie: CURIE, isa_only: bool = False
-    ) -> RELATIONSHIP_MAP:
+    def outgoing_relationship_map(self, curie: CURIE, isa_only: bool = False) -> RELATIONSHIP_MAP:
         rmap = defaultdict(list)
         for pred, obj in self._get_outgoing_edges_by_curie(curie):
             rmap[pred].append(obj)
         return rmap
 
-    def get_incoming_relationship_map_by_curie(
-        self, curie: CURIE, isa_only: bool = False
-    ) -> RELATIONSHIP_MAP:
+    def incoming_relationship_map(self, curie: CURIE, isa_only: bool = False) -> RELATIONSHIP_MAP:
         rmap = defaultdict(list)
         for pred, s in self._get_incoming_edges_by_curie(curie):
             rmap[pred].append(s)
@@ -228,7 +224,7 @@ class WikidataImplementation(
         return list(set([t[0] for t in self._triples(None, RDF.type, OWL.ObjectProperty)]))
 
     def node(self, curie: CURIE) -> obograph.Node:
-        params = dict(id=curie, lbl=self.get_label_by_curie(curie))
+        params = dict(id=curie, lbl=self.label(curie))
         return obograph.Node(**params)
 
     def ancestor_graph(
@@ -399,7 +395,7 @@ class WikidataImplementation(
         best_mrcas = [a for a in ics if ics[a] == max_ic]
         mrca = best_mrcas[0]
         sim = TermPairwiseSimilarity(subject_id=subject, object_id=object, ancestor_id=mrca)
-        for curie, label in self.get_labels_for_curies([subject, object, mrca]):
+        for curie, label in self.labels([subject, object, mrca]):
             if label is None:
                 continue
             # print(f'C={curie} L={label}')

--- a/src/oaklib/interfaces/basic_ontology_interface.py
+++ b/src/oaklib/interfaces/basic_ontology_interface.py
@@ -3,6 +3,8 @@ from abc import ABC
 from dataclasses import field
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
+from deprecation import deprecated
+
 from oaklib.datamodels.vocabulary import (
     BIOPORTAL_PURL,
     IS_A,
@@ -79,25 +81,29 @@ class BasicOntologyInterface(OntologyInterface, ABC):
     strict: bool = False
     autosave: bool = field(default_factory=lambda: True)
 
-    def get_prefix_map(self) -> PREFIX_MAP:
+    def prefix_map(self) -> PREFIX_MAP:
         """
-        Returns all prefixes known to the resource plus their URI expansion
+        Returns a dictionary mapping all prefixes known to the resource to their URI expansion
 
-        :return:
+        :return: prefix map
         """
         raise NotImplementedError
 
+    @deprecated("Replaced by prefix_map")
+    def get_prefix_map(self) -> PREFIX_MAP:
+        return self.prefix_map()
+
     def curie_to_uri(self, curie: CURIE, strict=False) -> Optional[URI]:
         """
-        Expands a CURIE
+        Expands a CURIE to a URI
 
         :param curie:
-        :param strict:
+        :param strict: (Default is False) if True, exceptions will be raised if curie cannot be expanded
         :return:
         """
         if curie.startswith("http"):
             return curie
-        pm = self.get_prefix_map()
+        pm = self.prefix_map()
         parts = curie.split(":")
         if len(parts) == 2:
             pfx, local_id = parts
@@ -114,7 +120,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
 
     def uri_to_curie(self, uri: URI, strict=True) -> Optional[CURIE]:
         """
-        Contracts a URI
+        Contracts a URI to a CURIE
 
         If strict conditions hold, then no URI can map to more than one CURIE
         (i.e one URI base should not start with another).
@@ -123,7 +129,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :param strict: Boolean [default: True]
         :return: CURIE
         """
-        pm = self.get_prefix_map()
+        pm = self.prefix_map()
         for k, v in pm.items():
             if uri.startswith(v):
                 return uri.replace(v, f"{k}:")
@@ -137,7 +143,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
             return uri.replace("_", ":")
         return uri
 
-    def all_ontology_curies(self) -> Iterable[CURIE]:
+    def ontologies(self) -> Iterable[CURIE]:
         """
         returns iterator over all known ontology CURIEs
 
@@ -148,13 +154,25 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError
 
-    def all_obsolete_curies(self) -> Iterable[CURIE]:
+    @deprecated("Replaced by ontologies()")
+    def ontology_curies(self) -> Iterable[CURIE]:
+        return self.ontologies()
+
+    @deprecated("Replaced by ontology_curies")
+    def all_ontology_curies(self) -> Iterable[CURIE]:
+        return self.ontologies()
+
+    def obsoletes(self) -> Iterable[CURIE]:
         """
         returns iterator over all known CURIEs that are obsolete
 
         :return: iterator
         """
         raise NotImplementedError
+
+    @deprecated("Replaced by obsoletes()")
+    def all_obsolete_curies(self) -> Iterable[CURIE]:
+        return self.obsoletes()
 
     def ontology_versions(self, ontology: CURIE) -> Iterable[str]:
         """
@@ -173,7 +191,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError
 
-    def all_entity_curies(self, filter_obsoletes=True, owl_type=None) -> Iterable[CURIE]:
+    def entities(self, filter_obsoletes=True, owl_type=None) -> Iterable[CURIE]:
         """
         returns iterator over all known entity CURIEs
 
@@ -182,6 +200,10 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :return: iterator
         """
         raise NotImplementedError
+
+    @deprecated("Replaced by entities")
+    def all_entity_curies(self, **kwargs) -> Iterable[CURIE]:
+        return self.entities(**kwargs)
 
     def roots(
         self,
@@ -203,7 +225,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         # this interface-level method should be replaced by specific implementations
         logging.info("Using naive approach for root detection, may be slow")
         candidates = []
-        for curie in self.all_entity_curies(owl_type=OWL_CLASS):
+        for curie in self.entities(owl_type=OWL_CLASS):
             if id_prefixes is None or get_curie_prefix(curie) in id_prefixes:
                 candidates.append(curie)
         logging.info(f"Candidates: {len(candidates)}")
@@ -221,7 +243,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
                     candidates.remove(subject)
                     logging.debug(f"Not a root: {subject} [{pred} {object}]")
         if filter_obsoletes:
-            exclusion_list = list(self.all_obsolete_curies())
+            exclusion_list = list(self.obsoletes())
         else:
             exclusion_list = []
         exclusion_list += [OWL_THING, OWL_NOTHING]
@@ -241,7 +263,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :param filter_obsoletes: do not include obsolete/deprecated nodes in results (default=True)
         :return:
         """
-        all_curies = set(list(self.all_entity_curies(owl_type=OWL_CLASS)))
+        all_curies = set(list(self.entities(owl_type=OWL_CLASS)))
         candidates = all_curies
         logging.info(f"Candidates: {len(candidates)}")
         for subject, pred, object in self.all_relationships():
@@ -254,7 +276,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
                     candidates.remove(object)
                     logging.debug(f"Not a leaf: {object} [inv({pred}) {subject}]")
         if filter_obsoletes:
-            exclusion_list = list(self.all_obsolete_curies())
+            exclusion_list = list(self.obsoletes())
         else:
             exclusion_list = []
         exclusion_list += [OWL_THING, OWL_NOTHING]
@@ -262,7 +284,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
             if term not in exclusion_list:
                 yield term
 
-    def all_subset_curies(self) -> Iterable[SUBSET_CURIE]:
+    def subsets(self) -> Iterable[SUBSET_CURIE]:
         """
         returns iterator over all known subset CURIEs
 
@@ -270,7 +292,15 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError
 
-    def curies_by_subset(self, subset: SUBSET_CURIE) -> Iterable[CURIE]:
+    @deprecated("Replaced by subsets()")
+    def subset_curies(self) -> Iterable[SUBSET_CURIE]:
+        return self.subsets()
+
+    @deprecated("Replaced by subset_curies()")
+    def all_subset_curies(self) -> Iterable[SUBSET_CURIE]:
+        return self.subsets()
+
+    def subset_members(self, subset: SUBSET_CURIE) -> Iterable[CURIE]:
         """
         returns iterator over all CURIEs belonging to a subset
 
@@ -278,7 +308,11 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError
 
-    def get_label_by_curie(self, curie: CURIE) -> Optional[str]:
+    @deprecated("Replaced by subset_members(subset)")
+    def curies_by_subset(self, subset: SUBSET_CURIE) -> Iterable[CURIE]:
+        return self.subset_members(subset)
+
+    def label(self, curie: CURIE) -> Optional[str]:
         """
         fetches the unique label for a CURIE
 
@@ -289,9 +323,11 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError
 
-    def get_labels_for_curies(
-        self, curies: Iterable[CURIE], allow_none=True
-    ) -> Iterable[Tuple[CURIE, str]]:
+    @deprecated("Use label(curie))")
+    def get_label_by_curie(self, curie: CURIE) -> Optional[str]:
+        return self.label(curie)
+
+    def labels(self, curies: Iterable[CURIE], allow_none=True) -> Iterable[Tuple[CURIE, str]]:
         """
         fetches the unique label for a CURIE
 
@@ -303,9 +339,13 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         # default implementation: may be overridden for efficiency
         for curie in curies:
-            yield [curie, self.get_label_by_curie(curie)]
+            yield [curie, self.label(curie)]
 
-    def set_label_for_curie(self, curie: CURIE, label: str) -> bool:
+    @deprecated("Use labels(...)")
+    def get_labels_for_curies(self, **kwargs) -> Iterable[Tuple[CURIE, str]]:
+        return self.labels(**kwargs)
+
+    def set_label(self, curie: CURIE, label: str) -> bool:
         """
         updates the label
 
@@ -315,7 +355,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError
 
-    def get_curies_by_label(self, label: str) -> List[CURIE]:
+    def curies_by_label(self, label: str) -> List[CURIE]:
         """
         Fetches all curies with a given label
 
@@ -327,9 +367,11 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError()
 
-    def get_hierararchical_parents_by_curie(
-        self, curie: CURIE, isa_only: bool = False
-    ) -> List[CURIE]:
+    @deprecated("Use curies_by_label(label)")
+    def get_curies_by_label(self, label: str) -> List[CURIE]:
+        return self.curies_by_label(label)
+
+    def hierararchical_parents(self, curie: CURIE, isa_only: bool = False) -> List[CURIE]:
         """
         Returns all hierarchical parents
 
@@ -338,7 +380,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
 
         This only returns Named Entities; i.e. if an RDF source is wrapped, this will NOT return blank nodes
 
-        To get all relationships, see :ref:`get_outgoing_relationships_by_curie`
+        To get all relationships, see :ref:`outgoing_relationships`
 
         A fresh map is created each invocation
 
@@ -346,9 +388,9 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :param isa_only: restrict hierarchical parents to isa only
         :return:
         """
-        return self.get_outgoing_relationship_map_by_curie(curie)[IS_A]
+        return self.outgoing_relationship_map(curie)[IS_A]
 
-    def get_outgoing_relationship_map_by_curie(self, curie: CURIE) -> RELATIONSHIP_MAP:
+    def outgoing_relationship_map(self, curie: CURIE) -> RELATIONSHIP_MAP:
         """
         The return relationship map is keyed by relationship type, where the values
         are the 'parents' or fillers
@@ -363,31 +405,48 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError()
 
-    def get_outgoing_relationships(
+    @deprecated("Use outgoing_relationship_map(curie)")
+    def get_outgoing_relationship_map_by_curie(self, curie: CURIE) -> RELATIONSHIP_MAP:
+        return self.outgoing_relationship_map(curie)
+
+    def outgoing_relationships(
         self, curie: CURIE, predicates: List[PRED_CURIE] = None
     ) -> Iterator[Tuple[PRED_CURIE, CURIE]]:
         """
-        Returns relationships where curie in the subject
+        Returns relationships where the input curie in the subject
 
         :param curie:
         :param predicates: if None, do not filter
         :return:
         """
-        for p, vs in self.get_outgoing_relationship_map_by_curie(curie).items():
+        for p, vs in self.outgoing_relationship_map(curie).items():
             if predicates is not None and p not in predicates:
                 continue
             for v in vs:
                 yield p, v
 
-    def get_incoming_relationship_map_by_curie(self, curie: CURIE) -> RELATIONSHIP_MAP:
+    @deprecated("Use outgoing_relationships()")
+    def get_outgoing_relationships(
+        self, curie: CURIE, predicates: List[PRED_CURIE] = None
+    ) -> Iterator[Tuple[PRED_CURIE, CURIE]]:
+        return self.outgoing_relationships(curie, predicates)
+
+    def incoming_relationship_map(self, curie: CURIE) -> RELATIONSHIP_MAP:
         """
+        Returns a map of all the relationships where the object is the input CURIE
+
+        See :ref:outgoing_relationship_map:
 
         :param curie:
         :return:
         """
         raise NotImplementedError
 
-    def get_incoming_relationships(
+    @deprecated("Use incoming_relationship_map(curie)")
+    def get_incoming_relationship_map_by_curie(self, curie: CURIE) -> RELATIONSHIP_MAP:
+        return self.incoming_relationship_map(curie)
+
+    def incoming_relationships(
         self, curie: CURIE, predicates: List[PRED_CURIE] = None
     ) -> Iterator[Tuple[PRED_CURIE, CURIE]]:
         """
@@ -397,13 +456,17 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :param predicates: if None, do not filter
         :return:
         """
-        for p, vs in self.get_incoming_relationship_map_by_curie(curie).items():
+        for p, vs in self.incoming_relationship_map(curie).items():
             if predicates is None or p not in predicates:
                 continue
             for v in vs:
                 yield p, v
 
-    def get_relationships(
+    @deprecated("Replaced by incoming_relationships(...)")
+    def get_incoming_relationships(self, **kwargs) -> Iterator[Tuple[PRED_CURIE, CURIE]]:
+        return self.incoming_relationships(**kwargs)
+
+    def relationships(
         self,
         subjects: List[CURIE] = None,
         predicates: List[PRED_CURIE] = None,
@@ -418,12 +481,10 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :return:
         """
         if not subjects:
-            subjects = list(self.all_entity_curies())
+            subjects = list(self.entities())
         logging.info(f"Subjects: {len(subjects)}")
         for subject in subjects:
-            for this_predicate, this_objects in self.get_outgoing_relationship_map_by_curie(
-                subject
-            ).items():
+            for this_predicate, this_objects in self.outgoing_relationship_map(subject).items():
                 if predicates and this_predicate not in predicates:
                     continue
                 for this_object in this_objects:
@@ -431,18 +492,23 @@ class BasicOntologyInterface(OntologyInterface, ABC):
                         continue
                     yield subject, this_predicate, this_object
 
+    @deprecated("Use relationships()")
+    def get_relationships(self, **kwargs) -> Iterator[RELATIONSHIP]:
+        return self.relationships(**kwargs)
+
+    @deprecated("Use relationships()")
     def all_relationships(self) -> Iterable[RELATIONSHIP]:
         """
         returns iterator over all known relationships
 
         :return:
         """
-        for curie in self.all_entity_curies():
-            for pred, fillers in self.get_outgoing_relationship_map_by_curie(curie).items():
+        for curie in self.entities():
+            for pred, fillers in self.outgoing_relationship_map(curie).items():
                 for filler in fillers:
                     yield curie, pred, filler
 
-    def get_definition_by_curie(self, curie: CURIE) -> Optional[str]:
+    def definition(self, curie: CURIE) -> Optional[str]:
         """
 
         :param curie:
@@ -450,15 +516,20 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError()
 
-    def get_simple_mappings_by_curie(self, curie: CURIE) -> Iterable[Tuple[PRED_CURIE, CURIE]]:
+    @deprecated("Use definition()")
+    def get_definition_by_curie(self, curie: CURIE) -> Optional[str]:
+        return self.definition(curie)
+
+    def simple_mappings_by_curie(self, curie: CURIE) -> Iterable[Tuple[PRED_CURIE, CURIE]]:
         """
+        Yields mappings for a given subject, where each mapping is represented as a simple tuple
 
         :param curie:
-        :return:
+        :return: iterator over predicate-object tuples
         """
         raise NotImplementedError()
 
-    def aliases_by_curie(self, curie: CURIE) -> List[str]:
+    def entity_aliases(self, curie: CURIE) -> List[str]:
         """
         All aliases/synonyms for a given CURIE
 
@@ -468,11 +539,15 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :return:
         """
         aliases = set()
-        for v in self.alias_map_by_curie(curie).values():
+        for v in self.entity_alias_map(curie).values():
             aliases.update(set(v))
         return list(aliases)
 
-    def alias_map_by_curie(self, curie: CURIE) -> ALIAS_MAP:
+    @deprecated("Use entity_aliases(curie)")
+    def aliases_by_curie(self, curie: CURIE) -> List[str]:
+        return self.entity_aliases(curie)
+
+    def entity_alias_map(self, curie: CURIE) -> ALIAS_MAP:
         """
         Returns aliases keyed by alias type (scope in OBO terms)
 
@@ -484,7 +559,11 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         """
         raise NotImplementedError
 
-    def metadata_map_by_curie(self, curie: CURIE) -> METADATA_MAP:
+    @deprecated("Replaced by alias_map(curie)")
+    def alias_map_by_curie(self, curie: CURIE) -> ALIAS_MAP:
+        return self.entity_alias_map(curie)
+
+    def entity_metadata_map(self, curie: CURIE) -> METADATA_MAP:
         """
         Returns a dictionary keyed by property predicate, with a list of zero or more values,
         where each key corresponds to any of a set of open-ended metadata predicates

--- a/src/oaklib/interfaces/differ_interface.py
+++ b/src/oaklib/interfaces/differ_interface.py
@@ -36,8 +36,8 @@ class DifferInterface(BasicOntologyInterface, ABC):
         :param other_ontology:
         :return:
         """
-        this_terms = set(self.all_entity_curies())
-        other_terms = set(other_ontology.all_entity_curies())
+        this_terms = set(self.entities())
+        other_terms = set(other_ontology.entities())
         for t in this_terms.difference(other_terms):
             yield NodeDeletion(
                 id="x",

--- a/src/oaklib/interfaces/mapping_provider_interface.py
+++ b/src/oaklib/interfaces/mapping_provider_interface.py
@@ -1,7 +1,8 @@
 import logging
 from abc import ABC
-from typing import Iterable
+from typing import Iterable, Optional
 
+from deprecation import deprecated
 from sssom_schema import Mapping
 
 from oaklib.interfaces.basic_ontology_interface import BasicOntologyInterface
@@ -15,7 +16,9 @@ class MappingProviderInterface(BasicOntologyInterface, ABC):
     TODO: move code from mapping-walker
     """
 
-    def all_sssom_mappings(self, subject_or_object_source: str = None) -> Iterable[Mapping]:
+    def sssom_mappings_by_source(
+        self, subject_or_object_source: Optional[str] = None
+    ) -> Iterable[Mapping]:
         """
         All SSSOM mappings in the ontology
 
@@ -25,7 +28,7 @@ class MappingProviderInterface(BasicOntologyInterface, ABC):
         :return:
         """
         logging.info("Getting all mappings")
-        for curie in self.all_entity_curies():
+        for curie in self.entities():
             logging.debug(f"Getting mappings for {curie}")
             for m in self.get_sssom_mappings_by_curie(curie):
                 if subject_or_object_source:
@@ -36,6 +39,13 @@ class MappingProviderInterface(BasicOntologyInterface, ABC):
                         continue
                 yield m
 
+    @deprecated("Replaced by sssom_mappings()")
+    def all_sssom_mappings(
+        self, subject_or_object_source: Optional[str] = None
+    ) -> Iterable[Mapping]:
+        return self.sssom_mappings_by_source(subject_or_object_source)
+
+    @deprecated("Use sssom_mappings()")
     def get_sssom_mappings_by_curie(self, curie: CURIE) -> Iterable[Mapping]:
         """
         All SSSOM mappings about a curie
@@ -46,6 +56,29 @@ class MappingProviderInterface(BasicOntologyInterface, ABC):
         :return:
         """
         raise NotImplementedError
+
+    def sssom_mappings(
+        self, curie: Optional[CURIE] = None, source: Optional[str] = None
+    ) -> Iterable[Mapping]:
+        """
+        returns all sssom mappings matching filter conditions
+
+        :param curie:
+        :param source:
+        :return:
+        """
+        logging.info("Getting all mappings")
+        if curie:
+            it = [curie]
+        else:
+            it = self.entities()
+        for curie in it:
+            logging.debug(f"Getting mappings for {curie}")
+            for m in self.get_sssom_mappings_by_curie(curie):
+                if source:
+                    if m.object_source != source and m.subject_source != source:
+                        continue
+                yield m
 
     def get_transitive_mappings_by_curie(self, curie: CURIE) -> Iterable[Mapping]:
         """

--- a/src/oaklib/interfaces/text_annotator_interface.py
+++ b/src/oaklib/interfaces/text_annotator_interface.py
@@ -65,6 +65,6 @@ class TextAnnotatorInterface(BasicOntologyInterface, ABC):
                 f"to use the default annotate_text() implementation"
             )
         for object_id in self.basic_search(text):
-            label = self.get_label_by_curie(object_id)
+            label = self.label(object_id)
             # amap = self.alias_map_by_curie(object_id)
             yield nen_annotation(text=text, curie=object_id, label=label)

--- a/src/oaklib/interfaces/validator_interface.py
+++ b/src/oaklib/interfaces/validator_interface.py
@@ -41,8 +41,8 @@ class ValidatorInterface(BasicOntologyInterface, ABC):
         :return:
         """
         # Implementations are advise to implement more efficient interfaces for their back-end
-        for curie in self.all_entity_curies():
-            if self.get_definition_by_curie(curie) is None:
+        for curie in self.entities():
+            if self.definition(curie) is None:
                 yield curie
 
     def validate(self, configuration: ValidationConfiguration = None) -> Iterable[ValidationResult]:

--- a/src/oaklib/io/streaming_csv_writer.py
+++ b/src/oaklib/io/streaming_csv_writer.py
@@ -51,20 +51,20 @@ class StreamingCsvWriter(StreamingWriter):
         oi = self.ontology_interface
         d = dict(
             id=curie,
-            label=oi.get_label_by_curie(curie),
-            definition=oi.get_definition_by_curie(curie),
+            label=oi.label(curie),
+            definition=oi.definition(curie),
         )
-        for k, vs in oi.alias_map_by_curie(curie).items():
+        for k, vs in oi.entity_alias_map(curie).items():
             d[k] = "|".join(vs)
-        for _, x in oi.get_simple_mappings_by_curie(curie):
+        for _, x in oi.simple_mappings_by_curie(curie):
             d["mappings"] = x
-        for k, vs in oi.metadata_map_by_curie(curie).items():
+        for k, vs in oi.entity_metadata_map(curie).items():
             if k not in [HAS_DBXREF, HAS_DEFINITION_CURIE]:
                 d[k] = str(vs)
         if isinstance(oi, OboGraphInterface):
-            for k, vs in oi.get_outgoing_relationship_map_by_curie(curie).items():
+            for k, vs in oi.outgoing_relationship_map(curie).items():
                 d[k] = "|".join(vs)
-                d[f"{k}_label"] = "|".join([oi.get_label_by_curie(v) for v in vs])
+                d[f"{k}_label"] = "|".join([oi.label(v) for v in vs])
         if isinstance(oi, SemanticSimilarityInterface):
             d["information_content_via_is_a"] = oi.get_information_content(curie, predicates=[IS_A])
             d["information_content_via_is_a_part_of"] = oi.get_information_content(

--- a/src/oaklib/io/streaming_info_writer.py
+++ b/src/oaklib/io/streaming_info_writer.py
@@ -29,26 +29,26 @@ class StreamingInfoWriter(StreamingWriter):
     def emit_curie(self, curie, label=None, **kwargs):
         oi = self.ontology_interface
         if label is None:
-            label = oi.get_label_by_curie(curie)
+            label = oi.label(curie)
         self.file.write(f"{curie} ! {label}")
         if self.display_options:
             show_all = "all" in self.display_options
             if show_all or "x" in self.display_options:
-                for _, x in oi.get_simple_mappings_by_curie(curie):
+                for _, x in oi.simple_mappings_by_curie(curie):
                     self.file.write(f" {x}")
             if show_all or "r" in self.display_options and isinstance(oi, OboGraphInterface):
-                for k, vs in oi.get_outgoing_relationship_map_by_curie(curie).items():
+                for k, vs in oi.outgoing_relationship_map(curie).items():
                     p = predicate_code_map.get(k, None)
                     if p is None:
-                        p = oi.get_label_by_curie(k)
+                        p = oi.label(k)
                         if p is None:
                             p = k
                     self.file.write(f" {p}: [")
                     for v in vs:
-                        self.file.write(f' {v} "{oi.get_label_by_curie(curie)}"')
+                        self.file.write(f' {v} "{oi.label(curie)}"')
                     self.file.write("]")
             if show_all or "d" in self.display_options:
-                defn = oi.get_definition_by_curie(curie)
+                defn = oi.definition(curie)
                 if defn:
                     self.file.write(f' "{defn}"')
             if (

--- a/src/oaklib/io/streaming_markdown_writer.py
+++ b/src/oaklib/io/streaming_markdown_writer.py
@@ -31,27 +31,27 @@ class StreamingMarkdownWriter(StreamingWriter):
     def emit(self, curie, label=None, **kwargs):
         oi = self.ontology_interface
         if label is None:
-            label = oi.get_label_by_curie(curie)
+            label = oi.label(curie)
         self.file.write(f"## {curie} {label}\n\n")
-        defn = oi.get_definition_by_curie(curie)
+        defn = oi.definition(curie)
         if defn:
             self.file.write(f"_{defn}_\n\n")
         self.file.write("### Xrefs\n\n")
 
-        for _, x in oi.get_simple_mappings_by_curie(curie):
+        for _, x in oi.simple_mappings_by_curie(curie):
             self.file.write(f" * {x}\n")
         self.file.write("\n")
         if isinstance(oi, OboGraphInterface):
             self.file.write("### Relationships\n\n")
-            for k, vs in oi.get_outgoing_relationship_map_by_curie(curie).items():
+            for k, vs in oi.outgoing_relationship_map(curie).items():
                 p = predicate_code_map.get(k, None)
                 if p is None:
-                    p = oi.get_label_by_curie(k)
+                    p = oi.label(k)
                     if p is None:
                         p = k
                 self.file.write(f"* {p}\n")
                 for v in vs:
-                    self.file.write(f'    * {v} "{oi.get_label_by_curie(curie)}"\n')
+                    self.file.write(f'    * {v} "{oi.label(curie)}"\n')
         if "t" in self.display_options and isinstance(oi, OboGraphInterface):
             self.file.write("### Taxon Constraints\n\n")
             tc_subj = get_term_with_taxon_constraints(oi, curie)

--- a/src/oaklib/io/streaming_obo_writer.py
+++ b/src/oaklib/io/streaming_obo_writer.py
@@ -25,29 +25,29 @@ class StreamingOboWriter(StreamingWriter):
         self.line("[Term]")
         self.line(f"id: {curie}")
         if label is None:
-            label = oi.get_label_by_curie(curie)
+            label = oi.label(curie)
         self.tag_val("name", label)
-        defn = oi.get_definition_by_curie(curie)
+        defn = oi.definition(curie)
         if defn:
             if isinstance(oi, MetadataInterface):
                 _, anns = oi.definition_with_annotations(curie)
             else:
                 anns = []
             self.tag_val("def", f'"{defn}"', xrefs=[ann.object for ann in anns])
-        for _, x in oi.get_simple_mappings_by_curie(curie):
+        for _, x in oi.simple_mappings_by_curie(curie):
             self.line(f"xref: {x}")
-        amap = oi.alias_map_by_curie(curie)
+        amap = oi.entity_alias_map(curie)
         for a, vs in amap.items():
             if a in SYNONYM_PRED_TO_SCOPE_MAP:
                 scope = SYNONYM_PRED_TO_SCOPE_MAP[a]
                 for v in vs:
                     self.line(f'synonym: "{v}" {scope} []')
         if isinstance(oi, OboGraphInterface):
-            rmap = oi.get_outgoing_relationship_map_by_curie(curie)
+            rmap = oi.outgoing_relationship_map(curie)
             for p in rmap.get(IS_A, []):
-                self.line(f"is_a: {p} ! {oi.get_label_by_curie(p)}")
+                self.line(f"is_a: {p} ! {oi.label(p)}")
             for r, ps in rmap.items():
                 if r != IS_A:
                     for p in ps:
-                        self.line(f"relationship: {r} {p} ! {oi.get_label_by_curie(p)}")
+                        self.line(f"relationship: {r} {p} ! {oi.label(p)}")
         self.line("\n")

--- a/src/oaklib/io/streaming_owl_functional_writer.py
+++ b/src/oaklib/io/streaming_owl_functional_writer.py
@@ -29,7 +29,7 @@ class StreamingOwlFunctionalWriter(StreamingWriter):
     def emit_curie(self, curie: CURIE, label=None):
         oi = self.ontology_interface
         if label is None:
-            label = oi.get_label_by_curie(curie)
+            label = oi.label(curie)
         if label:
             ax = AnnotationAssertion(
                 property=AnnotationProperty(oi.curie_to_uri(LABEL_PREDICATE)),

--- a/src/oaklib/io/streaming_rdf_writer.py
+++ b/src/oaklib/io/streaming_rdf_writer.py
@@ -23,7 +23,7 @@ class StreamingRdfWriter(StreamingWriter):
     def emit_curie(self, curie: CURIE, label=None):
         oi = self.ontology_interface
         if label is None:
-            label = oi.get_label_by_curie(curie)
+            label = oi.label(curie)
         if label:
             self.add_triple(
                 oi.curie_to_uri(curie), oi.curie_to_uri(LABEL_PREDICATE), rdflib.Literal(label)

--- a/src/oaklib/io/streaming_writer.py
+++ b/src/oaklib/io/streaming_writer.py
@@ -72,7 +72,7 @@ class StreamingWriter(ABC):
                 curie = obj_as_dict.get(f, None)
                 if curie:
                     if isinstance(curie, list):
-                        label = [self.ontology_interface.get_label_by_curie(c) for c in curie]
+                        label = [self.ontology_interface.label(c) for c in curie]
                     else:
-                        label = self.ontology_interface.get_label_by_curie(curie)
+                        label = self.ontology_interface.label(curie)
                     obj_as_dict[f"{f}_label"] = label

--- a/src/oaklib/utilities/graph/relationship_walker.py
+++ b/src/oaklib/utilities/graph/relationship_walker.py
@@ -42,7 +42,7 @@ def walk_up(
     while len(next_curies) > 0:
         logging.debug(f"Walking graph; {len(next_curies)} in stack")
         next_curie = next_curies.pop()
-        for pred, fillers in oi.get_outgoing_relationship_map_by_curie(next_curie).items():
+        for pred, fillers in oi.outgoing_relationship_map(next_curie).items():
             if not predicates or pred in predicates:
                 for filler in fillers:
                     if filler not in visited:
@@ -74,7 +74,7 @@ def walk_down(
     visited = copy(next_curies)
     while len(next_curies) > 0:
         next_curie = next_curies.pop()
-        for pred, subjects in oi.get_incoming_relationship_map_by_curie(next_curie).items():
+        for pred, subjects in oi.incoming_relationship_map(next_curie).items():
             if not predicates or pred in predicates:
                 for subject in subjects:
                     if subject not in visited:

--- a/src/oaklib/utilities/label_utilities.py
+++ b/src/oaklib/utilities/label_utilities.py
@@ -22,6 +22,6 @@ def add_labels_to_object(
     for curie_slot, label_slot in pairs:
         curie = getattr(obj, curie_slot, None)
         if curie is not None:
-            label = oi.get_label_by_curie(curie)
+            label = oi.label(curie)
             if label is not None:
                 setattr(obj, label_slot, label)

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -49,9 +49,9 @@ def add_labels_from_uris(oi: BasicOntologyInterface):
     :return:
     """
     logging.info("Adding labels from URIs")
-    curies = list(oi.all_entity_curies())
+    curies = list(oi.entities())
     for curie in curies:
-        if not oi.get_label_by_curie(curie):
+        if not oi.label(curie):
             if "#" in curie:
                 sep = "#"
             elif curie.startswith("http") or curie.startswith("<http"):
@@ -63,7 +63,7 @@ def add_labels_from_uris(oi: BasicOntologyInterface):
                 label = label.replace(">", "")
             label = " ".join(label.split("_"))
             # print(f'{curie} ==> {label} // {type(oi)}')
-            oi.set_label_for_curie(curie, label)
+            oi.set_label(curie, label)
             # print(oi.get_label_by_curie(curie))
 
 
@@ -85,13 +85,13 @@ def create_lexical_index(
         step2 = LexicalTransformation(TransformationType.WhitespaceNormalization)
         pipelines = [LexicalTransformationPipeline(name="default", transformations=[step1, step2])]
     ix = LexicalIndex(pipelines={p.name: p for p in pipelines})
-    for curie in oi.all_entity_curies():
+    for curie in oi.entities():
         logging.debug(f"Indexing {curie}")
         if not URIorCURIE.is_valid(curie):
             logging.warning(f"Skipping {curie} as it is not a valid CURIE")
             continue
-        alias_map = oi.alias_map_by_curie(curie)
-        mapping_map = pairs_as_dict(oi.get_simple_mappings_by_curie(curie))
+        alias_map = oi.entity_alias_map(curie)
+        mapping_map = pairs_as_dict(oi.simple_mappings_by_curie(curie))
         for pred, terms in {**alias_map, **mapping_map}.items():
             for term in terms:
                 if not term:
@@ -254,8 +254,8 @@ def inferred_mapping(
     best_weight, best_mapping, _ = best
     if best_weight is not None:
         best_mapping.confidence = inverse_logit(best_weight)
-    best_mapping.subject_label = oi.get_label_by_curie(best_mapping.subject_id)
-    best_mapping.object_label = oi.get_label_by_curie(best_mapping.object_id)
+    best_mapping.subject_label = oi.label(best_mapping.subject_id)
+    best_mapping.object_label = oi.label(best_mapping.object_id)
     return best_mapping
 
 

--- a/src/oaklib/utilities/mapping/mapping_validation.py
+++ b/src/oaklib/utilities/mapping/mapping_validation.py
@@ -35,7 +35,7 @@ def unreciprocated_mappings(
     :return:
     """
     groups = group_mappings_by_source_pairs(subject_oi, object_oi)
-    for m in subject_oi.all_sssom_mappings():
+    for m in subject_oi.sssom_mappings_by_source():
         subject_src = subject_source(m)
         object_src = object_source(m)
         subject_id = m.subject_id

--- a/src/oaklib/utilities/subsets/slimmer_utils.py
+++ b/src/oaklib/utilities/subsets/slimmer_utils.py
@@ -43,7 +43,7 @@ def roll_up_to_named_subset(
     :return:
     """
     # see https://metacpan.org/dist/go-perl/view/scripts/map2slim
-    terms_in_subset = set(oi.curies_by_subset(subset))
+    terms_in_subset = set(oi.subset_members(subset))
     # print(f'SUBSET={list(terms_in_subset)}')
     logging.info(f"Terms in {subset} = {len(terms_in_subset)}")
     subset_anc_map = {

--- a/src/oaklib/utilities/subsets/subset_analysis.py
+++ b/src/oaklib/utilities/subsets/subset_analysis.py
@@ -20,7 +20,7 @@ def get_subset_dict(oi: OboGraphInterface) -> SUBSET_DICT:
     :param oi:
     :return:
     """
-    return {s: list(oi.curies_by_subset(s)) for s in oi.all_subset_curies()}
+    return {s: list(oi.subset_members(s)) for s in oi.subsets()}
 
 
 def terms_by_subsets(
@@ -37,7 +37,7 @@ def terms_by_subsets(
     all_curies = set()
     for curies in subsets.values():
         all_curies.update(curies)
-    label_map = {curie: label for curie, label in oi.get_labels_for_curies(all_curies)}
+    label_map = {curie: label for curie, label in oi.labels(all_curies)}
     predicates = DEFAULT_PREDICATES
     subset_ancs = {}
     if subsumed_score is not None:
@@ -116,8 +116,8 @@ def subset_overlap(
     subset2: SUBSET_CURIE,
     predicates: List[PRED_CURIE] = None,
 ) -> float:
-    curies1 = list(oi.curies_by_subset(subset1))
-    curies2 = list(oi.curies_by_subset(subset2))
+    curies1 = list(oi.subset_members(subset1))
+    curies2 = list(oi.subset_members(subset2))
     if predicates is None:
         predicates = [IS_A, PART_OF]
     descs1 = oi.descendants(curies1, predicates=predicates)
@@ -126,9 +126,9 @@ def subset_overlap(
 
 
 def all_subsets_overlap(oi: OboGraphInterface) -> List[Tuple[float, SUBSET_CURIE, SUBSET_CURIE]]:
-    subsets = list(oi.all_subset_curies())
+    subsets = list(oi.subsets())
     results = []
-    dmap = {s: list(oi.descendants(list(oi.curies_by_subset(s)))) for s in subsets}
+    dmap = {s: list(oi.descendants(list(oi.subset_members(s)))) for s in subsets}
     dmap = {k: v for k, v in dmap.items() if len(v) > 0}
     subsets = dmap.keys()
     for s1 in subsets:

--- a/src/oaklib/utilities/table_filler.py
+++ b/src/oaklib/utilities/table_filler.py
@@ -210,11 +210,11 @@ class TableFiller:
         # abstract or less efficient code
         if rel == LABEL_KEY:
             if pk_vals:
-                for curie, label in oi.get_labels_for_curies(list(pk_vals)):
+                for curie, label in oi.labels(list(pk_vals)):
                     fwd_mapping[curie] = label
             if dc_vals:
                 for v in dc_vals:
-                    curies = oi.get_curies_by_label(v)
+                    curies = oi.curies_by_label(v)
                     if len(curies) == 1:
                         rev_mapping[v] = curies[0]
                     elif len(curies) == 0:
@@ -225,7 +225,7 @@ class TableFiller:
         elif rel == DEFINITION_KEY:
             if pk_vals:
                 for curie in pk_vals:
-                    defn = oi.get_definition_by_curie(curie)
+                    defn = oi.definition(curie)
                     fwd_mapping[curie] = defn
             if dc_vals:
                 raise NotImplementedError
@@ -249,7 +249,7 @@ class TableFiller:
                         params = dependency.parameters
                         if not params:
                             params = {}
-                        mappings = [x for _, x in oi.get_simple_mappings_by_curie(curie)]
+                        mappings = [x for _, x in oi.simple_mappings_by_curie(curie)]
                         fwd_mapping[curie] = mappings
                 else:
                     raise ValueError(f"{oi} must implement OboGraphInterface for ancestors option")

--- a/src/oaklib/utilities/taxon/taxon_constraint_utils.py
+++ b/src/oaklib/utilities/taxon/taxon_constraint_utils.py
@@ -25,7 +25,7 @@ def _taxon_ids(tcs: List[TaxonConstraint]) -> List[TAXON_CURIE]:
 def get_direct_taxon_constraints(
     oi: OboGraphInterface, curie: CURIE
 ) -> Iterator[Tuple[PRED_CURIE, TAXON_CURIE]]:
-    for pred, taxons in oi.get_outgoing_relationship_map_by_curie(curie).items():
+    for pred, taxons in oi.outgoing_relationship_map(curie).items():
         if pred in TAXON_PREDICATES:
             if pred == ONLY_IN_TAXON:
                 pred = IN_TAXON
@@ -71,13 +71,13 @@ def _fill_missing(st: SubjectTerm):
 
 def inject_labels(oi: OboGraphInterface, st: SubjectTerm):
     if st.label is None:
-        st.label = oi.get_label_by_curie(st.id)
+        st.label = oi.label(st.id)
     for r in st.only_in + st.never_in + st.present_in + st.present_in_ancestor_of:
         if r.taxon.label is None:
-            r.taxon.label = oi.get_label_by_curie(r.taxon.id)
+            r.taxon.label = oi.label(r.taxon.id)
         for t in r.via_terms:
             if t.label is None:
-                t.label = oi.get_label_by_curie(t.id)
+                t.label = oi.label(t.id)
 
 
 def test_candidate_taxon_constraint(
@@ -103,7 +103,7 @@ def test_candidate_taxon_constraint(
     candidate_never = [tc.taxon.id for tc in candidate_st.never_in]
     # msgs = []
     for candidate_tc in candidate_st.only_in:
-        if not oi.get_label_by_curie(candidate_tc.taxon.id):
+        if not oi.label(candidate_tc.taxon.id):
             raise ValueError(f"Unknown taxon: {candidate_tc.taxon.id}")
         if not candidate_tc.redundant:
             for other_candidate_tc in candidate_st.only_in:
@@ -154,7 +154,7 @@ def test_candidate_taxon_constraint(
                 candidate_st.unsatisfiable = True
                 tc.contradicted_by(pos_tc)
     for candidate_tc in candidate_st.never_in:
-        if not oi.get_label_by_curie(candidate_tc.taxon.id):
+        if not oi.label(candidate_tc.taxon.id):
             raise ValueError(f"Unknown taxon: {candidate_tc.taxon.id}")
         if not candidate_tc.redundant:
             for anc in oi.ancestors(candidate_tc.taxon.id, predicates):
@@ -198,7 +198,7 @@ def get_term_with_taxon_constraints(
     :param add_labels:
     :return:
     """
-    label = oi.get_label_by_curie(curie)
+    label = oi.label(curie)
     st = SubjectTerm(curie, label=label)
     if label is None:
         raise ValueError(f"Unknown term: {curie}")
@@ -334,7 +334,7 @@ def parse_gain_loss_file(file: TextIO) -> Iterator[SubjectTerm]:
 
 def get_taxon_constraints_description(oi: OboGraphInterface, st: SubjectTerm) -> str:
     def td(t: CURIE) -> str:
-        return f'{t} "{oi.get_label_by_curie(t)}"'
+        return f'{t} "{oi.label(t)}"'
 
     def tds(ts: List[CURIE]) -> List[str]:
         return [td(t) for t in ts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,7 +247,7 @@ class TestCommandLineInterface(unittest.TestCase):
                     ".anc//p=i",
                     "nucleus",
                     ".filter",
-                    "[x for x in terms if not impl.get_definition_by_curie(x)]",
+                    "[x for x in terms if not impl.definition(x)]",
                 ],
                 True,
                 ["CARO:0000000", "CARO:0030000"],

--- a/tests/test_implementations/test_aggregator.py
+++ b/tests/test_implementations/test_aggregator.py
@@ -38,24 +38,24 @@ class TestAggregator(unittest.TestCase):
 
     def test_relationships(self):
         oi = self.oi
-        rels = oi.get_outgoing_relationship_map_by_curie("GO:0005773")
+        rels = oi.outgoing_relationship_map("GO:0005773")
         # for k, v in rels.items():
         #    print(f'{k} = {v}')
         self.assertCountEqual(rels[IS_A], ["GO:0043231"])
         self.assertCountEqual(rels[PART_OF], [CYTOPLASM])
-        rels = oi.get_outgoing_relationship_map_by_curie(TISSUE)
+        rels = oi.outgoing_relationship_map(TISSUE)
         # for k, v in rels.items():
         #    print(f'{k} = {v}')
         self.assertCountEqual(rels[IS_A], ["UBERON:0010000"])
 
     def test_all_terms(self):
-        curies = list(self.oi.all_entity_curies())
+        curies = list(self.oi.entities())
         self.assertIn(NUCLEUS, curies)
         self.assertIn(INTERNEURON, curies)
 
     def test_relations(self):
         oi = self.oi
-        label = oi.get_label_by_curie(PART_OF)
+        label = oi.label(PART_OF)
         assert label.startswith("part")
         t = self.oi.node(PART_OF)
         assert t.id == PART_OF
@@ -63,10 +63,10 @@ class TestAggregator(unittest.TestCase):
 
     @unittest.skip("TODO")
     def test_metadata(self):
-        for curie in self.oi.all_entity_curies():
-            m = self.oi.metadata_map_by_curie(curie)
+        for curie in self.oi.entities():
+            m = self.oi.entity_metadata_map(curie)
             print(f"{curie} {m}")
-        m = self.oi.metadata_map_by_curie("GO:0005622")
+        m = self.oi.entity_metadata_map("GO:0005622")
         assert "term_tracker_item" in m.keys()
         assert "https://github.com/geneontology/go-ontology/issues/17776" in m["term_tracker_item"]
 
@@ -76,19 +76,19 @@ class TestAggregator(unittest.TestCase):
         :return:
         """
         oi = self.oi
-        label = oi.get_label_by_curie(VACUOLE)
+        label = oi.label(VACUOLE)
         self.assertEqual(str, type(label))
         self.assertEqual(label, "vacuole")
-        label = oi.get_label_by_curie("FOOBAR:123")
+        label = oi.label("FOOBAR:123")
         self.assertIsNone(label)
         # TODO: test strict mode
-        label = oi.get_label_by_curie(IS_A)
+        label = oi.label(IS_A)
         self.assertIsNotNone(label)
-        self.assertEqual("interneuron", oi.get_label_by_curie(INTERNEURON))
-        self.assertEqual("tissue", oi.get_label_by_curie(TISSUE))
+        self.assertEqual("interneuron", oi.label(INTERNEURON))
+        self.assertEqual("tissue", oi.label(TISSUE))
 
     def test_synonyms(self):
-        syns = self.oi.aliases_by_curie(CELLULAR_COMPONENT)
+        syns = self.oi.entity_aliases(CELLULAR_COMPONENT)
         self.assertCountEqual(
             syns,
             [
@@ -98,20 +98,20 @@ class TestAggregator(unittest.TestCase):
                 "subcellular entity",
             ],
         )
-        syns = self.oi.aliases_by_curie("CL:0000100")
+        syns = self.oi.entity_aliases("CL:0000100")
         self.assertCountEqual(syns, ["motoneuron", "motor neuron"])
         self.assertCountEqual(
-            self.oi.aliases_by_curie(TISSUE),
+            self.oi.entity_aliases(TISSUE),
             ["tissue", "simple tissue", "tissue portion", "portion of tissue"],
         )
 
     def test_subsets(self):
         oi = self.oi
-        subsets = list(oi.all_subset_curies())
+        subsets = list(oi.subsets())
         self.assertIn("goslim_aspergillus", subsets)
-        self.assertIn("GO:0003674", oi.curies_by_subset("goslim_generic"))
-        self.assertNotIn("GO:0003674", oi.curies_by_subset("gocheck_do_not_manually_annotate"))
-        self.assertIn(TISSUE, oi.curies_by_subset("pheno_slim"))
+        self.assertIn("GO:0003674", oi.subset_members("goslim_generic"))
+        self.assertNotIn("GO:0003674", oi.subset_members("gocheck_do_not_manually_annotate"))
+        self.assertIn(TISSUE, oi.subset_members("pheno_slim"))
 
     def test_ancestors(self):
         oi = self.oi

--- a/tests/test_implementations/test_funowl.py
+++ b/tests/test_implementations/test_funowl.py
@@ -21,7 +21,7 @@ class TestFunOwlImplementation(unittest.TestCase):
         self.oi = oi
 
     def test_entities(self):
-        curies = list(self.oi.all_entity_curies())
+        curies = list(self.oi.entities())
         self.assertIn(NUCLEUS, curies)
         self.assertIn(CHEBI_NUCLEUS, curies)
         self.assertIn(HUMAN, curies)
@@ -64,10 +64,10 @@ class TestFunOwlImplementation(unittest.TestCase):
         oi = self.oi
         anns = list(oi.annotation_assertion_axioms(NUCLEUS))
         self.assertGreater(len(anns), 5)
-        label = oi.get_label_by_curie(NUCLEUS)
+        label = oi.label(NUCLEUS)
         self.assertEqual("nucleus", label)
         oi.apply_patch(
             kgcl.NodeRename(id=generate_change_id(), about_node=VACUOLE, new_value=NEW_NAME)
         )
-        label = oi.get_label_by_curie(VACUOLE)
+        label = oi.label(VACUOLE)
         self.assertEqual(NEW_NAME, label)

--- a/tests/test_implementations/test_ontobee.py
+++ b/tests/test_implementations/test_ontobee.py
@@ -24,38 +24,38 @@ class TestOntobeeImplementation(unittest.TestCase):
 
     def test_relationships(self):
         ont = self.oi
-        rels = ont.get_outgoing_relationship_map_by_curie(VACUOLE)
+        rels = ont.outgoing_relationship_map(VACUOLE)
         for k, v in rels.items():
             logging.info(f"{k} = {v}")
         self.assertIn("GO:0043231", rels[IS_A])
         self.assertIn("GO:0005737", rels[PART_OF])
 
     def test_parents(self):
-        parents = self.oi.get_hierararchical_parents_by_curie(VACUOLE)
+        parents = self.oi.hierararchical_parents(VACUOLE)
         # print(parents)
         assert "GO:0043231" in parents
 
     def test_labels(self):
-        label = self.oi.get_label_by_curie(DIGIT)
+        label = self.oi.label(DIGIT)
         logging.info(label)
         self.assertEqual(label, "digit")
 
     def test_subontology(self):
         oi = self.pato_graph_oi
         self.assertIsNotNone(oi.named_graph)
-        label = oi.get_label_by_curie(DIGIT)
+        label = oi.label(DIGIT)
         self.assertIsNone(label)
         # logging.info(label)
         # self.assertEqual(label, 'digit')
-        self.assertEqual("shape", oi.get_label_by_curie(SHAPE))
+        self.assertEqual("shape", oi.label(SHAPE))
 
     def test_synonyms(self):
-        syns = self.oi.aliases_by_curie(CELLULAR_COMPONENT)
+        syns = self.oi.entity_aliases(CELLULAR_COMPONENT)
         logging.info(syns)
         assert "cellular component" in syns
 
     def test_definition(self):
-        defn = self.oi.get_definition_by_curie(CELLULAR_COMPONENT)
+        defn = self.oi.definition(CELLULAR_COMPONENT)
         logging.info(defn)
         assert defn
 

--- a/tests/test_implementations/test_pronto.py
+++ b/tests/test_implementations/test_pronto.py
@@ -43,7 +43,7 @@ class TestProntoImplementation(unittest.TestCase):
     def test_obo_json(self) -> None:
         resource = OntologyResource(slug="go-nucleus.json", directory=INPUT_DIR, local=True)
         json_oi = ProntoImplementation(resource)
-        curies = list(json_oi.all_entity_curies())
+        curies = list(json_oi.entities())
         # for e in curies:
         #    print(e)
         self.assertIn(NUCLEUS, curies)
@@ -60,7 +60,7 @@ class TestProntoImplementation(unittest.TestCase):
 
     def test_relationships(self):
         oi = self.oi
-        rels = oi.get_outgoing_relationship_map_by_curie("GO:0005773")
+        rels = oi.outgoing_relationship_map("GO:0005773")
         for k, v in rels.items():
             print(f"{k} = {v}")
         self.assertCountEqual(rels[IS_A], ["GO:0043231"])
@@ -68,35 +68,35 @@ class TestProntoImplementation(unittest.TestCase):
 
     def test_gci_relationships(self):
         oi = self.oi
-        rels = oi.get_outgoing_relationship_map_by_curie(CELL)
+        rels = oi.outgoing_relationship_map(CELL)
         self.assertCountEqual(rels[IS_A], ["CARO:0000003"])
         self.assertCountEqual(rels[ONLY_IN_TAXON], [CELLULAR_ORGANISMS])
         self.assertNotIn(PART_OF, rels)  # GCI relations excluded
 
     def test_incoming_relationships(self):
         oi = self.oi
-        rels = oi.get_incoming_relationship_map_by_curie(CYTOPLASM)
+        rels = oi.incoming_relationship_map(CYTOPLASM)
         for k, v in rels.items():
             print(f"{k} = {v}")
         self.assertCountEqual(rels[IS_A], ["GO:0005938", "GO:0099568"])
         self.assertCountEqual(rels[PART_OF], ["GO:0005773", "GO:0099568"])
 
     def test_all_terms(self):
-        assert any(curie for curie in self.oi.all_entity_curies() if curie == "GO:0008152")
+        assert any(curie for curie in self.oi.entities() if curie == "GO:0008152")
 
     def test_relations(self):
         oi = self.oi
-        label = oi.get_label_by_curie(PART_OF)
+        label = oi.label(PART_OF)
         assert label.startswith("part")
         t = self.oi.node(PART_OF)
         assert t.id == PART_OF
         assert t.lbl.startswith("part")
 
     def test_metadata(self):
-        for curie in self.oi.all_entity_curies():
-            m = self.oi.metadata_map_by_curie(curie)
+        for curie in self.oi.entities():
+            m = self.oi.entity_metadata_map(curie)
             print(f"{curie} {m}")
-        m = self.oi.metadata_map_by_curie("GO:0005622")
+        m = self.oi.entity_metadata_map("GO:0005622")
         assert "term_tracker_item" in m.keys()
         assert "https://github.com/geneontology/go-ontology/issues/17776" in m["term_tracker_item"]
 
@@ -106,17 +106,17 @@ class TestProntoImplementation(unittest.TestCase):
         :return:
         """
         oi = self.oi
-        label = oi.get_label_by_curie("GO:0005773")
+        label = oi.label("GO:0005773")
         self.assertEqual(str, type(label))
         self.assertEqual(label, "vacuole")
-        label = oi.get_label_by_curie("FOOBAR:123")
+        label = oi.label("FOOBAR:123")
         self.assertIsNone(label)
         # TODO: test strict mode
-        label = oi.get_label_by_curie(IS_A)
+        label = oi.label(IS_A)
         self.assertIsNotNone(label)
 
     def test_synonyms(self):
-        syns = self.oi.aliases_by_curie("GO:0005575")
+        syns = self.oi.entity_aliases("GO:0005575")
         # print(syns)
         self.assertCountEqual(
             syns,
@@ -127,10 +127,10 @@ class TestProntoImplementation(unittest.TestCase):
                 "subcellular entity",
             ],
         )
-        syns = self.oi.aliases_by_curie(NUCLEUS)
+        syns = self.oi.entity_aliases(NUCLEUS)
         logging.info(syns)
         self.assertCountEqual(syns, ["nucleus", "cell nucleus", "horsetail nucleus"])
-        syn_pairs = list(self.oi.alias_map_by_curie(NUCLEUS).items())
+        syn_pairs = list(self.oi.entity_alias_map(NUCLEUS).items())
         self.assertCountEqual(
             syn_pairs,
             [
@@ -155,10 +155,10 @@ class TestProntoImplementation(unittest.TestCase):
 
     def test_subsets(self):
         oi = self.oi
-        subsets = list(oi.all_subset_curies())
+        subsets = list(oi.subsets())
         self.assertIn("goslim_aspergillus", subsets)
-        self.assertIn("GO:0003674", oi.curies_by_subset("goslim_generic"))
-        self.assertNotIn("GO:0003674", oi.curies_by_subset("gocheck_do_not_manually_annotate"))
+        self.assertIn("GO:0003674", oi.subset_members("goslim_generic"))
+        self.assertNotIn("GO:0003674", oi.subset_members("gocheck_do_not_manually_annotate"))
 
     def test_save(self):
         oi = ProntoImplementation.create()
@@ -174,7 +174,7 @@ class TestProntoImplementation(unittest.TestCase):
 
     def test_from_obo_library(self):
         oi = ProntoImplementation.create(OntologyResource(local=False, slug="pato.obo"))
-        curies = oi.get_curies_by_label("shape")
+        curies = oi.curies_by_label("shape")
         self.assertEqual(["PATO:0000052"], curies)
 
     @unittest.skip("Hide warnings")
@@ -328,5 +328,5 @@ class TestProntoImplementation(unittest.TestCase):
         oi2 = ProntoImplementation(resource)
         self.assertCountEqual(
             ["cell or subcellular entity", "cellular component", "cellular_component", "foo bar"],
-            oi2.aliases_by_curie(CELLULAR_COMPONENT),
+            oi2.entity_aliases(CELLULAR_COMPONENT),
         )

--- a/tests/test_implementations/test_sparql.py
+++ b/tests/test_implementations/test_sparql.py
@@ -43,32 +43,32 @@ class TestSparqlImplementation(unittest.TestCase):
     def test_relationships(self):
         oi = self.oi
         self.assertIsNotNone(oi.graph)
-        rels = oi.get_outgoing_relationship_map_by_curie(VACUOLE)
+        rels = oi.outgoing_relationship_map(VACUOLE)
         for k, v in rels.items():
             logging.info(f"{k} = {v}")
         self.assertIn("GO:0043231", rels[IS_A])
         self.assertIn("GO:0005737", rels[PART_OF])
 
     def test_parents(self):
-        parents = self.oi.get_hierararchical_parents_by_curie(VACUOLE)
+        parents = self.oi.hierararchical_parents(VACUOLE)
         # print(parents)
         assert "GO:0043231" in parents
 
     def test_labels(self):
-        label = self.oi.get_label_by_curie(NUCLEUS)
+        label = self.oi.label(NUCLEUS)
         logging.info(label)
         self.assertEqual(label, "nucleus")
-        self.assertEqual(self.oi.get_curies_by_label(label), [NUCLEUS])
+        self.assertEqual(self.oi.curies_by_label(label), [NUCLEUS])
 
     @unittest.skip("TODO")
     def test_subontology(self):
         oi = self.oi
         self.assertIsNotNone(oi.named_graph)
-        label = oi.get_label_by_curie(DIGIT)
+        label = oi.label(DIGIT)
         self.assertIsNone(label)
         # logging.info(label)
         # self.assertEqual(label, 'digit')
-        self.assertEqual("shape", oi.get_label_by_curie(SHAPE))
+        self.assertEqual("shape", oi.label(SHAPE))
 
     def test_dump(self):
         OUTPUT_DIR.mkdir(exist_ok=True)
@@ -76,19 +76,19 @@ class TestSparqlImplementation(unittest.TestCase):
 
     @unittest.skip("TODO")
     def test_set_label(self):
-        self.oi.set_label_for_curie(NUCLEUS, "foo")
+        self.oi.set_label(NUCLEUS, "foo")
         OUTPUT_DIR.mkdir(exist_ok=True)
         self.oi.dump(TEST_MUTABLE_RDF, "ttl")
 
     def test_synonyms(self):
-        syns = self.oi.aliases_by_curie(CELLULAR_COMPONENT)
+        syns = self.oi.entity_aliases(CELLULAR_COMPONENT)
         logging.info(syns)
         assert "cellular component" in syns
         assert "cellular_component" in syns
-        syns = self.oi.aliases_by_curie(NUCLEUS)
+        syns = self.oi.entity_aliases(NUCLEUS)
         logging.info(syns)
         self.assertCountEqual(syns, ["nucleus", "cell nucleus", "horsetail nucleus"])
-        syn_pairs = list(self.oi.alias_map_by_curie(NUCLEUS).items())
+        syn_pairs = list(self.oi.entity_alias_map(NUCLEUS).items())
         self.assertCountEqual(
             syn_pairs,
             [
@@ -99,12 +99,12 @@ class TestSparqlImplementation(unittest.TestCase):
         )
 
     def test_all_entity_curies(self):
-        curies = list(self.oi.all_entity_curies())
+        curies = list(self.oi.entities())
         self.assertGreater(len(curies), 100)
         self.assertIn(NUCLEUS, curies)
 
     def test_definition(self):
-        defn = self.oi.get_definition_by_curie(CELLULAR_COMPONENT)
+        defn = self.oi.definition(CELLULAR_COMPONENT)
         assert defn.startswith("A location, relative to cellular compartments")
 
     def test_search_exact(self):
@@ -191,14 +191,14 @@ class TestSparqlImplementation(unittest.TestCase):
         """
         shutil.copyfile(TEST_RDF, TEST_MUTABLE_RDF)
         oi = SparqlImplementation(OntologyResource(slug=str(TEST_MUTABLE_RDF)))
-        label = oi.get_label_by_curie(NUCLEUS)
+        label = oi.label(NUCLEUS)
         preds = [IS_A, PART_OF]
         preds2 = [IS_A, FAKE_PREDICATE]
         ancestors = list(oi.ancestors(NUCLEUS, predicates=preds, reflexive=False))
         descendants = list(oi.descendants(NUCLEUS, predicates=preds, reflexive=False))
         oi.migrate_curies({NUCLEUS: FAKE_ID, PART_OF: FAKE_PREDICATE})
-        self.assertEqual(label, oi.get_label_by_curie(FAKE_ID))
-        self.assertIsNone(oi.get_label_by_curie(NUCLEUS))
+        self.assertEqual(label, oi.label(FAKE_ID))
+        self.assertIsNone(oi.label(NUCLEUS))
         self.assertCountEqual(ancestors, oi.ancestors(FAKE_ID, predicates=preds2, reflexive=False))
         self.assertCountEqual([], list(oi.ancestors(NUCLEUS, predicates=preds, reflexive=False)))
         self.assertCountEqual(

--- a/tests/test_implementations/test_sqldb.py
+++ b/tests/test_implementations/test_sqldb.py
@@ -57,23 +57,23 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
 
     def test_relationships(self):
         oi = self.oi
-        rels = oi.get_outgoing_relationship_map_by_curie(VACUOLE)
+        rels = oi.outgoing_relationship_map(VACUOLE)
         self.assertCountEqual(rels[IS_A], ["GO:0043231"])
         self.assertCountEqual(rels[PART_OF], ["GO:0005737"])
         self.assertCountEqual([IS_A, PART_OF], rels)
 
     def test_all_nodes(self):
-        for curie in self.oi.all_entity_curies():
+        for curie in self.oi.entities():
             print(curie)
 
     def test_labels(self):
-        label = self.oi.get_label_by_curie(VACUOLE)
+        label = self.oi.label(VACUOLE)
         self.assertEqual(label, "vacuole")
 
     def test_get_labels_for_curies(self):
         oi = self.oi
-        curies = oi.curies_by_subset("goslim_generic")
-        tups = list(oi.get_labels_for_curies(curies))
+        curies = oi.subset_members("goslim_generic")
+        tups = list(oi.labels(curies))
         for curie, label in tups:
             print(f"{curie} ! {label}")
         assert (VACUOLE, "vacuole") in tups
@@ -81,7 +81,7 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
         self.assertEqual(11, len(tups))
 
     def test_synonyms(self):
-        syns = self.oi.aliases_by_curie(CELLULAR_COMPONENT)
+        syns = self.oi.entity_aliases(CELLULAR_COMPONENT)
         print(syns)
         assert "cellular component" in syns
 
@@ -417,7 +417,7 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
         )
         self.assertEqual(len(rels), 0)
         # trivial edge case - subset using all terms and all predicates
-        rels = list(oi.gap_fill_relationships(list(oi.all_entity_curies())))
+        rels = list(oi.gap_fill_relationships(list(oi.entities())))
         all_rels = list(oi.all_relationships())
         # self.assertEqual(len(rels), len(all_rels))
         for rel in rels:
@@ -432,26 +432,26 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
         shutil.copyfile(DB, MUTABLE_DB)
         oi = SqlImplementation(OntologyResource(slug=f"sqlite:///{MUTABLE_DB}"))
         oi.autosave = True
-        label = oi.get_label_by_curie(VACUOLE)
+        label = oi.label(VACUOLE)
         self.assertEqual("vacuole", label)
-        oi.set_label_for_curie(VACUOLE, "foo")
-        label = oi.get_label_by_curie(VACUOLE)
+        oi.set_label(VACUOLE, "foo")
+        label = oi.label(VACUOLE)
         self.assertEqual("foo", label)
         # oi.save()
         oi.autosave = False
-        label = oi.get_label_by_curie(VACUOLE)
+        label = oi.label(VACUOLE)
         self.assertEqual("foo", label)
-        oi.set_label_for_curie(NUCLEUS, "bar")
-        oi.set_label_for_curie(NUCLEAR_ENVELOPE, "baz")
-        self.assertNotEqual("bar", oi.get_label_by_curie(NUCLEUS))
-        self.assertNotEqual("baz", oi.get_label_by_curie(NUCLEAR_ENVELOPE))
+        oi.set_label(NUCLEUS, "bar")
+        oi.set_label(NUCLEAR_ENVELOPE, "baz")
+        self.assertNotEqual("bar", oi.label(NUCLEUS))
+        self.assertNotEqual("baz", oi.label(NUCLEAR_ENVELOPE))
         oi.save()
-        self.assertEqual("bar", oi.get_label_by_curie(NUCLEUS))
-        self.assertEqual("baz", oi.get_label_by_curie(NUCLEAR_ENVELOPE))
+        self.assertEqual("bar", oi.label(NUCLEUS))
+        self.assertEqual("baz", oi.label(NUCLEAR_ENVELOPE))
         # get a fresh copy to ensure changes have persisted
         oi = SqlImplementation(OntologyResource(slug=f"sqlite:///{MUTABLE_DB}"))
-        self.assertEqual("bar", oi.get_label_by_curie(NUCLEUS))
-        self.assertEqual("baz", oi.get_label_by_curie(NUCLEAR_ENVELOPE))
+        self.assertEqual("bar", oi.label(NUCLEUS))
+        self.assertEqual("baz", oi.label(NUCLEAR_ENVELOPE))
 
     def test_set_labels_from_iris(self):
         """
@@ -460,8 +460,8 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
         shutil.copyfile(SSN_DB, MUTABLE_SSN_DB)
         oi = SqlImplementation(OntologyResource(slug=f"sqlite:///{MUTABLE_SSN_DB}"))
         no_label_curies = []
-        for curie in oi.all_entity_curies():
-            label = oi.get_label_by_curie(curie)
+        for curie in oi.entities():
+            label = oi.label(curie)
             # print(f'{curie}: {label}')
             if label is None:
                 no_label_curies.append(curie)
@@ -470,7 +470,7 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
         add_labels_from_uris(oi)
         oi.save()
         for curie in no_label_curies:
-            label = oi.get_label_by_curie(curie)
+            label = oi.label(curie)
             # TODO
             # print(f'XXX {curie}: {label}')
             # self.assertIsNotNone(label)
@@ -481,7 +481,7 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
         """
         shutil.copyfile(DB, MUTABLE_DB)
         oi = SqlImplementation(OntologyResource(slug=f"sqlite:///{MUTABLE_DB}"))
-        label = oi.get_label_by_curie(NUCLEUS)
+        label = oi.label(NUCLEUS)
         preds = [IS_A, PART_OF]
         preds2 = [IS_A, FAKE_PREDICATE]
         ancestors = list(oi.ancestors(NUCLEUS, predicates=preds))
@@ -494,8 +494,8 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
         descendants_ancs = non_reflexive(descendants)
         oi.migrate_curies({NUCLEUS: FAKE_ID, PART_OF: FAKE_PREDICATE})
         oi.save()
-        self.assertEqual(label, oi.get_label_by_curie(FAKE_ID))
-        self.assertIsNone(oi.get_label_by_curie(NUCLEUS))
+        self.assertEqual(label, oi.label(FAKE_ID))
+        self.assertIsNone(oi.label(NUCLEUS))
         self.assertCountEqual(
             expected_ancs, non_reflexive(oi.ancestors(FAKE_ID, predicates=preds2))
         )
@@ -507,7 +507,7 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
 
     def test_statements_with_annotations(self):
         oi = self.oi
-        for curie in oi.all_entity_curies():
+        for curie in oi.entities():
             for ax in oi.statements_with_annotations(curie):
                 logging.info(yaml_dumper.dumps(ax))
         for ax in oi.statements_with_annotations(NUCLEUS):
@@ -542,12 +542,12 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
         #                                                                )))
         oi.save()
         oi = SqlImplementation(OntologyResource(slug=f"sqlite:///{MUTABLE_DB}"))
-        obs = list(oi.all_obsolete_curies())
+        obs = list(oi.obsoletes())
         self.assertIn(NUCLEUS, obs)
-        self.assertIsNone(oi.get_label_by_curie(VACUOLE))
-        self.assertIn("envelope of nucleus", oi.aliases_by_curie(NUCLEAR_ENVELOPE))
-        self.assertIn(CELLULAR_COMPONENT, oi.get_outgoing_relationship_map_by_curie(NUCLEUS)[IS_A])
-        self.assertNotIn(IMBO, oi.get_outgoing_relationship_map_by_curie(NUCLEUS)[IS_A])
+        self.assertIsNone(oi.label(VACUOLE))
+        self.assertIn("envelope of nucleus", oi.entity_aliases(NUCLEAR_ENVELOPE))
+        self.assertIn(CELLULAR_COMPONENT, oi.outgoing_relationship_map(NUCLEUS)[IS_A])
+        self.assertNotIn(IMBO, oi.outgoing_relationship_map(NUCLEUS)[IS_A])
 
     def test_sqla_write(self):
         shutil.copyfile(DB, MUTABLE_DB)

--- a/tests/test_implementations/test_ubergraph.py
+++ b/tests/test_implementations/test_ubergraph.py
@@ -36,7 +36,7 @@ class TestUbergraphImplementation(unittest.TestCase):
     @unittest.skip("HTTP Error 503: Service Temporarily Unavailable")
     def test_relationships(self):
         ont = self.oi
-        rels = ont.get_outgoing_relationship_map_by_curie(VACUOLE)
+        rels = ont.outgoing_relationship_map(VACUOLE)
         for k, v in rels.items():
             logging.info(f"{k} = {v}")
         self.assertIn("GO:0043231", rels[IS_A])
@@ -54,22 +54,22 @@ class TestUbergraphImplementation(unittest.TestCase):
 
     @unittest.skip("HTTP Error 503: Service Temporarily Unavailable")
     def test_labels(self):
-        label = self.oi.get_label_by_curie(DIGIT)
+        label = self.oi.label(DIGIT)
         self.assertEqual(label, "digit")
-        self.assertIn(DIGIT, self.oi.get_curies_by_label(label))
+        self.assertIn(DIGIT, self.oi.curies_by_label(label))
 
     @unittest.skip("HTTP Error 503: Service Temporarily Unavailable")
     def test_synonyms(self):
-        syns = self.oi.aliases_by_curie(CELLULAR_COMPONENT)
+        syns = self.oi.entity_aliases(CELLULAR_COMPONENT)
         logging.info(syns)
         assert "cellular component" in syns
 
     @unittest.skip("This test is too rigid as synonyms are liable to change")
     def test_synonyms_granular(self):
-        syns = self.oi.aliases_by_curie(NUCLEUS)
+        syns = self.oi.entity_aliases(NUCLEUS)
         logging.info(syns)
         self.assertCountEqual(syns, ["nucleus", "cell nucleus", "horsetail nucleus"])
-        syn_pairs = list(self.oi.alias_map_by_curie(NUCLEUS).items())
+        syn_pairs = list(self.oi.entity_alias_map(NUCLEUS).items())
         self.assertCountEqual(
             syn_pairs,
             [
@@ -81,7 +81,7 @@ class TestUbergraphImplementation(unittest.TestCase):
 
     @unittest.skip("HTTP Error 504: Gateway Time-out")
     def test_definition(self):
-        defn = self.oi.get_definition_by_curie("GO:0005575")
+        defn = self.oi.definition("GO:0005575")
         logging.info(defn)
         assert defn
 

--- a/tests/test_implementations/test_wikidata.py
+++ b/tests/test_implementations/test_wikidata.py
@@ -25,7 +25,7 @@ class TestWikidataImplementation(unittest.TestCase):
 
     def test_relationships(self):
         oi = self.oi
-        rels = oi.get_outgoing_relationship_map_by_curie(WD_SLY_SYNDROME)
+        rels = oi.outgoing_relationship_map(WD_SLY_SYNDROME)
         for k, vs in rels.items():
             print(f"{k}")
             for v in vs:
@@ -34,24 +34,24 @@ class TestWikidataImplementation(unittest.TestCase):
     @unittest.skip("Too slow")
     def test_relationships_slow(self):
         oi = self.oi
-        rels = oi.get_outgoing_relationship_map_by_curie(WD_SLY_SYNDROME)
+        rels = oi.outgoing_relationship_map(WD_SLY_SYNDROME)
         for k, vs in rels.items():
-            print(f'{k} "{oi.get_label_by_curie(k)}"')
+            print(f'{k} "{oi.label(k)}"')
             for v in vs:
-                print(f'  = {v} "{oi.get_label_by_curie(v)}"')
+                print(f'  = {v} "{oi.label(v)}"')
 
     def test_labels(self):
-        label = self.oi.get_label_by_curie(WD_SLY_SYNDROME)
+        label = self.oi.label(WD_SLY_SYNDROME)
         # print(label)
-        self.assertIn(WD_SLY_SYNDROME, self.oi.get_curies_by_label(label))
+        self.assertIn(WD_SLY_SYNDROME, self.oi.curies_by_label(label))
 
     def test_synonyms(self):
-        syns = self.oi.aliases_by_curie(WD_SLY_SYNDROME)
+        syns = self.oi.entity_aliases(WD_SLY_SYNDROME)
         logging.info(syns)
         assert "mucopolysaccharidosis VII" in syns
 
     def test_definition(self):
-        defn = self.oi.get_definition_by_curie(WD_PECTORAL_FIN_MORPHOGENESIS)
+        defn = self.oi.definition(WD_PECTORAL_FIN_MORPHOGENESIS)
         logging.info(f"DEF={defn}")
         assert defn
 
@@ -59,7 +59,7 @@ class TestWikidataImplementation(unittest.TestCase):
         oi = self.oi
         config = SearchConfiguration(is_partial=False, limit=3)
         curies = list(oi.basic_search("endoplasmic reticulum", config=config))
-        tups = list(oi.get_labels_for_curies(curies))
+        tups = list(oi.labels(curies))
         # print(tups)
         self.assertIn((WD_ER, "endoplasmic reticulum"), tups)
 
@@ -70,7 +70,7 @@ class TestWikidataImplementation(unittest.TestCase):
         ancs = list(oi.ancestors([WD_SLY_SYNDROME], predicates=[IS_A, "wdp:P1199"]))
         for a in ancs:
             print(a)
-        for curie, label in oi.get_labels_for_curies(ancs):
+        for curie, label in oi.labels(ancs):
             print(f"{curie} ! {label}")
         self.assertIn(WD_MPS, ancs)
 
@@ -80,7 +80,7 @@ class TestWikidataImplementation(unittest.TestCase):
         for a in results:
             print(a)
         self.assertIn(WD_SLY_SYNDROME, results)
-        for curie, label in oi.get_labels_for_curies(results):
+        for curie, label in oi.labels(results):
             print(f"D: {curie} ! {label}")
 
     def test_ancestor_graph(self):

--- a/tests/test_utilities/test_roll_up_to_subset.py
+++ b/tests/test_utilities/test_roll_up_to_subset.py
@@ -26,8 +26,8 @@ class TestSubsetUtils(unittest.TestCase):
 
     def test_roll_up(self):
         oi = self.oi
-        term_curies = [t for t in oi.all_entity_curies() if t.startswith("GO:")]
-        for subset in oi.all_subset_curies():
+        term_curies = [t for t in oi.entities() if t.startswith("GO:")]
+        for subset in oi.subsets():
             # print(f'SUBSET: {subset}')
             m = roll_up_to_named_subset(self.oi, subset, term_curies, predicates=[IS_A, PART_OF])
             n = 0

--- a/tests/test_utilities/test_taxon_constraints.py
+++ b/tests/test_utilities/test_taxon_constraints.py
@@ -270,7 +270,7 @@ class TestTaxonConstraintsUtils(unittest.TestCase):
 
     def test_all(self):
         oi = self.oi
-        term_curies = [t for t in oi.all_entity_curies() if t.startswith("GO:")]
+        term_curies = [t for t in oi.entities() if t.startswith("GO:")]
         for t in term_curies:
             st = get_term_with_taxon_constraints(oi, t)
             logging.info(yaml_dumper.dumps(st))


### PR DESCRIPTION
* Lookup methods no longer start with `get_`, this is reserved for methods that do some kind of computation
* Methods no longer called `X_by_curie`
* General naming convention is to name the method by the statement type queried/returned:
   - labels
   - aliases
   - relationships
   - ancestors
   - paths
   - subsets
   - ontologies
   - entities
   - etc
   - 
* These generally follow a filter pattern and can be parameterized by various properties such as the subject

Note: this will be backwards compatible because the old
method names are retained as no-docstring deprecated methods
that forward to the new method name.

Fixes #109

See also #145
