### PR TITLE
Added `qualifier` attr to Synonymizer

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -110,6 +110,7 @@ from oaklib.utilities.associations.association_differ import AssociationDiffer
 from oaklib.utilities.iterator_utils import chunk
 from oaklib.utilities.kgcl_utilities import generate_change_id
 from oaklib.utilities.lexical.lexical_indexer import (
+    DEFAULT_QUALIFIER,
     add_labels_from_uris,
     apply_synonymizer,
     create_lexical_index,
@@ -3891,18 +3892,20 @@ def synonymize(terms, rules_file, apply_patch, patch, output):
                     # matches.extend([x for x in aliases if re.search(eval(rule.match), x) is not None])
                     for alias in aliases:
                         if alias:
-                            synonymized, new_alias = apply_synonymizer(alias, syn_rules)
+                            synonymized, new_alias, qualifier = apply_synonymizer(alias, syn_rules)
                             if synonymized:
                                 matches.append(new_alias)
 
                 if len(matches) > 0:
+                    if qualifier is None or qualifier == "":
+                        qualifier = DEFAULT_QUALIFIER
                     terms_to_synonymize[curie] = matches
                     change = kgcl.NewSynonym(
                         id="kgcl_change_id_" + str(len(terms_to_synonymize)),
                         about_node=curie,
                         old_value=alias,
                         new_value=new_alias,
-                        qualifier="exact",
+                        qualifier=qualifier,
                     )
                     change_list.append(change)
                     if patch:

--- a/src/oaklib/datamodels/mapping_rules_datamodel.py
+++ b/src/oaklib/datamodels/mapping_rules_datamodel.py
@@ -1,5 +1,5 @@
 # Auto generated from mapping_rules_datamodel.yaml by pythongen.py version: 0.9.0
-# Generation date: 2022-09-21T23:32:26
+# Generation date: 2022-10-18T08:25:52
 # Schema: mapping-rules
 #
 # id: https://w3id.org/linkml/mapping_rules_datamodel
@@ -256,6 +256,7 @@ class Synonymizer(YAMLRoot):
     match: Optional[str] = None
     match_scope: Optional[str] = None
     replacement: Optional[str] = None
+    qualifier: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self.the_rule is not None and not isinstance(self.the_rule, str):
@@ -269,6 +270,9 @@ class Synonymizer(YAMLRoot):
 
         if self.replacement is not None and not isinstance(self.replacement, str):
             self.replacement = str(self.replacement)
+
+        if self.qualifier is not None and not isinstance(self.qualifier, str):
+            self.qualifier = str(self.qualifier)
 
         super().__post_init__(**kwargs)
 
@@ -694,6 +698,15 @@ slots.synonymizer__replacement = Slot(
     name="synonymizer__replacement",
     curie=MRULES.curie("replacement"),
     model_uri=MRULES.synonymizer__replacement,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.synonymizer__qualifier = Slot(
+    uri=MRULES.qualifier,
+    name="synonymizer__qualifier",
+    curie=MRULES.curie("qualifier"),
+    model_uri=MRULES.synonymizer__qualifier,
     domain=None,
     range=Optional[str],
 )

--- a/src/oaklib/datamodels/mapping_rules_datamodel.yaml
+++ b/src/oaklib/datamodels/mapping_rules_datamodel.yaml
@@ -109,4 +109,7 @@ classes:
     replacement:
       description: Reg-ex rule to replace substrings in labels
       range: string
+    qualifier:
+      description: Type of match for the new synonym generated.
+      range: string
     

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -46,6 +46,7 @@ from oaklib.types import PRED_CURIE
 from oaklib.utilities.basic_utils import pairs_as_dict
 
 LEXICAL_INDEX_FORMATS = ["yaml", "json"]
+DEFAULT_QUALIFIER = "exact"
 
 
 def add_labels_from_uris(oi: BasicOntologyInterface):
@@ -124,7 +125,7 @@ def create_lexical_index(
                     term2 = term
                     for tr in pipeline.transformations:
                         if tr.type.code == TransformationType.Synonymization:
-                            synonymized, term2 = apply_transformation(term2, tr)
+                            synonymized, term2, _ = apply_transformation(term2, tr)
                         else:
                             term2 = apply_transformation(term2, tr)
 
@@ -406,14 +407,18 @@ def apply_transformation(term: str, transformation: LexicalTransformation) -> st
         )
 
 
-def apply_synonymizer(term: str, rules: List[Synonymizer]) -> str:
+def apply_synonymizer(term: str, rules: List[Synonymizer]) -> Tuple:
     tmp_term = term
     for rule in rules:
         term = re.sub(eval(rule.match), rule.replacement, term)
+        if rule.qualifier:
+            qualifier = rule.qualifier
+        else:
+            qualifier = DEFAULT_QUALIFIER
     if tmp_term == term:
-        return False, term.rstrip()
+        return False, term.rstrip(), qualifier
     else:
-        return True, term.rstrip()
+        return True, term.rstrip(), qualifier
 
 
 def save_mapping_rules(mapping_rules: MappingRuleCollection, path: str):


### PR DESCRIPTION
Added `qualifier` attribute to Synonymizer to indicate if the new synonymized label is an `exact`, `broad`, `narrow` or `related` synonym.