### PR TITLE
Pass `prefix_map` to `lexmatch` output and clean the same before generating SSSOM output

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -3750,6 +3750,7 @@ def lexmatch(output, recreate, rules_file, lexical_index_file, add_labels, terms
         ruleset = load_mapping_rules(rules_file)
     else:
         ruleset = None
+    prefix_map = impl.prefix_map()
 
     # if exclude_tokens:
     #     token_exclusion_list = get_exclusion_token_list(exclude_tokens)
@@ -3784,7 +3785,9 @@ def lexmatch(output, recreate, rules_file, lexical_index_file, add_labels, terms
                 logging.info("Saving index")
                 save_lexical_index(ix, lexical_index_file)
         logging.info(f"Generating mappings from {len(ix.groupings)} groupings")
-        msdf = lexical_index_to_sssom(impl, ix, ruleset=ruleset, subjects=subjects, objects=objects)
+        msdf = lexical_index_to_sssom(
+            impl, ix, ruleset=ruleset, subjects=subjects, objects=objects, prefix_map=prefix_map
+        )
         sssom_writers.write_table(msdf, output)
     else:
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -203,6 +203,7 @@ def lexical_index_to_sssom(
     lexical_index: LexicalIndex,
     ruleset: MappingRuleCollection = None,
     meta: Metadata = None,
+    prefix_map: dict = None,
     subjects: Collection[CURIE] = None,
     objects: Collection[CURIE] = None,
     symmetric: bool = False,
@@ -254,6 +255,7 @@ def lexical_index_to_sssom(
     if meta is None:
         meta = get_default_metadata()
 
+    meta.prefix_map.update({k: v for k, v in prefix_map.items() if k not in meta.prefix_map.keys()})
     mapping_set_id = meta.metadata[MAPPING_SET_ID]
     license = meta.metadata[LICENSE]
 

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -254,8 +254,10 @@ def lexical_index_to_sssom(
 
     if meta is None:
         meta = get_default_metadata()
-
-    meta.prefix_map.update({k: v for k, v in prefix_map.items() if k not in meta.prefix_map.keys()})
+    if prefix_map:
+        meta.prefix_map.update(
+            {k: v for k, v in prefix_map.items() if k not in meta.prefix_map.keys()}
+        )
     mapping_set_id = meta.metadata[MAPPING_SET_ID]
     license = meta.metadata[LICENSE]
 

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -263,7 +263,7 @@ def lexical_index_to_sssom(
     msdf = to_mapping_set_dataframe(doc)
     # TODO uncomment below.
     # TODO Right now it erases the entire msdf.df in the absence of CURIEs in map.
-    # msdf.clean_prefix_map()
+    msdf.clean_prefix_map()
     return msdf
 
 

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -261,8 +261,6 @@ def lexical_index_to_sssom(
     # doc = MappingSetDocument(prefix_map=oi.prefix_map(), mapping_set=mset)
     doc = MappingSetDocument(prefix_map=meta.prefix_map, mapping_set=mset)
     msdf = to_mapping_set_dataframe(doc)
-    # TODO uncomment below.
-    # TODO Right now it erases the entire msdf.df in the absence of CURIEs in map.
     msdf.clean_prefix_map()
     return msdf
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -590,6 +590,8 @@ class TestCommandLineInterface(unittest.TestCase):
         result = self.runner.invoke(
             main,
             [
+                "--prefix",
+                "x=http://example.org/x/",
                 "-i",
                 f"sqlite:{INPUT_DIR}/matcher-test.db",
                 "lexmatch",


### PR DESCRIPTION
- [x] Passes prefix_map from oak to`lexmatch` output.
- [x] This avoid the mapping file from having a huge noisy `prefix_map` as a header of the SSSOM tsv file.

Fixes #350 