### PR TITLE
FHIR: CodeSystem.property

### DIFF
--- a/src/oaklib/datamodels/fhir.py
+++ b/src/oaklib/datamodels/fhir.py
@@ -5,7 +5,6 @@
 # id: https://w3id.org/linkml/fhir
 # description: Schema for working with FHIR objects
 # license: https://creativecommons.org/publicdomain/zero/1.0/
-
 import dataclasses
 import re
 import sys

--- a/src/oaklib/datamodels/fhir.yaml
+++ b/src/oaklib/datamodels/fhir.yaml
@@ -128,10 +128,18 @@ classes:
   CodeSystemProperty:
     attributes:
       code:
+        range: string  # Pattern: [^\s]+(\s[^\s]+)* / See: https://hl7.org/fhir/datatypes.html#code
         required: true
       uri:
+        range: uri
+        required: false
       description:
+        range: string
+        required: false
       type:
+        # TODO: type: an enum of: code | Coding | string | integer | boolean | dateTime | decimal
+        #  https://hl7:org/fhir/valueset-concept-property-type.html
+        required: true
         range: string
 
   Coding:

--- a/tests/test_converters/test_obo_graph_to_fhir.py
+++ b/tests/test_converters/test_obo_graph_to_fhir.py
@@ -1,6 +1,10 @@
+"""Tests for: Obographs to FHIR converter"""
+import os
 import unittest
+from typing import List
 
 import curies
+import requests
 from linkml_runtime.loaders import json_loader
 
 from oaklib.converters.obo_graph_to_fhir_converter import OboGraphToFHIRConverter
@@ -10,24 +14,44 @@ from oaklib.interfaces.basic_ontology_interface import get_default_prefix_map
 from tests import IMBO, INPUT_DIR, NUCLEUS, OUTPUT_DIR
 from tests.test_implementations import ComplianceTester
 
-ONT = INPUT_DIR / "go-nucleus.json"
-OUT = OUTPUT_DIR / "go-nucleus.fhir.codesystem.json"
+DOWNLOAD_TESTS_ON = False
 
 
 class OboGraphToFHIRTest(unittest.TestCase):
-    """Tests OBO JSON -> FHIR."""
+    """Tests OBO JSON -> FHIR. Different ontologies have unique structures, so test some specifics for those."""
+
+    @staticmethod
+    def _load_ontology(url: str, download_path: str, use_cache: bool = True) -> GraphDocument:
+        """Downloads ontology if needed, and loads it."""
+        if not os.path.exists(download_path) and use_cache:
+            r = requests.get(url)
+            with open(download_path, "wb") as f:
+                f.write(r.content)
+            return json_loader.load(str(download_path), target_class=GraphDocument)
+        elif use_cache:
+            return json_loader.load(str(download_path), target_class=GraphDocument)
+        return json_loader.load(url, target_class=GraphDocument)
+
+    def _load_and_convert(self, outpath: str, obograph_path: str, dl_url: str = None) -> CodeSystem:
+        """Loads and converts an ontology."""
+        if dl_url:
+            gd: GraphDocument = self._load_ontology(dl_url, obograph_path)
+        else:
+            gd: GraphDocument = json_loader.load(str(obograph_path), target_class=GraphDocument)
+        self.converter.dump(gd, outpath, include_all_predicates=True)
+        return json_loader.load(str(outpath), target_class=CodeSystem)
 
     def setUp(self):
+        """Set up tests"""
         self.converter = OboGraphToFHIRConverter()
         self.converter.curie_converter = curies.Converter.from_prefix_map(get_default_prefix_map())
         self.compliance_tester = ComplianceTester(self)
 
-    def test_convert(self):
-        """Tests parsing then converting to fhir documents."""
-        gd: GraphDocument = json_loader.load(str(ONT), target_class=GraphDocument)
-        self.converter.dump(gd, OUT, include_all_predicates=True)
-        cs: CodeSystem
-        cs = json_loader.load(str(OUT), target_class=CodeSystem)
+    def test_convert_go_nucleus(self):
+        """General test & specifis for go nucleus."""
+        ont = INPUT_DIR / "go-nucleus.json"
+        out = OUTPUT_DIR / "CodeSystem-go-nucleus.json"
+        cs: CodeSystem = self._load_and_convert(out, ont)
         self.assertEqual("CodeSystem", cs.resourceType)
         [nucleus_concept] = [c for c in cs.concept if c.code == NUCLEUS]
         self.assertEqual("nucleus", nucleus_concept.display)
@@ -35,3 +59,45 @@ class OboGraphToFHIRTest(unittest.TestCase):
         parents = [x for x in nucleus_concept.property if x.code == "parent"]
         self.assertEqual(len(parents), 1)
         self.assertTrue(parents[0].valueCode == IMBO)
+
+    def test_convert_mondo(self):
+        """Tests specific to Mondo."""
+        if DOWNLOAD_TESTS_ON:
+            dl_url = (
+                "https://github.com/"
+                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2022-12-20/mondo.owl.obographs.json"
+            )
+            dl_path = OUTPUT_DIR / "mondo.owl.obographs.json"
+            out = OUTPUT_DIR / "CodeSystem-Mondo.json"
+            cs: CodeSystem = self._load_and_convert(out, dl_path, dl_url)
+            self.assertGreater(cs.concept, 40000)
+            prop_uris: List[str] = [p.uri for p in cs.property]
+            self.assertIn("http://purl.obolibrary.org/obo/RO_0002353", prop_uris)
+
+    def test_convert_hpo(self):
+        """Tests specific to HPO."""
+        if DOWNLOAD_TESTS_ON:
+            dl_url = (
+                "https://github.com/"
+                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2022-12-20/hpo.owl.obographs.json"
+            )
+            dl_path = OUTPUT_DIR / "hpo.owl.obographs.json"
+            out = OUTPUT_DIR / "CodeSystem-HPO.json"
+            cs: CodeSystem = self._load_and_convert(out, dl_path, dl_url)
+            self.assertGreater(cs.concept, 30000)
+            prop_uris: List[str] = [p.uri for p in cs.property]
+            self.assertIn("http://purl.obolibrary.org/obo/RO_0002353", prop_uris)
+
+    def test_convert_comploinc(self):
+        """Tests specific to CompLOINC."""
+        if DOWNLOAD_TESTS_ON:
+            dl_url = (
+                "https://github.com/"
+                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2022-12-20/comploinc.owl.obographs.json"
+            )
+            dl_path = OUTPUT_DIR / "comploinc.owl.obographs.json"
+            out = OUTPUT_DIR / "CodeSystem-CompLOINC.json"
+            cs: CodeSystem = self._load_and_convert(out, dl_path, dl_url)
+            self.assertGreater(cs.concept, 5000)
+            prop_uris: List[str] = [p.uri for p in cs.property]
+            self.assertIn("https://loinc.org/hasComponent", prop_uris)


### PR DESCRIPTION
Updates
```
FHIR
- Add: unit tests for specific ontologies
- Add: unit test helpers to download and use cache
- Update: LinkML: CodeSystemProperty
- Update: OboGraph to FHIR Converter: Now populates CodeSystem.property
```