### PR TITLE
Adding a valueset toolkit, performs expansion.

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -1112,7 +1112,9 @@ def term_metadata(terms, predicates, reification: bool, output_type: str, output
             else:
                 metadata = impl.entity_metadata_map(curie)
                 if predicates:
-                    metadata = {p: metadata.get(p, None) for p in _process_predicates_arg(predicates)}
+                    metadata = {
+                        p: metadata.get(p, None) for p in _process_predicates_arg(predicates)
+                    }
                 writer.emit(metadata)
     else:
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")

--- a/src/oaklib/conf/value-set-expander.conf.yaml
+++ b/src/oaklib/conf/value-set-expander.conf.yaml
@@ -1,0 +1,6 @@
+resource_resolvers:
+  bioregistry:wikidata:
+    shorthand: "wikidata:"
+prefix_resolvers:
+  obo:
+    shorthand_prefix: "sqlite:obo"

--- a/src/oaklib/datamodels/value_set_configuration.py
+++ b/src/oaklib/datamodels/value_set_configuration.py
@@ -1,0 +1,273 @@
+# Auto generated from value_set_configuration.yaml by pythongen.py version: 0.9.0
+# Generation date: 2022-11-27T17:19:16
+# Schema: value-set-configuration
+#
+# id: https://w3id.org/linkml/value-set-configuration
+# description: A datamodel for configuring value sets and value set expabsions
+# license: https://creativecommons.org/publicdomain/zero/1.0/
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, List, Optional, Union
+
+from jsonasobj2 import JsonObj, as_dict
+from linkml_runtime.linkml_model.meta import (
+    EnumDefinition,
+    PermissibleValue,
+    PvFormulaOptions,
+)
+from linkml_runtime.linkml_model.types import String, Uri
+from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.utils.dataclass_extensions_376 import (
+    dataclasses_init_fn_with_kwargs,
+)
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from linkml_runtime.utils.formatutils import camelcase, sfx, underscore
+from linkml_runtime.utils.metamodelcore import URI, bnode, empty_dict, empty_list
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_float,
+    extended_int,
+    extended_str,
+)
+from rdflib import Namespace, URIRef
+
+metamodel_version = "1.7.0"
+version = None
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+LINKML = CurieNamespace("linkml", "https://w3id.org/linkml/")
+OA = CurieNamespace("oa", "http://www.w3.org/ns/oa#")
+SCHEMA = CurieNamespace("schema", "http://schema.org/")
+SH = CurieNamespace("sh", "https://w3id.org/shacl/")
+VSCONF = CurieNamespace("vsconf", "https://w3id.org/linkml/value-set-configuration/")
+DEFAULT_ = VSCONF
+
+
+# Types
+
+# Class references
+class ResolverName(extended_str):
+    pass
+
+
+class NamedResolverName(ResolverName):
+    pass
+
+
+@dataclass
+class ValueSetConfiguration(YAMLRoot):
+    """
+    configuration for value sets
+    """
+
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VSCONF.ValueSetConfiguration
+    class_class_curie: ClassVar[str] = "vsconf:ValueSetConfiguration"
+    class_name: ClassVar[str] = "ValueSetConfiguration"
+    class_model_uri: ClassVar[URIRef] = VSCONF.ValueSetConfiguration
+
+    default_resolver: Optional[Union[dict, "Resolver"]] = None
+    resource_resolvers: Optional[
+        Union[
+            Dict[Union[str, ResolverName], Union[dict, "Resolver"]], List[Union[dict, "Resolver"]]
+        ]
+    ] = empty_dict()
+    prefix_resolvers: Optional[
+        Union[
+            Dict[Union[str, ResolverName], Union[dict, "Resolver"]], List[Union[dict, "Resolver"]]
+        ]
+    ] = empty_dict()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.default_resolver is not None and not isinstance(self.default_resolver, Resolver):
+            self.default_resolver = Resolver(**as_dict(self.default_resolver))
+
+        self._normalize_inlined_as_dict(
+            slot_name="resource_resolvers", slot_type=Resolver, key_name="name", keyed=True
+        )
+
+        self._normalize_inlined_as_dict(
+            slot_name="prefix_resolvers", slot_type=Resolver, key_name="name", keyed=True
+        )
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Resolver(YAMLRoot):
+    """
+    A mechanism for resolving using an ontology
+    """
+
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VSCONF.Resolver
+    class_class_curie: ClassVar[str] = "vsconf:Resolver"
+    class_name: ClassVar[str] = "Resolver"
+    class_model_uri: ClassVar[URIRef] = VSCONF.Resolver
+
+    name: Union[str, ResolverName] = None
+    shorthand_prefix: Optional[str] = None
+    shorthand: Optional[str] = None
+    method: Optional[Union[str, "ResolverMethod"]] = None
+    url: Optional[Union[str, URI]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.name):
+            self.MissingRequiredField("name")
+        if not isinstance(self.name, ResolverName):
+            self.name = ResolverName(self.name)
+
+        if self.shorthand_prefix is not None and not isinstance(self.shorthand_prefix, str):
+            self.shorthand_prefix = str(self.shorthand_prefix)
+
+        if self.shorthand is not None and not isinstance(self.shorthand, str):
+            self.shorthand = str(self.shorthand)
+
+        if self.method is not None and not isinstance(self.method, ResolverMethod):
+            self.method = ResolverMethod(self.method)
+
+        if self.url is not None and not isinstance(self.url, URI):
+            self.url = URI(self.url)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class NamedResolver(Resolver):
+    """
+    A resolver that is associated with a named resource or prefix
+    """
+
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VSCONF.NamedResolver
+    class_class_curie: ClassVar[str] = "vsconf:NamedResolver"
+    class_name: ClassVar[str] = "NamedResolver"
+    class_model_uri: ClassVar[URIRef] = VSCONF.NamedResolver
+
+    name: Union[str, NamedResolverName] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.name):
+            self.MissingRequiredField("name")
+        if not isinstance(self.name, NamedResolverName):
+            self.name = NamedResolverName(self.name)
+
+        super().__post_init__(**kwargs)
+
+
+# Enumerations
+class ResolverMethod(EnumDefinitionImpl):
+
+    SemanticSQL = PermissibleValue(text="SemanticSQL")
+    OLS = PermissibleValue(text="OLS")
+    BioPortal = PermissibleValue(text="BioPortal")
+    OntoBee = PermissibleValue(text="OntoBee")
+    Ubergraph = PermissibleValue(text="Ubergraph")
+    TCCM = PermissibleValue(text="TCCM")
+    SPARQL = PermissibleValue(text="SPARQL")
+    LOV = PermissibleValue(text="LOV")
+    Pronto = PermissibleValue(text="Pronto")
+    Uniprot = PermissibleValue(text="Uniprot")
+
+    _defn = EnumDefinition(
+        name="ResolverMethod",
+    )
+
+
+# Slots
+class slots:
+    pass
+
+
+slots.valueSetConfiguration__default_resolver = Slot(
+    uri=VSCONF.default_resolver,
+    name="valueSetConfiguration__default_resolver",
+    curie=VSCONF.curie("default_resolver"),
+    model_uri=VSCONF.valueSetConfiguration__default_resolver,
+    domain=None,
+    range=Optional[Union[dict, Resolver]],
+)
+
+slots.valueSetConfiguration__resource_resolvers = Slot(
+    uri=VSCONF.resource_resolvers,
+    name="valueSetConfiguration__resource_resolvers",
+    curie=VSCONF.curie("resource_resolvers"),
+    model_uri=VSCONF.valueSetConfiguration__resource_resolvers,
+    domain=None,
+    range=Optional[
+        Union[Dict[Union[str, ResolverName], Union[dict, Resolver]], List[Union[dict, Resolver]]]
+    ],
+)
+
+slots.valueSetConfiguration__prefix_resolvers = Slot(
+    uri=VSCONF.prefix_resolvers,
+    name="valueSetConfiguration__prefix_resolvers",
+    curie=VSCONF.curie("prefix_resolvers"),
+    model_uri=VSCONF.valueSetConfiguration__prefix_resolvers,
+    domain=None,
+    range=Optional[
+        Union[Dict[Union[str, ResolverName], Union[dict, Resolver]], List[Union[dict, Resolver]]]
+    ],
+)
+
+slots.resolver__name = Slot(
+    uri=VSCONF.name,
+    name="resolver__name",
+    curie=VSCONF.curie("name"),
+    model_uri=VSCONF.resolver__name,
+    domain=None,
+    range=URIRef,
+)
+
+slots.resolver__shorthand_prefix = Slot(
+    uri=VSCONF.shorthand_prefix,
+    name="resolver__shorthand_prefix",
+    curie=VSCONF.curie("shorthand_prefix"),
+    model_uri=VSCONF.resolver__shorthand_prefix,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.resolver__shorthand = Slot(
+    uri=VSCONF.shorthand,
+    name="resolver__shorthand",
+    curie=VSCONF.curie("shorthand"),
+    model_uri=VSCONF.resolver__shorthand,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.resolver__method = Slot(
+    uri=VSCONF.method,
+    name="resolver__method",
+    curie=VSCONF.curie("method"),
+    model_uri=VSCONF.resolver__method,
+    domain=None,
+    range=Optional[Union[str, "ResolverMethod"]],
+)
+
+slots.resolver__url = Slot(
+    uri=VSCONF.url,
+    name="resolver__url",
+    curie=VSCONF.curie("url"),
+    model_uri=VSCONF.resolver__url,
+    domain=None,
+    range=Optional[Union[str, URI]],
+)
+
+slots.namedResolver__name = Slot(
+    uri=VSCONF.name,
+    name="namedResolver__name",
+    curie=VSCONF.curie("name"),
+    model_uri=VSCONF.namedResolver__name,
+    domain=None,
+    range=URIRef,
+)

--- a/src/oaklib/datamodels/value_set_configuration.yaml
+++ b/src/oaklib/datamodels/value_set_configuration.yaml
@@ -1,0 +1,98 @@
+id: https://w3id.org/linkml/value-set-configuration
+title: Value Set Configuration
+name: value-set-configuration
+description: >-
+  A datamodel for configuring value sets and value set expabsions
+license: https://creativecommons.org/publicdomain/zero/1.0/
+
+prefixes:
+  vsconf: https://w3id.org/linkml/value-set-configuration/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+  sh: https://w3id.org/shacl/
+  oa: http://www.w3.org/ns/oa#
+
+default_prefix: vsconf
+default_range: string
+
+imports:
+  - linkml:types
+
+
+#==================================
+# Classes                         #
+#==================================
+classes:
+  ValueSetConfiguration:
+    description: configuration for value sets
+    attributes:
+      default_resolver:
+        range: Resolver
+        inlined: true
+      resource_resolvers:
+        range: Resolver
+        multivalued: true
+        inlined: true
+      prefix_resolvers:
+        range: Resolver
+        multivalued: true
+        inlined: true
+
+  Resolver:
+    description: A mechanism for resolving using an ontology
+    attributes:
+      name:
+        range: string
+        key: true
+        description: The name of the resource or prefix
+      shorthand_prefix:
+      shorthand:
+        description: A shorthand for the resolver, using the OAK shorthand syntax
+      method:
+        range: ResolverMethod
+        description: >-
+          The method used to resolve the value set.
+      url:
+        range: uri
+
+  NamedResolver:
+    description: A resolver that is associated with a named resource or prefix
+    is_a: Resolver
+    attributes:
+      name:
+        range: string
+        key: true
+        description: The name of the resource or prefix
+
+enums:
+  ResolverMethod:
+    permissible_values:
+      SemanticSQL:
+        annotations:
+          prefix: sqlite:obo
+      OLS:
+        annotations:
+          prefix: ols
+      BioPortal:
+        annotations:
+          prefix: bioportal
+      OntoBee:
+        annotations:
+          prefix: ontobee
+      Ubergraph:
+        annotations:
+          prefix: ubergraph
+      TCCM:
+      SPARQL:
+      LOV:
+        annotations:
+          prefix: lov
+      Pronto:
+        annotations:
+          prefix: pronto
+      Uniprot:
+        annotations:
+          prefix: uniprot
+
+
+

--- a/src/oaklib/implementations/obograph/obograph_implementation.py
+++ b/src/oaklib/implementations/obograph/obograph_implementation.py
@@ -40,6 +40,7 @@ from oaklib.interfaces.basic_ontology_interface import (
     RELATIONSHIP_MAP,
 )
 from oaklib.interfaces.differ_interface import DifferInterface
+from oaklib.interfaces.dumper_interface import DumperInterface
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
 from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.interfaces.patcher_interface import PatcherInterface
@@ -68,6 +69,7 @@ class OboGraphImplementation(
     SearchInterface,
     MappingProviderInterface,
     PatcherInterface,
+    DumperInterface,
 ):
     """
     OBO Graphs JSON backed implementation.
@@ -377,13 +379,13 @@ class OboGraphImplementation(
 
     def dump(self, path: str = None, syntax: str = "json"):
         logging.info(f"Dumping graph to {path} syntax: {syntax}")
-        if syntax in RDFLIB_FORMAT_MAP:
-            converter = OboGraphToRdfOwlConverter(curie_converter=self.converter)
-            g = converter.convert(self.obograph_document)
-            g.serialize(path, format=RDFLIB_FORMAT_MAP[syntax])
+        if syntax == "json" or syntax == "obojson":
+            if path is None:
+                print(json_dumper.dumps(self.obograph_document))
+            else:
+                json_dumper.dump(self.obograph_document, to_file=str(path))
         else:
-            logging.info("Using JSON dumper")
-            json_dumper.dump(self.obograph_document, to_file=str(path))
+            super().dump(path, syntax)
 
     def save(
         self,

--- a/src/oaklib/implementations/obograph/obograph_implementation.py
+++ b/src/oaklib/implementations/obograph/obograph_implementation.py
@@ -9,10 +9,7 @@ from kgcl_schema.datamodel import kgcl
 from linkml_runtime.dumpers import json_dumper
 from linkml_runtime.loaders import json_loader
 
-from oaklib.converters.obo_graph_to_rdf_owl_converter import (
-    SCOPE_MAP,
-    OboGraphToRdfOwlConverter,
-)
+from oaklib.converters.obo_graph_to_rdf_owl_converter import SCOPE_MAP
 from oaklib.datamodels import obograph
 from oaklib.datamodels.obograph import (
     Edge,

--- a/src/oaklib/implementations/sparql/abstract_sparql_implementation.py
+++ b/src/oaklib/implementations/sparql/abstract_sparql_implementation.py
@@ -43,6 +43,7 @@ from oaklib.interfaces.basic_ontology_interface import (
     RELATIONSHIP,
     RELATIONSHIP_MAP,
 )
+from oaklib.interfaces.dumper_interface import DumperInterface
 from oaklib.interfaces.rdf_interface import TRIPLE, RdfInterface
 from oaklib.resource import OntologyResource
 from oaklib.types import CURIE, URI
@@ -93,7 +94,7 @@ def _quote_uri(uri: str) -> str:
 
 
 @dataclass
-class AbstractSparqlImplementation(RdfInterface, ABC):
+class AbstractSparqlImplementation(RdfInterface, DumperInterface, ABC):
     """
     An OntologyInterface implementation that wraps a (typically remote) SPARQL endpoint.
 
@@ -590,6 +591,8 @@ class AbstractSparqlImplementation(RdfInterface, ABC):
             return None
 
     def dump(self, path: str = None, syntax: str = "turtle"):
+        if syntax in ["fhirjson", "obo", "obojson"]:
+            return super().dump(path, syntax)
         if self.named_graph is None and not self.graph:
             raise ValueError("Must specify a named graph to dump for a remote triplestore")
         query = SparqlQuery(select=["?s", "?p", "?o"], where=["?s ?p ?o"])
@@ -681,9 +684,16 @@ class AbstractSparqlImplementation(RdfInterface, ABC):
         self, curie: CURIE, strict=False, include_metadata=False, expand_curies=False
     ) -> obograph.Node:
         params = dict(id=curie, lbl=self.label(curie))
+        node = obograph.Node(**params)
         if include_metadata:
-            raise NotImplementedError
-        return obograph.Node(**params)
+            meta = obograph.Meta()
+            node.meta = meta
+            defn = self.definition(curie)
+            if defn:
+                meta.definition = obograph.DefinitionPropertyValue(val=defn)
+            for pred, syn in self.alias_relationships(curie, exclude_labels=True):
+                meta.synonyms.append(obograph.SynonymPropertyValue(pred=pred.replace("oio:", ""), val=syn))
+        return node
 
     def hierarchical_descendants(self, start_curies: Union[CURIE, List[CURIE]]) -> Iterable[CURIE]:
         query_uris = [self.curie_to_sparql(curie) for curie in start_curies]

--- a/src/oaklib/implementations/sparql/abstract_sparql_implementation.py
+++ b/src/oaklib/implementations/sparql/abstract_sparql_implementation.py
@@ -692,7 +692,9 @@ class AbstractSparqlImplementation(RdfInterface, DumperInterface, ABC):
             if defn:
                 meta.definition = obograph.DefinitionPropertyValue(val=defn)
             for pred, syn in self.alias_relationships(curie, exclude_labels=True):
-                meta.synonyms.append(obograph.SynonymPropertyValue(pred=pred.replace("oio:", ""), val=syn))
+                meta.synonyms.append(
+                    obograph.SynonymPropertyValue(pred=pred.replace("oio:", ""), val=syn)
+                )
         return node
 
     def hierarchical_descendants(self, start_curies: Union[CURIE, List[CURIE]]) -> Iterable[CURIE]:

--- a/src/oaklib/interfaces/dumper_interface.py
+++ b/src/oaklib/interfaces/dumper_interface.py
@@ -52,4 +52,5 @@ class DumperInterface(BasicOntologyInterface, ABC):
                 print(json_str)
         else:
             converter = OBOGRAPH_CONVERTERS[syntax]()
+            converter.curie_converter = self.converter
             converter.dump(ogdoc, target=path)

--- a/src/oaklib/interfaces/obograph_interface.py
+++ b/src/oaklib/interfaces/obograph_interface.py
@@ -369,7 +369,7 @@ class OboGraphInterface(BasicOntologyInterface, ABC):
         :param subjects:
         :return:
         """
-        raise NotImplementedError
+        return iter(())
 
     def add_metadata(self, graph: Graph) -> None:
         """

--- a/src/oaklib/utilities/subsets/value_set_expander.py
+++ b/src/oaklib/utilities/subsets/value_set_expander.py
@@ -1,0 +1,289 @@
+import logging
+from abc import ABC
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator, List, Union
+
+import click
+from linkml_runtime.dumpers import json_dumper
+from linkml_runtime.linkml_model import EnumDefinition, PermissibleValue
+from linkml_runtime.linkml_model.meta import (
+    AnonymousEnumExpression,
+    EnumExpression,
+    SchemaDefinition,
+)
+from linkml_runtime.loaders import yaml_loader
+from ruamel.yaml import YAML
+
+from oaklib import get_implementation_from_shorthand
+from oaklib.datamodels.search import SearchConfiguration
+from oaklib.datamodels.search_datamodel import SearchProperty, SearchTermSyntax
+from oaklib.datamodels.value_set_configuration import Resolver, ValueSetConfiguration
+from oaklib.datamodels.vocabulary import IS_A
+from oaklib.interfaces import SearchInterface
+from oaklib.interfaces.basic_ontology_interface import BasicOntologyInterface
+from oaklib.interfaces.obograph_interface import OboGraphInterface
+from oaklib.types import CURIE
+
+DEFAULT_CONFIG = ValueSetConfiguration(default_resolver=Resolver("", shorthand_prefix="sqlite:obo"))
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ValueSetExpander(BasicOntologyInterface, ABC):
+    """
+    Tool for working with Value Sets in OAK
+    """
+
+    configuration: ValueSetConfiguration = field(default_factory=lambda: DEFAULT_CONFIG)
+
+    def expand_value_set(
+        self,
+        value_set: EnumExpression,
+        schema: SchemaDefinition = None,
+        source_enum_definition: EnumDefinition = None,
+    ) -> Iterator[PermissibleValue]:
+        """
+        Expand a value set definition into a list of curies
+
+        See:
+
+         - https://douroucouli.wordpress.com/2022/07/15/using-ontologies-within-data-models-and-standards/
+
+        TODO: extend this to allow FHIR value sets
+
+        :param value_set:
+        :param schema:
+        :param source_enum_definition:
+        :return:
+        """
+        if isinstance(value_set, EnumDefinition):
+            if source_enum_definition is None:
+                source_enum_definition = value_set
+        pvs = list(value_set.permissible_values.values())
+        if value_set.inherits:
+            if schema is None:
+                raise ValueError("Schema must be provided to expand value set")
+            for inherited in value_set.inherits:
+                if inherited not in schema.enums:
+                    raise ValueError(f"Unknown value set: {inherited}")
+                vset = schema.enums[inherited]
+                pvs.extend(
+                    self.expand_value_set(
+                        vset, schema=schema, source_enum_definition=source_enum_definition
+                    )
+                )
+        if value_set.include:
+            for include in value_set.include:
+                if isinstance(include, AnonymousEnumExpression):
+                    pvs.extend(
+                        self.expand_value_set(
+                            include, schema=schema, source_enum_definition=source_enum_definition
+                        )
+                    )
+                else:
+                    raise ValueError(f"Unexpected type for include: {type(include)}")
+                pvs.extend(
+                    self.expand_value_set(
+                        include, schema=schema, source_enum_definition=source_enum_definition
+                    )
+                )
+        if value_set.concepts:
+            for concept in value_set.concepts:
+                pvs.append(PermissibleValue(text=concept, meaning=concept))
+        if value_set.matches:
+            m = value_set.matches
+            oi = self._get_handle(m.source_ontology)
+            if m.identifier_pattern:
+                if isinstance(oi, SearchInterface):
+                    search_config = SearchConfiguration(
+                        syntax=SearchTermSyntax.REGULAR_EXPRESSION,
+                        properties=[SearchProperty.IDENTIFIER],
+                    )
+                    for curie in oi.basic_search(m.identifier_pattern, config=search_config):
+                        pvs.append(PermissibleValue(text=curie, meaning=curie))
+                else:
+                    raise NotImplementedError(f"Must be a SearchInterface: {type(oi)}")
+        if value_set.reachable_from:
+            rq = value_set.reachable_from
+            oi = self._get_handle(rq.source_ontology)
+            predicates = rq.relationship_types or [IS_A]
+            logging.debug(f"Predicates: {predicates}")
+            if isinstance(oi, OboGraphInterface):
+                if rq.traverse_up:
+                    if rq.is_direct:
+                        results = [
+                            o
+                            for _s, _p, o in oi.relationships(
+                                rq.source_nodes, predicates=predicates
+                            )
+                        ]
+                    else:
+                        results = oi.ancestors(
+                            rq.source_nodes, predicates=predicates, reflexive=rq.include_self
+                        )
+                else:
+                    if rq.is_direct:
+                        results = [
+                            s
+                            for s, _p, _o in oi.relationships(
+                                objects=rq.source_nodes, predicates=predicates
+                            )
+                        ]
+                    else:
+                        results = oi.descendants(
+                            rq.source_nodes, predicates=predicates, reflexive=rq.include_self
+                        )
+                for curie in results:
+                    pvs.append(self._generate_permissible_value(curie, oi, source_enum_definition))
+            else:
+                raise NotImplementedError(f"Must be an OboGraphInterface: {type(oi)}")
+        if value_set.minus:
+            for minus_vs in value_set.minus:
+                if isinstance(minus_vs, EnumExpression) or isinstance(
+                    minus_vs, AnonymousEnumExpression
+                ):
+                    for pv in self.expand_value_set(
+                        minus_vs, schema=schema, source_enum_definition=source_enum_definition
+                    ):
+                        if pv in pvs:
+                            pvs.remove(pv)
+                else:
+                    raise ValueError(f"Unexpected type for minus: {type(minus_vs)}")
+        for pv in pvs:
+            yield pv
+
+    def _get_handle(self, ontology_id: CURIE) -> BasicOntologyInterface:
+        prefix, local_name = ontology_id.split(":")
+        prefix_lower = prefix.lower()
+        config = self.configuration
+        resolver = None
+        if config.default_resolver:
+            resolver = config.default_resolver
+        if prefix_lower in config.prefix_resolvers:
+            resolver = config.prefix_resolvers[prefix_lower]
+        if ontology_id in config.resource_resolvers:
+            resolver = config.resource_resolvers[ontology_id]
+        if resolver:
+            if resolver.shorthand_prefix:
+                shorthand = f"{resolver.shorthand_prefix}:{local_name}"
+            elif resolver.shorthand:
+                shorthand = resolver.shorthand
+            else:
+                raise ValueError(f"Invalid resolver configuration: {resolver}")
+            return get_implementation_from_shorthand(shorthand)
+        else:
+            raise ValueError(f"Don't know how to resolve: {ontology_id}")
+
+    def _generate_permissible_value(
+        self,
+        curie: CURIE,
+        oi: BasicOntologyInterface,
+        enum_definition: EnumDefinition = None,
+    ) -> PermissibleValue:
+        label = oi.label(curie)
+        pv_formula = enum_definition.pv_formula if enum_definition else None
+        if str(pv_formula) == "CURIE":
+            text = curie
+        elif str(pv_formula) == "LABEL":
+            text = label
+        elif str(pv_formula) == "URI":
+            text = curie
+        elif str(pv_formula) == "CODE":
+            text = curie.split(":")[1]
+        else:
+            text = curie
+        return PermissibleValue(text=text, meaning=curie, description=label)
+
+    def expand_in_place(
+        self,
+        schema_path: Union[str, Path],
+        value_set_names: List[str] = None,
+        output_path: Union[str, Path] = None,
+    ) -> SchemaDefinition:
+        """
+        Expand value sets in place
+
+        :param schema_path:
+        :param value_set_names:
+        :param configuration:
+        :param output_path:
+        :return:
+        """
+        yaml = YAML()
+        with open(schema_path) as file:
+            yaml_obj = yaml.load(file)
+        from linkml_runtime.loaders import yaml_loader
+
+        schema = yaml_loader.load(schema_path, target_class=SchemaDefinition)
+        if value_set_names is None:
+            value_set_names = list(schema.enums.keys())
+        for value_set_name in value_set_names:
+            if value_set_name not in schema.enums:
+                raise ValueError(f"Unknown value set: {value_set_name}")
+            value_set = schema.enums[value_set_name]
+            pvs = list(self.expand_value_set(value_set, schema=schema))
+            yaml_obj["enums"][value_set_name]["permissible_values"] = {
+                str(pv.text): json_dumper.to_dict(pv) for pv in pvs
+            }
+        if output_path:
+            with open(output_path, "w", encoding="UTF-8") as file:
+                yaml.dump(yaml_obj, stream=file)
+
+
+@click.group()
+@click.option("-v", "--verbose", count=True)
+@click.option("-q", "--quiet")
+def main(verbose: int, quiet: bool):
+    """Run the ValueSet CLI."""
+    if verbose >= 2:
+        logger.setLevel(level=logging.DEBUG)
+    elif verbose == 1:
+        logger.setLevel(level=logging.INFO)
+    else:
+        logger.setLevel(level=logging.WARNING)
+    if quiet:
+        logger.setLevel(level=logging.ERROR)
+
+
+@main.command()
+@click.option("-c", "--config", type=click.Path(exists=True))
+@click.option("-s", "--schema", type=click.Path(exists=True))
+@click.option("-o", "--output", type=click.Path())
+@click.argument("value_set_names", nargs=-1)
+def expand(config: str, schema: str, value_set_names: List[str], output: str):
+    """
+    Expand a value set. EXPERIMENTAL.
+
+    This will expand an *intensional value set* (aka *dynamic enum*), running a query against
+    an ontology backend or backends to materialize the value set (permissible values).
+
+    Currently the value set must be specified as LinkML, but in future this will be
+    possible with other specifications such as FHIR ValueSet objects.
+
+    Each expression in a dynamic enum has a *source ontology*, this is specified as a CURIE
+    such as:
+
+    - obo:mondo
+    - bioregistry:wikidata
+
+    These can be mapped to specific OAK selectors. By default, any obo prefix is mapped to
+    the semsql implementation of that. You can use a configuration file to map to other backends,
+    such as BioPortal or Wikidata. However, note that not all backends are capable of being able to
+    render all value sets.
+
+    Example:
+
+        vskit expand -c config.yaml -s schema.yaml -o expanded.yaml my_value_set1 my_value_set2
+    """
+    expander = ValueSetExpander()
+    if config:
+        expander.configuration = yaml_loader.load(config, target_class=ValueSetConfiguration)
+    expander.expand_in_place(
+        schema_path=schema, value_set_names=value_set_names, output_path=output
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/input/value_set_example.yaml
+++ b/tests/input/value_set_example.yaml
@@ -1,0 +1,195 @@
+id: https://w3id.org/linkml/examples/enums
+title: Dynamic Enums Example
+name: dynamicenums-example
+description: This demonstrates the use of dynamic enums
+license: https://creativecommons.org/publicdomain/zero/1.0/
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://w3id.org/linkml/examples/enums/
+  sh: https://w3id.org/shacl/
+  bioregistry: https://bioregistry.io/registry/
+  MONDO: http://purl.obolibrary.org/obo/MONDO_
+  NCIT: http://purl.obolibrary.org/obo/NCIT_
+  loinc: http://loinc.org/
+
+default_prefix: ex
+default_range: string
+
+default_curi_maps:
+    - semweb_context
+
+emit_prefixes:
+  - linkml
+  - rdf
+  - rdfs
+  - xsd
+  - owl
+
+imports:
+  - linkml:types
+
+
+#==================================
+# Classes                         #
+#==================================
+
+classes:
+  HumanSample:
+    slots:
+      - name
+      - disease
+
+
+#==================================
+# Slots                           #
+#==================================
+
+slots:
+  name:
+    range: string
+  disease:
+    range: HumanDisease
+  vital_status:
+    enum_range:
+      permissible_values:
+        LIVING:
+        DEAD:
+        UNDEAD:
+
+#==================================
+# Enums
+#==================================
+
+enums:
+  GoMembrane:
+    pv_formula: CURIE
+    reachable_from:
+      include_self: true
+      source_ontology: obo:go
+      source_nodes:
+        - GO:0016020 ## membrane
+
+  OnlyInEukaryotes:
+    reachable_from:
+      source_ontology: obo:go
+      source_nodes:
+        - NCBITaxon:2759 ## Eukaryota
+      relationship_types:
+        - rdfs:subClassOf
+        - RO:0002162 ## in taxon
+        - BFO:0000050 ## part of
+
+  MembraneExcludingEukaryotes:
+    inherits: GoMembrane
+    minus:
+      - inherits: OnlyInEukaryotes
+
+
+  Disease:
+    reachable_from:
+      source_ontology: bioregistry:mondo
+      source_nodes:
+        - MONDO:0000001 ## disease or disorder
+      is_direct: false
+      relationship_types:
+        - rdfs:subClassOf
+    minus:
+      permissible_values:
+        root_node:
+          meaning: MONDO:0000001 ## disease or disorder
+
+  HumanDisease:
+    description: Extends the Disease value set, including NCIT neoplasms, excluding non-human diseases
+    inherits:
+      - Disease
+    include:
+      - reachable_from:
+          source_ontology: bioregistry:ncit
+          source_nodes:
+            - NCIT:C3262
+    minus:
+      - reachable_from:
+          source_ontology: bioregistry:mondo
+          source_nodes:
+            - MONDO:0005583 ## non-human animal disease
+          relationship_types:
+            - rdfs:subClassOf
+      - permissible_values:
+          NOT_THIS_ONE:
+            meaning: MONDO:9999
+            description: Example of excluding a single node
+
+  LoincExample:
+    enum_uri: http://hl7.org/fhir/ValueSet/example-intensional
+    see_also:
+      - https://build.fhir.org/valueset-example-intensional.json.html
+    include:
+      - reachable_from:
+          source_ontology: "loinc:"
+          source_nodes:
+            - loinc:LP43571-6
+          is_direct: true
+    minus:
+      concepts:
+        - LOINC:5932-9
+
+  HCAExample:
+    see_also:
+      - https://github.com/linkml/linkml/issues/274
+    include:
+      - reachable_from:
+          source_ontology: bioregistry:go
+          source_nodes:
+            - GO:0007049
+            - GO:0022403
+          include_self: false
+          relationship_types:
+            - rdfs:subClassOf
+    minus:
+      concepts:
+        - LOINC:5932-9
+
+  BodyPartEnum:
+    reachable_from:
+      source_ontology: obo:cl
+      source_nodes:
+        - CL:0000540 ## neuron
+      include_self: false
+      relationship_types:
+        - rdfs:subClassOf
+
+  Brand:
+    enum_uri: wikidata:Q431289
+    include:
+      - reachable_from:
+          source_ontology: bioregistry:wikidata
+          source_nodes:
+          - wikidata:Q431289
+          include_self: false
+          relationship_types:
+            - wdp:P31
+            - wdp:P279
+
+  SerumCholesterolExample:
+    description: >
+      This is an example value set that includes all the LOINC codes for serum/plasma cholesterol from v2.36.
+    code_set: http://hl7.org/fhir/ValueSet/serum-cholesterol
+    code_set_version: "1.0.0"
+    pv_formula: CODE
+    include:
+      - concepts:
+          - LP43571-6
+    minus:
+      - concepts:
+          - 5932-9
+    reachable_from:
+      source_ontology: http://loinc.org
+      source_nodes:
+        - LP43571-6
+      relationship_types: null
+      is_direct: true
+      include_self: true
+      traverse_up: false
+    concepts:
+      - http://loinc.org/LP43571-6

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ from tests import (
 )
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"
+TEST_OBOJSON = INPUT_DIR / "go-nucleus.json"
 TEST_OWL_RDF = INPUT_DIR / "go-nucleus.owl.ttl"
 TEST_DB = INPUT_DIR / "go-nucleus.db"
 BAD_ONTOLOGY_DB = INPUT_DIR / "bad-ontology.db"
@@ -299,7 +300,12 @@ class TestCommandLineInterface(unittest.TestCase):
     # DUMPER
 
     def test_dump(self):
+        obojson_input = f"obograph:{TEST_OBOJSON}"
         cases = [
+            (obojson_input, "obojson"),
+            (obojson_input, "obo"),
+            (obojson_input, "fhirjson"),
+            (obojson_input, "owl"),
             (TEST_ONT, "obo"),
             (TEST_DB, "obo"),
             (TEST_ONT, "obojson"),

--- a/tests/test_utilities/test_value_set_expander.py
+++ b/tests/test_utilities/test_value_set_expander.py
@@ -1,0 +1,120 @@
+import unittest
+
+from linkml_runtime.linkml_model import EnumDefinition, SchemaDefinition
+from linkml_runtime.loaders import yaml_loader
+
+from oaklib.datamodels.value_set_configuration import ValueSetConfiguration
+from oaklib.utilities.subsets.value_set_expander import ValueSetExpander
+from tests import (
+    BACTERIA,
+    EXAMPLE_ONTOLOGY_DB,
+    FUNGI,
+    INPUT_DIR,
+    MEMBRANE,
+    NUCLEAR_MEMBRANE,
+    OUTPUT_DIR,
+    PLASMA_MEMBRANE,
+    VACUOLE,
+)
+
+SCHEMA = str(INPUT_DIR / "value_set_example.yaml")
+SCHEMA_OUT = str(OUTPUT_DIR / "value_set_example-expanded.yaml")
+
+CONF = f"""
+resource_resolvers:
+  obo:go:
+    shorthand: {EXAMPLE_ONTOLOGY_DB}
+"""
+
+cases = [
+    ("GoMembrane", [MEMBRANE, NUCLEAR_MEMBRANE, PLASMA_MEMBRANE], [VACUOLE]),
+    ("OnlyInEukaryotes", [NUCLEAR_MEMBRANE, FUNGI], [MEMBRANE, BACTERIA]),
+    ("MembraneExcludingEukaryotes", [MEMBRANE], [NUCLEAR_MEMBRANE, FUNGI]),
+]
+
+
+class TestValueSetExpander(unittest.TestCase):
+    def setUp(self) -> None:
+        self.expander = ValueSetExpander()
+        self.expander.configuration = yaml_loader.loads(CONF, ValueSetConfiguration)
+
+    def test_trivial(self):
+        expander = self.expander
+        vset = yaml_loader.loads(
+            """
+        name: test
+        permissible_values:
+          a:
+          b:
+          c:
+        """,
+            EnumDefinition,
+        )
+        pvs = list(expander.expand_value_set(vset))
+        for pv in pvs:
+            print(pv)
+        self.assertEqual(3, len(pvs))
+        self.assertCountEqual(["a", "b", "c"], [pv.text for pv in pvs])
+
+    def test_descendants(self):
+        expander = self.expander
+        vset: EnumDefinition = yaml_loader.loads(
+            f"""
+        name: test
+        reachable_from:
+          source_ontology: obo:go
+          source_nodes: {MEMBRANE}
+        """,
+            EnumDefinition,
+        )
+        pvs = list(expander.expand_value_set(vset))
+        for pv in pvs:
+            print(pv)
+        self.assertEqual(len(pvs), 4)
+        texts = [pv.text for pv in pvs]
+        self.assertIn(PLASMA_MEMBRANE, texts)
+        self.assertNotIn(MEMBRANE, texts)
+        vset.reachable_from.include_self = True
+        pvs = list(expander.expand_value_set(vset))
+        self.assertEqual(len(pvs), len(texts) + 1)
+        texts = [pv.text for pv in pvs]
+        self.assertIn(PLASMA_MEMBRANE, texts)
+        self.assertIn(MEMBRANE, texts)
+
+    def test_identifier(self):
+        expander = self.expander
+        vset = yaml_loader.loads(
+            """
+        name: test
+        matches:
+          source_ontology: obo:go
+          identifier_pattern: "GO:003196.*"
+        """,
+            EnumDefinition,
+        )
+        pvs = list(expander.expand_value_set(vset))
+        # for pv in pvs:
+        #    print(pv)
+        self.assertEqual(len(pvs), 2)
+        self.assertIn(NUCLEAR_MEMBRANE, [pv.text for pv in pvs])
+
+    def test_complex(self):
+        schema = yaml_loader.load(SCHEMA, SchemaDefinition)
+        enums = schema.enums
+        for case in cases:
+            vset_name, expected, unexpected = case
+            vset = enums[vset_name]
+            pvs = list(self.expander.expand_value_set(vset, schema=schema))
+            texts = [pv.text for pv in pvs]
+            for ex in expected:
+                self.assertIn(ex, texts, f"Expected {ex} in {vset_name}")
+            for un in unexpected:
+                self.assertNotIn(un, texts, f"Unexpected {un} in {vset_name}")
+
+    def test_expand_in_place(self):
+        self.expander.expand_in_place(
+            SCHEMA,
+            # value_set_names=[case[0] for case in cases],
+            value_set_names=["GoMembrane"],
+            output_path=SCHEMA_OUT,
+        )


### PR DESCRIPTION
Fixes:

 -  #370

This PR adds a new top level command (name is not yet final) called vskit:

```
vskit expand  --help
Usage: vskit expand [OPTIONS] [VALUE_SET_NAMES]...

  Expand a value set. EXPERIMENTAL.

  This will expand an *intensional value set* (aka *dynamic enum*), running a
  query against an ontology backend or backends to materialize the value set
  (permissible values).

  Currently the value set must be specified as LinkML, but in future this will
  be possible with other specifications such as FHIR ValueSet objects.

  Each expression in a dynamic enum has a *source ontology*, this is specified
  as a CURIE such as:

  - obo:mondo - bioregistry:wikidata

  These can be mapped to specific OAK selectors. By default, any obo prefix is
  mapped to the semsql implementation of that. You can use a configuration
  file to map to other backends, such as BioPortal or Wikidata. However, note
  that not all backends are capable of being able to render all value sets.

  Example:

      vskit expand -c config.yaml -s schema.yaml -o expanded.yaml
      my_value_set1 my_value_set2

Options:
  -c, --config PATH
  -s, --schema PATH
  -o, --output PATH
  --help             Show this message and exit.
```

This can be used to expand a value set.

E.g.

`vskit expand  -s tests/input/value_set_example.yaml -o z GoMembrane   MembraneExcludingEukaryotes`

will expand two value sets (enums) from a linkml spec

```yaml
  GoMembrane:
    pv_formula: CURIE
    reachable_from:
      include_self: true
      source_ontology: obo:go
      source_nodes:
        - GO:0016020 ## membrane

  OnlyInEukaryotes:
    reachable_from:
      source_ontology: obo:go
      source_nodes:
        - NCBITaxon:2759 ## Eukaryota
      relationship_types:
        - rdfs:subClassOf
        - RO:0002162 ## in taxon
        - BFO:0000050 ## part of

  MembraneExcludingEukaryotes:
    inherits: GoMembrane
    minus:
      - inherits: OnlyInEukaryotes
```

it will materialize the permissible values by querying the relevant ontology

It uses rueaml.yaml when writing the output, so comments are preserved
