### PR TITLE
Adding a Translator Node Normalizer adapter. Fixes #397

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -2831,11 +2831,11 @@ def mappings(terms, maps_to_source, autolabel: bool, output, output_type):
                     impl.inject_mapping_labels([mapping])
                 writer.emit(mapping)
         else:
-            for curie in query_terms_iterator(terms, impl):
-                for mapping in impl.get_sssom_mappings_by_curie(curie):
-                    if autolabel:
-                        impl.inject_mapping_labels([mapping])
-                    writer.emit(mapping)
+            curies = query_terms_iterator(terms, impl)
+            for mapping in impl.sssom_mappings(curies):
+                if autolabel:
+                    impl.inject_mapping_labels([mapping])
+                writer.emit(mapping)
     else:
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")
 

--- a/src/oaklib/implementations/obograph/obograph_implementation.py
+++ b/src/oaklib/implementations/obograph/obograph_implementation.py
@@ -38,7 +38,6 @@ from oaklib.interfaces.basic_ontology_interface import (
 )
 from oaklib.interfaces.differ_interface import DifferInterface
 from oaklib.interfaces.dumper_interface import DumperInterface
-from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
 from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.interfaces.patcher_interface import PatcherInterface
 from oaklib.interfaces.rdf_interface import RdfInterface
@@ -64,7 +63,6 @@ class OboGraphImplementation(
     RdfInterface,
     OboGraphInterface,
     SearchInterface,
-    MappingProviderInterface,
     PatcherInterface,
     DumperInterface,
 ):
