### PR TITLE
Bugfix: basic_ontology_interface

### DIFF
--- a/src/oaklib/interfaces/basic_ontology_interface.py
+++ b/src/oaklib/interfaces/basic_ontology_interface.py
@@ -517,7 +517,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         :param isa_only: restrict hierarchical parents to isa only
         :return:
         """
-        return self.outgoing_relationship_map(curie)[IS_A]
+        return self.outgoing_relationship_map(curie).get(IS_A, [])
 
     def outgoing_relationship_map(self, curie: CURIE) -> RELATIONSHIP_MAP:
         """


### PR DESCRIPTION
Updates
```
Bugfix: basic_ontology_interface
- Bugfix: hierararchical_parents(): If no parents found, now returns an empty list rather than resulting in `KeyError`.
```