### PR TITLE
Combine coverage analysis

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,19 +80,12 @@ jobs:
         run: poetry install --no-interaction --extras gilda
 
       #----------------------------------------------
-      #              run test suite   
-      #----------------------------------------------
-      - name: Run tests
-        run: poetry run python -m unittest discover
-        env:
-          BIOPORTAL_API_KEY: ${{ secrets.BIOPORTAL_API_KEY }}
-
-      #----------------------------------------------
-      #              coverage report   
+      #        run test suite + coverage report
       #----------------------------------------------
       - name: Generate coverage results
         run: |
-          poetry run coverage run -m unittest discover
+          poetry run coverage run -p -m pytest tests/
+          poetry run coverage combine
           poetry run coverage xml
           poetry run coverage report -m
         env:

--- a/tests/test_implementations/test_bioportal.py
+++ b/tests/test_implementations/test_bioportal.py
@@ -24,7 +24,7 @@ class TestBioportal(unittest.TestCase):
             api_key = get_apikey_value(cls.ontoportal_client_class.name)
         except ValueError:
             self.skipTest("no API key for this source {}".format(cls.ontoportal_client_class.name))
-        if api_key is None:
+        if not api_key:
             self.skipTest("Skipping bioportal tests, no API key set")
         impl = cls(api_key=api_key)
         self.impl = impl


### PR DESCRIPTION
The tests were running twice, which is wasteful of compute resources and slow. This PR combines them together. It also switches from unittest to pytest, which makes it much easier to look through the logs