### PR TITLE
Added a new flag `ensure_strict_prefixes` to `lexmatch`

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -3692,9 +3692,15 @@ def set_apikey(endpoint, keyval):
     show_default=True,
     help="if true and lexical index is specified, always recreate, otherwise load from index",
 )
+@click.option(
+    "--ensure-strict-prefixes/--no-ensure-strict-prefixes",
+    default=False,
+    show_default=True,
+    help="Clean prefix map and mappings before generating an output.",
+)
 @output_option
 @click.argument("terms", nargs=-1)
-def lexmatch(output, recreate, rules_file, lexical_index_file, add_labels, terms):
+def lexmatch(output, recreate, ensure_strict_prefixes, rules_file, lexical_index_file, add_labels, terms):
     """
     Performs lexical matching between pairs of terms in one more more ontologies.
 
@@ -3786,7 +3792,7 @@ def lexmatch(output, recreate, rules_file, lexical_index_file, add_labels, terms
                 save_lexical_index(ix, lexical_index_file)
         logging.info(f"Generating mappings from {len(ix.groupings)} groupings")
         msdf = lexical_index_to_sssom(
-            impl, ix, ruleset=ruleset, subjects=subjects, objects=objects, prefix_map=prefix_map
+            impl, ix, ruleset=ruleset, subjects=subjects, objects=objects, prefix_map=prefix_map, ensure_strict_prefixes=ensure_strict_prefixes
         )
         sssom_writers.write_table(msdf, output)
     else:

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -3700,7 +3700,9 @@ def set_apikey(endpoint, keyval):
 )
 @output_option
 @click.argument("terms", nargs=-1)
-def lexmatch(output, recreate, ensure_strict_prefixes, rules_file, lexical_index_file, add_labels, terms):
+def lexmatch(
+    output, recreate, ensure_strict_prefixes, rules_file, lexical_index_file, add_labels, terms
+):
     """
     Performs lexical matching between pairs of terms in one more more ontologies.
 
@@ -3792,7 +3794,13 @@ def lexmatch(output, recreate, ensure_strict_prefixes, rules_file, lexical_index
                 save_lexical_index(ix, lexical_index_file)
         logging.info(f"Generating mappings from {len(ix.groupings)} groupings")
         msdf = lexical_index_to_sssom(
-            impl, ix, ruleset=ruleset, subjects=subjects, objects=objects, prefix_map=prefix_map, ensure_strict_prefixes=ensure_strict_prefixes
+            impl,
+            ix,
+            ruleset=ruleset,
+            subjects=subjects,
+            objects=objects,
+            prefix_map=prefix_map,
+            ensure_strict_prefixes=ensure_strict_prefixes,
         )
         sssom_writers.write_table(msdf, output)
     else:

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -207,7 +207,7 @@ def lexical_index_to_sssom(
     subjects: Collection[CURIE] = None,
     objects: Collection[CURIE] = None,
     symmetric: bool = False,
-    ensure_strict_prefixes:bool = False,
+    ensure_strict_prefixes: bool = False,
 ) -> MappingSetDataFrame:
     """
     Transform a lexical index to an SSSOM MappingSetDataFrame by finding all pairs for any given index term.

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -207,6 +207,7 @@ def lexical_index_to_sssom(
     subjects: Collection[CURIE] = None,
     objects: Collection[CURIE] = None,
     symmetric: bool = False,
+    ensure_strict_prefixes:bool = False,
 ) -> MappingSetDataFrame:
     """
     Transform a lexical index to an SSSOM MappingSetDataFrame by finding all pairs for any given index term.
@@ -265,7 +266,8 @@ def lexical_index_to_sssom(
     # doc = MappingSetDocument(prefix_map=oi.prefix_map(), mapping_set=mset)
     doc = MappingSetDocument(prefix_map=meta.prefix_map, mapping_set=mset)
     msdf = to_mapping_set_dataframe(doc)
-    msdf.clean_prefix_map()
+    if ensure_strict_prefixes:
+        msdf.clean_prefix_map()
     return msdf
 
 


### PR DESCRIPTION
This fixes #399.

This decides whether the SSSOM output has a cleaned prefix_map + mappings or no.