### PR TITLE
Ignore B024 for now

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,8 @@ ignore =
     S603 # subprocess call - check for execution of untrusted input.
     S607 # Starting a process with a partial executable path ["open" in both cases]
     S608 # Possible SQL injection vector through string-based query construction.
+    B024 # StreamingWriter is an abstract base class, but it has no abstract methods. 
+         # Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
 max-line-length = 120
 max-complexity = 13
 import-order-style = pycharm


### PR DESCRIPTION
```
B024 # StreamingWriter is an abstract base class, but it has no abstract methods. 
          # Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
```
Ignoring this for now.