### PR TITLE
Allow BioPortal tests to run in GitHub Actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,6 +84,8 @@ jobs:
       #----------------------------------------------
       - name: Run tests
         run: poetry run python -m unittest discover
+        env:
+          BIOPORTAL_API_KEY: ${{ secrets.BIOPORTAL_API_KEY }}
 
       #----------------------------------------------
       #              coverage report   
@@ -93,6 +95,8 @@ jobs:
           poetry run coverage run -m unittest discover
           poetry run coverage xml
           poetry run coverage report -m
+        env:
+          BIOPORTAL_API_KEY: ${{ secrets.BIOPORTAL_API_KEY }}
 
       #----------------------------------------------
       #           upload coverage results

--- a/src/oaklib/implementations/ontoportal/ontoportal_implementation_base.py
+++ b/src/oaklib/implementations/ontoportal/ontoportal_implementation_base.py
@@ -41,6 +41,7 @@ class OntoPortalImplementationBase(
 ):
 
     ontoportal_client_class: ClassVar[type[PreconfiguredOntoPortalClient]] = None
+    api_key: Union[str, None] = None
 
     label_cache: Dict[CURIE, str] = field(default_factory=lambda: {})
     ontology_cache: Dict[URI, str] = field(default_factory=lambda: {})
@@ -52,8 +53,9 @@ class OntoPortalImplementationBase(
                 self.focus_ontology = self.resource.slug
         if not self.ontoportal_client_class:
             raise NotImplementedError("ontoportal_client_class not specified")
-        api_key = get_apikey_value(self.ontoportal_client_class.name)
-        self.client = self.ontoportal_client_class(api_key=api_key)
+        if not self.api_key:
+            self.api_key = get_apikey_value(self.ontoportal_client_class.name)
+        self.client = self.ontoportal_client_class(api_key=self.api_key)
 
     def prefix_map(self) -> PREFIX_MAP:
         context = load_multi_context(["obo", "bioportal"])

--- a/tests/test_implementations/test_bioportal.py
+++ b/tests/test_implementations/test_bioportal.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import os
 import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
@@ -18,11 +19,16 @@ class TestBioportal(unittest.TestCase):
 
     def setUp(self) -> None:
         cls = BioportalImplementation
+        api_key = None
         try:
-            get_apikey_value(cls.ontoportal_client_class.name)
+            api_key = get_apikey_value(cls.ontoportal_client_class.name)
         except ValueError:
+            envar_key = "BIOPORTAL_API_KEY"
+            if envar_key in os.environ:
+                api_key = os.environ[envar_key]
+        if api_key is None:
             self.skipTest("Skipping bioportal tests, no API key set")
-        impl = cls()
+        impl = cls(api_key=api_key)
         self.impl = impl
 
     def test_text_annotator(self):


### PR DESCRIPTION
These changes allow passing an API key to `OntoPortalImplementationBase` classes. Then in `test_bioportal.py`, first the standard `get_apikey_value` function is called to get a key (this mainly supports running tests locally). If no API key is found that way, it will check for an environment variable named `BIOPORTAL_API_KEY` (this will be provided via repo secret when running via GitHub Actions). If neither method produces an API key the tests will be skipped.