### PR TITLE
Add a check of ENV variables to the apikey_manager.get_apikey_value method  fixes #262

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,7 @@ http://www.projecthalo.com/aura#Tentacle ! Tentacle
 CEPH:0000256 ! tentacle
 ...
 ```
-
-Alternatively, adding "BIOPORTAL_API_KEY" to your environment variables will also work.
-
+Alternatively, you can add "BIOPORTAL_API_KEY" to your environment variables.
 
 Searching over more limited set of ontologies in Ubergraph:
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ cd ontology-access-kit
 poetry install
 ```
 
+Testing:
+```shell
+poetry run pytest
+```
+
+Code quality:
+```shell   
+poetry run tox
+```
+
 ### Potential Refactoring
 Currently all implementations exist in this repo/module, this results in a lot of dependencies
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ CEPH:0000256 ! tentacle
 ...
 ```
 
+Alternatively, adding "BIOPORTAL_API_KEY" to your environment variables will also work.
+
+
 Searching over more limited set of ontologies in Ubergraph:
 
 ```bash
@@ -239,13 +242,14 @@ poetry install
 
 Testing:
 ```shell
-poetry run pytest
+poetry run python -m unittest discover
 ```
 
 Code quality:
 ```shell   
 poetry run tox
 ```
+
 
 ### Potential Refactoring
 Currently all implementations exist in this repo/module, this results in a lot of dependencies

--- a/README.md
+++ b/README.md
@@ -238,12 +238,12 @@ cd ontology-access-kit
 poetry install
 ```
 
-Testing:
+Testing locally:
 ```shell
 poetry run python -m unittest discover
 ```
 
-Code quality:
+Code quality locally:
 ```shell   
 poetry run tox
 ```

--- a/src/oaklib/utilities/apikey_manager.py
+++ b/src/oaklib/utilities/apikey_manager.py
@@ -5,6 +5,7 @@ See `<https://github.com/ActiveState/appdirs>`_
 """
 
 import logging
+import os
 from pathlib import Path
 
 from appdirs import user_config_dir
@@ -12,6 +13,7 @@ from appdirs import user_config_dir
 from oaklib.datamodels.vocabulary import APP_NAME
 
 APIKEY_SUFFIX = "apikey.txt"
+BIOPORTAL_API_KEY = "BIOPORTAL_API_KEY"
 
 
 def get_apikey_path(system: str) -> Path:
@@ -33,6 +35,9 @@ def get_apikey_value(system: str) -> str:
     :param system: e.g "bioportal"
     :return:
     """
+    if BIOPORTAL_API_KEY in os.environ:
+        api_key = os.environ[BIOPORTAL_API_KEY]
+        return api_key
     path = get_apikey_path(system)
     if not path.exists():
         raise ValueError(f"No API key found in: {path}")

--- a/src/oaklib/utilities/apikey_manager.py
+++ b/src/oaklib/utilities/apikey_manager.py
@@ -38,11 +38,12 @@ def get_apikey_value(system: str) -> str:
     if BIOPORTAL_API_KEY in os.environ:
         api_key = os.environ[BIOPORTAL_API_KEY]
         return api_key
-    path = get_apikey_path(system)
-    if not path.exists():
-        raise ValueError(f"No API key found in: {path}")
-    with open(path) as stream:
-        return stream.readlines()[0].strip()
+    else:
+        path = get_apikey_path(system)
+        if not path.exists():
+            raise ValueError(f"No API key found in: {path}")
+        with open(path) as stream:
+            return stream.readlines()[0].strip()
 
 
 def set_apikey_value(system: str, val: str) -> None:


### PR DESCRIPTION
Using oak in schema_automator to access bioportal with BIOPORTAL_API_KEY set in the ENV.  