### PR TITLE
Revert "Get 'scope' information from the command."

### DIFF
--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -521,7 +521,7 @@ class ProntoImplementation(
                     syn.description = patch.new_value
         elif isinstance(patch, kgcl.NewSynonym):
             t = self._entity(patch.about_node, strict=True)
-            # Get scope from patch.qualifier 
+            # Get scope from patch.qualifier
             # rather than forcing all synonyms to be related.
             scope = str(patch.qualifier.value).upper() if patch.qualifier else "RELATED"
             t.add_synonym(description=patch.new_value, scope=scope)

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -521,7 +521,10 @@ class ProntoImplementation(
                     syn.description = patch.new_value
         elif isinstance(patch, kgcl.NewSynonym):
             t = self._entity(patch.about_node, strict=True)
-            t.add_synonym(description=patch.new_value, scope="RELATED")
+            # Get scope from patch.qualifier 
+            # rather than forcing all synonyms to be related.
+            scope = str(patch.qualifier.value).upper() if patch.qualifier else "RELATED"
+            t.add_synonym(description=patch.new_value, scope=scope)
 
         else:
             raise NotImplementedError

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -520,8 +520,8 @@ class ProntoImplementation(
                 if syn.description == patch.old_value:
                     syn.description = patch.new_value
         elif isinstance(patch, kgcl.NewSynonym):
-            scope = str(patch.qualifier.value).upper() if patch.qualifier else "RELATED"
-            t.add_synonym(description=patch.new_value, scope=scope)
+            t = self._entity(patch.about_node, strict=True)
+            t.add_synonym(description=patch.new_value, scope="RELATED")
 
         else:
             raise NotImplementedError

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ description = Run linters.
 [testenv:flake8]
 skip_install = true
 deps =
-    flake8<5.0.0
+    flake8
     flake8-bandit
     flake8-black
     flake8-bugbear

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ description = Run linters.
 [testenv:flake8]
 skip_install = true
 deps =
-    flake8
+    flake8<5.0.0
     flake8-bandit
     flake8-black
     flake8-bugbear


### PR DESCRIPTION
Reverts INCATools/ontology-access-kit#215

Previous iteration #209 assumed all synonyms to be `RELATED`. Now this can be derived from the command using the following code:
```
scope = str(patch.qualifier.value).upper() if patch.qualifier else "RELATED"
t.add_synonym(description=patch.new_value, scope=scope)
```