@@ -394,8 +392,10 @@ class OboGraphImplementation(
     # Implements: MappingsInterface
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    def get_sssom_mappings_by_curie(self, curie: Union[str, CURIE]) -> Iterator[sssom.Mapping]:
-        raise NotImplementedError
+    def sssom_mappings(
+        self, curies: Optional[Union[CURIE, Iterable[CURIE]]] = None, source: Optional[str] = None
+    ) -> Iterable[sssom.Mapping]:
+        raise NotImplementedError()
 
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     # Implements: OboGraphInterface

--- a/src/oaklib/implementations/translator/translator_implementation.py
+++ b/src/oaklib/implementations/translator/translator_implementation.py
@@ -1,0 +1,83 @@
+"""
+Adapter for NCATS Biomedical Translator endpoints (experimental).
+
+.. warning ::
+
+    this is currently highly incomplete.
+    Only NodeNormalizer API implemented so far
+
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Optional, Union
+
+import requests
+import sssom_schema.datamodel.sssom_schema as sssom
+
+from oaklib.datamodels.vocabulary import SEMAPV, SKOS_CLOSE_MATCH, SKOS_EXACT_MATCH
+from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
+from oaklib.types import CURIE
+
+__all__ = [
+    "TranslatorImplementation",
+]
+
+from oaklib.utilities.mapping.sssom_utils import inject_mapping_sources
+
+NODE_NORMALIZER_ENDPOINT = "https://nodenormalization-sri.renci.org/1.3/get_normalized_nodes"
+
+
+@dataclass
+class TranslatorImplementation(
+    MappingProviderInterface,
+):
+    """
+    Wraps Translator endpoints.
+
+    TODO: implement other endpoints
+    """
+
+    def sssom_mappings(
+        self, curies: Optional[Union[CURIE, Iterable[CURIE]]] = None, source: Optional[str] = None
+    ) -> Iterable[Mapping]:
+        if isinstance(curies, CURIE):
+            curies = [curies]
+        else:
+            curies = list(curies)
+        r = requests.get(NODE_NORMALIZER_ENDPOINT, params={"curie": curies, "conflate": "false"})
+        non_conflated_results = r.json()
+        r = requests.get(NODE_NORMALIZER_ENDPOINT, params={"curie": curies, "conflate": "true"})
+        results = r.json()
+        if "detail" in results:
+            if results["detail"] == "Not found.":
+                return
+        for curies, data in results.items():
+            nc_data = non_conflated_results.get(curies, {})
+            label = None
+            for x in data["equivalent_identifiers"]:
+                if x["identifier"] == curies:
+                    label = x["label"]
+            for x in data["equivalent_identifiers"]:
+                pred = (
+                    SKOS_EXACT_MATCH
+                    if any(
+                        x2["identifier"] == x["identifier"]
+                        for x2 in nc_data["equivalent_identifiers"]
+                    )
+                    else SKOS_CLOSE_MATCH
+                )
+                m = sssom.Mapping(
+                    subject_id=curies,
+                    subject_label=label,
+                    predicate_id=pred,
+                    object_id=x["identifier"],
+                    object_label=x.get("label", None),
+                    subject_source="translator",
+                    object_source="translator",
+                    mapping_justification=str(SEMAPV.ManualMappingCuration.value),
+                )
+                inject_mapping_sources(m)
+                yield m
+
+    def inject_mapping_labels(self, mappings: Iterable[Mapping]) -> None:
+        return

--- a/src/oaklib/implementations/translator/translator_implementation.py
+++ b/src/oaklib/implementations/translator/translator_implementation.py
@@ -72,8 +72,6 @@ class TranslatorImplementation(
                     predicate_id=pred,
                     object_id=x["identifier"],
                     object_label=x.get("label", None),
-                    subject_source="translator",
-                    object_source="translator",
                     mapping_justification=str(SEMAPV.ManualMappingCuration.value),
                 )
                 inject_mapping_sources(m)

--- a/src/oaklib/interfaces/mapping_provider_interface.py
+++ b/src/oaklib/interfaces/mapping_provider_interface.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 
 from deprecation import deprecated
 from sssom_schema import Mapping
@@ -53,35 +53,38 @@ class MappingProviderInterface(BasicOntologyInterface, ABC):
         return self.sssom_mappings_by_source(subject_or_object_source)
 
     @deprecated("Use sssom_mappings()")
-    def get_sssom_mappings_by_curie(self, curie: CURIE) -> Iterable[Mapping]:
+    def get_sssom_mappings_by_curie(self, *args, **kwargs) -> Iterable[Mapping]:
         """
         All SSSOM mappings about a curie
 
         MUST yield mappings where EITHER subject OR object equals the CURIE
 
-        :param curie:
+        :param kwargs:
         :return:
         """
-        raise NotImplementedError
+        return self.sssom_mappings(*args, **kwargs)
 
     def sssom_mappings(
-        self, curie: Optional[CURIE] = None, source: Optional[str] = None
+        self, curies: Optional[Union[CURIE, Iterable[CURIE]]] = None, source: Optional[str] = None
     ) -> Iterable[Mapping]:
         """
         returns all sssom mappings matching filter conditions
 
-        :param curie:
+        :param curies:
         :param source:
         :return:
         """
         logging.info("Getting all mappings")
-        if curie:
-            it = [curie]
+        if curies is not None:
+            if isinstance(curies, CURIE):
+                it = [curies]
+            else:
+                it = curies
         else:
             it = self.entities()
-        for curie in it:
-            logging.debug(f"Getting mappings for {curie}")
-            for m in self.get_sssom_mappings_by_curie(curie):
+        for curies in it:
+            logging.debug(f"Getting mappings for {curies}")
+            for m in self.get_sssom_mappings_by_curie(curies):
                 if source:
                     if m.object_source != source and m.subject_source != source:
                         continue

--- a/src/oaklib/selector.py
+++ b/src/oaklib/selector.py
@@ -31,6 +31,9 @@ from oaklib.implementations.simpleobo.simple_obo_implementation import (
 from oaklib.implementations.sparql.lov_implementation import LovImplementation
 from oaklib.implementations.sparql.sparql_implementation import SparqlImplementation
 from oaklib.implementations.sqldb.sql_implementation import SqlImplementation
+from oaklib.implementations.translator.translator_implementation import (
+    TranslatorImplementation,
+)
 from oaklib.implementations.ubergraph import UbergraphImplementation
 from oaklib.implementations.uniprot.uniprot_implementation import UniprotImplementation
 from oaklib.implementations.wikidata.wikidata_implementation import (
@@ -71,6 +74,7 @@ SCHEME_DICT = {
     "obolibrary": ProntoImplementation,
     "prontolib": ProntoImplementation,
     "gilda": GildaImplementation,
+    "translator": TranslatorImplementation,
 }
 
 

--- a/src/oaklib/utilities/mapping/sssom_utils.py
+++ b/src/oaklib/utilities/mapping/sssom_utils.py
@@ -9,6 +9,7 @@ from sssom_schema import Mapping, MappingSet
 
 from oaklib.io.streaming_writer import StreamingWriter
 from oaklib.types import CURIE
+from oaklib.utilities.basic_utils import get_curie_prefix
 
 
 def create_sssom_mapping(
@@ -48,6 +49,15 @@ def mappings_to_pairs(mappings: Iterable[Mapping]) -> List[Tuple[CURIE, CURIE]]:
     :return:
     """
     return list(set([(m.subject_id, m.object_id) for m in mappings]))
+
+
+def inject_mapping_sources(m: Mapping) -> Mapping:
+    """Auto-adds subject_source and object_source if they are not present"""
+    if not m.subject_source:
+        m.subject_source = get_curie_prefix(m.subject_id)
+    if not m.object_source:
+        m.object_source = get_curie_prefix(m.object_id)
+    return m
 
 
 @dataclass

--- a/tests/test_implementations/test_translator.py
+++ b/tests/test_implementations/test_translator.py
@@ -1,0 +1,32 @@
+import unittest
+
+from oaklib.datamodels.vocabulary import SKOS_CLOSE_MATCH, SKOS_EXACT_MATCH
+from oaklib.implementations.translator.translator_implementation import (
+    TranslatorImplementation,
+)
+
+
+# TODO: use mock tests
+class TestTranslatorImplementation(unittest.TestCase):
+    """
+    Tests :ref:`TranslatorImplementation`
+    """
+
+    def setUp(self) -> None:
+        self.impl = TranslatorImplementation()
+
+    def test_sssom_mappings(self):
+        """
+        Tests SSSOM mappings from Node Normalizer using a known stable gene
+        :return:
+        """
+        mappings = list(self.impl.sssom_mappings("NCBIGene:1588"))
+        cases = [
+            ("UniProtKB:P11511", SKOS_CLOSE_MATCH),
+            ("HGNC:2594", SKOS_EXACT_MATCH),
+        ]
+        for mapping in mappings:
+            tpl = (mapping.object_id, mapping.predicate_id)
+            if tpl in cases:
+                cases.remove(tpl)
+        self.assertEqual(len(cases), 0, f"Missing cases: {cases}")


### PR DESCRIPTION
Example usage:

`runoak  -i translator: mappings NCBIGene:1588 MONDO:0005180 -O sssom`

output:

|subject_id|subject_label|predicate_id|object_id|object_label|mapping_justification|subject_source|object_source|
|---|---|---|---|---|---|---|---|
|MONDO:0005180|Parkinson disease|skos:exactMatch|DOID:14330|Parkinson's disease|semapv:ManualMappingCuration|MONDO|DOID|
|MONDO:0005180|Parkinson disease|skos:exactMatch|SNOMEDCT:49049000||semapv:ManualMappingCuration|MONDO|SNOMEDCT|
|MONDO:0005180|Parkinson disease|skos:exactMatch|NCIT:C26845|Parkinson's Disease|semapv:ManualMappingCuration|MONDO|NCIT|
|MONDO:0005180|Parkinson disease|skos:exactMatch|MEDDRA:10061536||semapv:ManualMappingCuration|MONDO|MEDDRA|
|MONDO:0005180|Parkinson disease|skos:exactMatch|MEDDRA:10034008||semapv:ManualMappingCuration|MONDO|MEDDRA|
|MONDO:0005180|Parkinson disease|skos:exactMatch|MEDDRA:10034007||semapv:ManualMappingCuration|MONDO|MEDDRA|
|MONDO:0005180|Parkinson disease|skos:exactMatch|MEDDRA:10033801||semapv:ManualMappingCuration|MONDO|MEDDRA|
|MONDO:0005180|Parkinson disease|skos:exactMatch|MEDDRA:10013113||semapv:ManualMappingCuration|MONDO|MEDDRA|
|MONDO:0005180|Parkinson disease|skos:exactMatch|MESH:D010300|Parkinson Disease|semapv:ManualMappingCuration|MONDO|MESH|
|MONDO:0005180|Parkinson disease|skos:exactMatch|UMLS:C0030567|Parkinson Disease|semapv:ManualMappingCuration|MONDO|UMLS|
|MONDO:0005180|Parkinson disease|skos:exactMatch|EFO:0002508||semapv:ManualMappingCuration|MONDO|EFO|
|MONDO:0005180|Parkinson disease|skos:exactMatch|ORPHANET:319705||semapv:ManualMappingCuration|MONDO|ORPHANET|
|MONDO:0005180|Parkinson disease|skos:exactMatch|OMIM.PS:168600||semapv:ManualMappingCuration|MONDO|OMIM.PS|
|MONDO:0005180|Parkinson disease|skos:exactMatch|OMIM:PS168600||semapv:ManualMappingCuration|MONDO|OMIM|
|MONDO:0005180|Parkinson disease|skos:exactMatch|KEGG.DISEASE:05012||semapv:ManualMappingCuration|MONDO|KEGG.DISEASE|
|MONDO:0005180|Parkinson disease|skos:exactMatch|MONDO:0005180|Parkinson disease|semapv:ManualMappingCuration|MONDO|MONDO|
|MONDO:0005180|Parkinson disease|skos:exactMatch|ICD9:332||semapv:ManualMappingCuration|MONDO|ICD9|
|NCBIGene:1588|CYP19A1|skos:closeMatch|UniProtKB:Q8TCA4|Q8TCA4_HUMAN CYP19A1 protein (trembl)|semapv:ManualMappingCuration|NCBIGene|UniProtKB|
|NCBIGene:1588|CYP19A1|skos:closeMatch|UniProtKB:Q8IYG4|Q8IYG4_HUMAN Cytochrome P450, family 19, subfamily A, polypeptide 1 (trembl)|semapv:ManualMappingCuration|NCBIGene|UniProtKB|
|NCBIGene:1588|CYP19A1|skos:closeMatch|UniProtKB:Q05CU4|Q05CU4_HUMAN CYP19A1 protein (Fragment) (trembl)|semapv:ManualMappingCuration|NCBIGene|UniProtKB|
|NCBIGene:1588|CYP19A1|skos:closeMatch|UMLS:C3254086|CYP19A1 protein, human|semapv:ManualMappingCuration|NCBIGene|UMLS|
|NCBIGene:1588|CYP19A1|skos:closeMatch|PR:P11511|aromatase (human)|semapv:ManualMappingCuration|NCBIGene|PR|
|NCBIGene:1588|CYP19A1|skos:closeMatch|UniProtKB:P11511|CP19A_HUMAN Aromatase (sprot)|semapv:ManualMappingCuration|NCBIGene|UniProtKB|
|NCBIGene:1588|CYP19A1|skos:closeMatch|UniProtKB:A8K6W3|A8K6W3_HUMAN cDNA FLJ75846, highly similar to Homo sapiens cytochrome P450, family 19, subfamily A, polypeptide 1 (CYP19A1), transcript variant 1, mRNA (trembl)|semapv:ManualMappingCuration|NCBIGene|UniProtKB|
|NCBIGene:1588|CYP19A1|skos:closeMatch|UniProtKB:A0A024R5S8|A0A024R5S8_HUMAN Cytochrome P450, family 19, subfamily A, polypeptide 1, isoform CRA_a (trembl)|semapv:ManualMappingCuration|NCBIGene|UniProtKB|
|NCBIGene:1588|CYP19A1|skos:exactMatch|UMLS:C1366496|CYP19A1 gene|semapv:ManualMappingCuration|NCBIGene|UMLS|
|NCBIGene:1588|CYP19A1|skos:exactMatch|OMIM:107910||semapv:ManualMappingCuration|NCBIGene|OMIM|
|NCBIGene:1588|CYP19A1|skos:exactMatch|HGNC:2594|CYP19A1|semapv:ManualMappingCuration|NCBIGene|HGNC|
|NCBIGene:1588|CYP19A1|skos:exactMatch|ENSEMBL:ENSG00000137869||semapv:ManualMappingCuration|NCBIGene|ENSEMBL|
|NCBIGene:1588|CYP19A1|skos:exactMatch|NCBIGene:1588|CYP19A1|semapv:ManualMappingCuration|NCBIGene|NCBIGene|
