### PR TITLE
Delay construction of ClassResolver instance

### DIFF
--- a/src/oaklib/implementations/__init__.py
+++ b/src/oaklib/implementations/__init__.py
@@ -1,4 +1,5 @@
 from functools import cache
+
 from class_resolver import ClassResolver
 
 from oaklib.implementations.funowl.funowl_implementation import FunOwlImplementation
@@ -59,6 +60,7 @@ __all__ = [
     "FunOwlImplementation",
     "GildaImplementation",
 ]
+
 
 @cache
 def get_implementation_resolver() -> ClassResolver[OntologyInterface]:

--- a/src/oaklib/implementations/__init__.py
+++ b/src/oaklib/implementations/__init__.py
@@ -1,3 +1,4 @@
+from functools import cache
 from class_resolver import ClassResolver
 
 from oaklib.implementations.funowl.funowl_implementation import FunOwlImplementation
@@ -39,7 +40,7 @@ from oaklib.implementations.wikidata.wikidata_implementation import (
 from oaklib.interfaces import OntologyInterface
 
 __all__ = [
-    "implementation_resolver",
+    "get_implementation_resolver",
     # Concrete classes
     "AgroPortalImplementation",
     "BioPortalImplementation",
@@ -59,31 +60,35 @@ __all__ = [
     "GildaImplementation",
 ]
 
-implementation_resolver: ClassResolver[OntologyInterface] = ClassResolver.from_subclasses(
-    OntologyInterface,
-    suffix="Implementation",
-    skip={
-        OntoPortalImplementationBase,
-        BaseOlsImplementation,
-    },
-)
-implementation_resolver.synonyms.update(
-    {
-        "obolibrary": ProntoImplementation,
-        "prontolib": ProntoImplementation,
-        "simpleobo": SimpleOboImplementation,
-        "sqlite": SqlImplementation,
-        "rdflib": SparqlImplementation,
-    }
-)
+@cache
+def get_implementation_resolver() -> ClassResolver[OntologyInterface]:
+    implementation_resolver: ClassResolver[OntologyInterface] = ClassResolver.from_subclasses(
+        OntologyInterface,
+        suffix="Implementation",
+        skip={
+            OntoPortalImplementationBase,
+            BaseOlsImplementation,
+        },
+    )
+    implementation_resolver.synonyms.update(
+        {
+            "obolibrary": ProntoImplementation,
+            "prontolib": ProntoImplementation,
+            "simpleobo": SimpleOboImplementation,
+            "sqlite": SqlImplementation,
+            "rdflib": SparqlImplementation,
+        }
+    )
 
-# Plugins which want to register an implementation should use
-# the entrypoint group "oaklib.plugins". The name of the entry
-# point will be used as a possible match against the input scheme
-# prefix. The value of the entry point should be an implementation
-# class.
-#
-# See also:
-# https://packaging.python.org/en/latest/specifications/entry-points/
-# https://class-resolver.readthedocs.io/en/latest/api/class_resolver.ClassResolver.html#class_resolver.ClassResolver.register_entrypoint
-implementation_resolver.register_entrypoint("oaklib.plugins")
+    # Plugins which want to register an implementation should use
+    # the entrypoint group "oaklib.plugins". The name of the entry
+    # point will be used as a possible match against the input scheme
+    # prefix. The value of the entry point should be an implementation
+    # class.
+    #
+    # See also:
+    # https://packaging.python.org/en/latest/specifications/entry-points/
+    # https://class-resolver.readthedocs.io/en/latest/api/class_resolver.ClassResolver.html#class_resolver.ClassResolver.register_entrypoint
+    implementation_resolver.register_entrypoint("oaklib.plugins")
+
+    return implementation_resolver

--- a/src/oaklib/resource.py
+++ b/src/oaklib/resource.py
@@ -66,7 +66,8 @@ class OntologyResource:
         self, implementation: HintOrType["OntologyInterface"] = None, **kwargs
     ) -> "OntologyInterface":
         """Materialize the ontology resource with the given implementation."""
-        from .implementations import SqlImplementation, implementation_resolver
+        from .implementations import SqlImplementation, get_implementation_resolver
 
+        implementation_resolver = get_implementation_resolver()
         cls = implementation_resolver.lookup(implementation, default=SqlImplementation)
         return implementation_resolver.make(cls, kwargs, resource=self)

--- a/src/oaklib/selector.py
+++ b/src/oaklib/selector.py
@@ -92,9 +92,9 @@ def get_implementation_class_from_scheme(scheme: str) -> Type[OntologyInterface]
         raise NotImplementedError("Web requests not implemented yet")
     else:
         # return SCHEME_DICT[scheme]
-        from oaklib.implementations import implementation_resolver
+        from oaklib.implementations import get_implementation_resolver
 
-        return implementation_resolver.lookup(scheme)
+        return get_implementation_resolver().lookup(scheme)
 
 
 def get_resource_imp_class_from_suffix_descriptor(


### PR DESCRIPTION
These changes move the construction of the `ClassResolver` instance for implementation classes into a function. This allows the loading of entry point classes to be delayed until one is actually needed. And that should make it a lot harder to get into the circular import / partially initialized module trap. The function is memoized so only one `ClassResolver` instance is ever created.

Fixes #280 