### PR TITLE
JSON Writer now outputs nodes in JSON format

### DIFF
--- a/src/oaklib/io/streaming_json_writer.py
+++ b/src/oaklib/io/streaming_json_writer.py
@@ -7,6 +7,7 @@ from linkml_runtime.dumpers import json_dumper
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
 from oaklib.io.streaming_writer import StreamingWriter
+from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.types import CURIE
 
 
@@ -30,7 +31,11 @@ class StreamingJsonWriter(StreamingWriter):
         if isinstance(obj, dict):
             self.file.write(json.dumps(obj))
         else:
-            self.file.write(json_dumper.dumps(obj))
+            oi = self.ontology_interface
+            if isinstance(oi, OboGraphInterface):
+                node = oi.node(obj, include_metadata=True)
+                self.line(json_dumper.dumps(node))
+            # self.file.write(json_dumper.dumps(obj))
         self.file.write("\n")
 
     def emit_curie(self, curie: CURIE, label=None):

--- a/src/oaklib/io/streaming_json_writer.py
+++ b/src/oaklib/io/streaming_json_writer.py
@@ -6,8 +6,8 @@ from linkml_runtime import CurieNamespace
 from linkml_runtime.dumpers import json_dumper
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
-from oaklib.io.streaming_writer import StreamingWriter
 from oaklib.interfaces.obograph_interface import OboGraphInterface
+from oaklib.io.streaming_writer import StreamingWriter
 from oaklib.types import CURIE
 
 


### PR DESCRIPTION
Fixes #213 

Command:
```
runoak -i hp.obo descendants HP:0000005 -p i,p -O json
```
now yields a result and does not error out as mentioned in #213