### PR TITLE
Use the gzipped file from the semsql s3 cache.

### DIFF
--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -241,8 +241,9 @@ class SqlImplementation(
                 # Note: this can take some time
                 prefix = locator[len("obo:") :]
                 # Option 1 uses direct URL construction:
-                url = f"https://s3.amazonaws.com/bbop-sqlite/{prefix}.db"
-                db_path = OAKLIB_MODULE.ensure(url=url)
+                url = f"https://s3.amazonaws.com/bbop-sqlite/{prefix}.db.gz"
+                logging.info(f"Ensuring gunzipped for {url}")
+                db_path = OAKLIB_MODULE.ensure_gunzip(url=url, autoclean=False)
                 # Option 2 uses botocore to interface with the S3 API directly:
                 # db_path = OAKLIB_MODULE.ensure_from_s3(s3_bucket="bbop-sqlite", s3_key=f"{prefix}.db")
                 locator = f"sqlite:///{db_path}"


### PR DESCRIPTION
This will ensure faster downloads for large databases;
it also means we can start phasing out the direct .db deposits
and save s3 space.

Utilizes https://github.com/cthoyt/pystow/issues/45

Note that the gzipped file is not cached in ~/.data - but
the gunzipped file is. It is necessary for the user
to periodically clean this cache.
See https://github.com/cthoyt/pystow/issues/54
