### PR TITLE
More FHIR updates

### DIFF
--- a/docs/howtos/fhir-conversions.rst
+++ b/docs/howtos/fhir-conversions.rst
@@ -1,0 +1,64 @@
+FHIR Conversions
+========================
+
+CLI
+===============
+The general pattern is from the CLI is:
+
+.. code-block:: bash
+
+    $ runoak -i INPUT-SPEC dump -O FORMAT -o OUTPUT-FILE
+
+The `fhirjson` format includes a --config-file / -c parameter for its additional parameters.
+
+Example:
+
+.. code-block:: bash
+
+    $ runoak --i go-nucleus.obo dump -o CodeSystem-go-nucleus.json -O fhirjson -c tests/input/fhir_config_example.json
+
+Config file
+===============
+
+Options:  
+
+code_system_id: _The code system ID to use for identification on the server uploaded to.
+See: https://hl7.org/fhir/resource-definitions.html#Resource.id
+
+code_system_url: _Canonical URL for the code system.
+See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url
+
+native_uri_stems: _A comma-separated list of URI stems that will be used to determine whether a
+concept is native to the CodeSystem. For example, for OMIM, the following URI stems are native:
+https://omim.org/entry/, https://omim.org/phenotypicSeries/PS
+
+include_all_predicates (default=True): Include the maximal amount of predicates. Changes the default behavior from
+only exporting: IS_A
+
+use_curies_native_concepts (default=False): _FHIR conventionally uses codes for references to
+concepts that are native to a given CodeSystem. With this option, references will be CURIEs instead.
+
+use_curies_foreign_concepts (default=False): _Typical FHIR CodeSystems do not contain any
+concepts that are not native to that CodeSystem. In cases where they do appear, this converter defaults to URIs for
+references, unless this flag is present, in which case the converter will attempt to construct CURIEs.
+
+predicate_period_replacement (default=False): _Predicates URIs populated into `CodeSystem.
+concept.property.code` and `CodeSystem.concept.property.code`, but the popular FHIR server "HAPI" has a bug in whih
+periods '.' cause errors. If this flag is present, periods will be replaced with underscores '_'.
+
+Example:
+
+
+.. code-block:: json
+
+    {
+        "code_system_id": "HPO",
+        "code_system_url": "http://purl.obolibrary.org/obo/hp.owl",
+            "native_uri_stems": [
+                "http://purl.obolibrary.org/obo/HP_"
+            ],
+        "include_all_predicates": true,
+        "use_curies_native_concepts": false,
+        "use_curies_foreign_concepts": false,
+        "predicate_period_replacement": true
+    }

--- a/docs/howtos/fhir-conversions.rst
+++ b/docs/howtos/fhir-conversions.rst
@@ -1,15 +1,37 @@
 FHIR Conversions
-========================
+================
+
+:term:`FHIR` (Fast Healthcare Interoperability Resources) is a standard for exchanging healthcare data.
+
+OAK includes methods for converting ontologies or ontology fragments to FHIR CodeSystems.
+However, there is no agreed-upon standard way of converting ontologies to FHIR, because
+each ontology has its own conventions and metadata vocabularies, and FHIR makes some
+assumptions that don't hold for ontologies in OBO such as all terms belonging to
+the same code system.
+
+For this reason we make FHIR conversion highly configurable to suit the needs
+of a particular project or FHIR server.
 
 CLI
-===============
-The general pattern is from the CLI is:
+---
+
+Here we will use the OAK ``dump`` command to export an entire ontology to FHIR.
+
+The general pattern for the ``dump`` command is from the CLI is:
 
 .. code-block:: bash
 
-    $ runoak -i INPUT-SPEC dump -O FORMAT -o OUTPUT-FILE
+    $ runoak -i INPUT dump -O FORMAT -o OUTPUT-FILE
+
+For dumping to the FHIR json serialization, use ``fhirjson`` as the format:
+
+.. code-block:: bash
+
+    $ runoak -i INPUT dump -O fhirjson -o OUTPUT-FILE
+
 
 The `fhirjson` format includes a --config-file / -c parameter for its additional parameters.
+
 
 Example:
 
@@ -18,7 +40,7 @@ Example:
     $ runoak --i go-nucleus.obo dump -o CodeSystem-go-nucleus.json -O fhirjson -c tests/input/fhir_config_example.json
 
 Config file
-===============
+-----------
 
 Options:  
 

--- a/docs/howtos/fhir-conversions.rst
+++ b/docs/howtos/fhir-conversions.rst
@@ -42,6 +42,8 @@ Example:
 Config file
 -----------
 
+See :ref:`obo_graph_to_fhir_converter` for the full list of options.
+
 Options:  
 
 code_system_id: _The code system ID to use for identification on the server uploaded to.

--- a/docs/howtos/index.rst
+++ b/docs/howtos/index.rst
@@ -13,6 +13,7 @@ How-To Guides
    :maxdepth: 3
    :caption: Contents:
 
+   fhir-conversions
    perform-lexical-matching
    roll-up-annotations-to-a-subset
    validate-an-obo-ontology

--- a/docs/howtos/index.rst
+++ b/docs/howtos/index.rst
@@ -13,12 +13,12 @@ How-To Guides
    :maxdepth: 3
    :caption: Contents:
 
-   fhir-conversions
    perform-lexical-matching
    roll-up-annotations-to-a-subset
    validate-an-obo-ontology
    visualize-ontology-subgraphs
    write-a-plugin
+   fhir-conversions
 
 
 

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -2300,7 +2300,7 @@ def descendants(
     code_system_url: For `fhirjson` only. Canonical URL for the code system.
     See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url
 
-    native_uri_stems: For `fhirjson` only. A comma-separated list of URI stems that will be used to determine whether a
+    native_uri_stems: For `fhirjson` only. A list of URI stems that will be used to determine whether a
     concept is native to the CodeSystem. For example, for OMIM, the following URI stems are native:
     https://omim.org/entry/, https://omim.org/phenotypicSeries/PS
 
@@ -2353,6 +2353,8 @@ def dump(terms, output, output_type: str, config_file: str = None, **kwargs):
     Example:
 
         runoak -i pato.owl dump -o pato.ttl -O turtle
+
+
 
     Currently each implementation only supports a subset of formats.
 

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -2287,10 +2287,35 @@ def descendants(
 @click.argument("terms", nargs=-1)
 @click.option("-o", "--output", help="Path to output file")
 @click.option(
-    "--include-all-predicates/--no-include-all-predicates",
+    "--code-system-id",
     default=False,
-    show_default=True,
-    help="For formats that export only IS_A by default, this will include all possible predicates",
+    help="For `fhirjson` only. The code system ID to use for identification on the server uploaded to. "
+         "See: https://hl7.org/fhir/resource-definitions.html#Resource.id",
+)
+@click.option(
+    "--code-system-url",
+    default=False,
+    help="For `fhirjson` only. Canonical URL for the code system. "
+         "See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url",
+)
+@click.option(
+    "--use-curies-native-concepts/--no-use-curies-native-concepts",
+    default=False,
+    help="For `fhirjson` only. FHIR conventionally uses codes for references to concepts that are native to a given CodeSystem. "
+    "With this option, references will be CURIEs instead.",
+)
+@click.option(
+    "--use-curies-foreign-concepts/--no-use-curies-foreign-concepts",
+    default=False,
+    help="For `fhirjson` only. Typical FHIR CodeSystems do not contain any concepts that are not native to that CodeSystem. In "
+    "cases where they do appear, this converter defaults to URIs for references, unless this flag is present, in "
+    "which case the converter will attempt to construct CURIEs.",
+)
+@click.option(
+    "--native-uri-stems",
+    help="For `fhirjson` only. A comma-separated list of URI stems that will be used to determine whether a concept is native to "
+    "the CodeSystem. For example, for OMIM, the following URI stems are native: "
+    "https://omim.org/entry/,https://omim.org/phenotypicSeries/PS",
 )
 @click.option(
     "--enforce-canonical-ordering/--no-enforce-canonical-ordering",

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -2290,31 +2290,31 @@ def descendants(
     "--code-system-id",
     default=False,
     help="For `fhirjson` only. The code system ID to use for identification on the server uploaded to. "
-         "See: https://hl7.org/fhir/resource-definitions.html#Resource.id",
+    "See: https://hl7.org/fhir/resource-definitions.html#Resource.id",
 )
 @click.option(
     "--code-system-url",
     default=False,
     help="For `fhirjson` only. Canonical URL for the code system. "
-         "See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url",
+    "See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url",
 )
 @click.option(
     "--use-curies-native-concepts/--no-use-curies-native-concepts",
     default=False,
-    help="For `fhirjson` only. FHIR conventionally uses codes for references to concepts that are native to a given CodeSystem. "
-    "With this option, references will be CURIEs instead.",
+    help="For `fhirjson` only. FHIR conventionally uses codes for references to concepts that are native to a given "
+    "CodeSystem. With this option, references will be CURIEs instead.",
 )
 @click.option(
     "--use-curies-foreign-concepts/--no-use-curies-foreign-concepts",
     default=False,
-    help="For `fhirjson` only. Typical FHIR CodeSystems do not contain any concepts that are not native to that CodeSystem. In "
-    "cases where they do appear, this converter defaults to URIs for references, unless this flag is present, in "
-    "which case the converter will attempt to construct CURIEs.",
+    help="For `fhirjson` only. Typical FHIR CodeSystems do not contain any concepts that are not native to that "
+    "CodeSystem. In cases where they do appear, this converter defaults to URIs for references, unless this flag is "
+    "present, in which case the converter will attempt to construct CURIEs.",
 )
 @click.option(
     "--native-uri-stems",
-    help="For `fhirjson` only. A comma-separated list of URI stems that will be used to determine whether a concept is native to "
-    "the CodeSystem. For example, for OMIM, the following URI stems are native: "
+    help="For `fhirjson` only. A comma-separated list of URI stems that will be used to determine whether a concept is "
+    "native to the CodeSystem. For example, for OMIM, the following URI stems are native: "
     "https://omim.org/entry/,https://omim.org/phenotypicSeries/PS",
 )
 @click.option(

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -2291,45 +2291,7 @@ def descendants(
 @click.option(
     "-c",
     "--config-file",
-    help="""Config file for additional params. Presently used by  `fhirjson` only.
-
-    Options:
-    code_system_id: For `fhirjson` only. The code system ID to use for identification on the server uploaded to.
-    See: https://hl7.org/fhir/resource-definitions.html#Resource.id
-
-    code_system_url: For `fhirjson` only. Canonical URL for the code system.
-    See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url
-
-    native_uri_stems: For `fhirjson` only. A list of URI stems that will be used to determine whether a
-    concept is native to the CodeSystem. For example, for OMIM, the following URI stems are native:
-    https://omim.org/entry/, https://omim.org/phenotypicSeries/PS
-
-    include_all_predicates (default=True): Include the maximal amount of predicates. Changes the default behavior from
-    only exporting: IS_A
-
-    use_curies_native_concepts (default=False): For `fhirjson` only. FHIR conventionally uses codes for references to
-    concepts that are native to a given CodeSystem. With this option, references will be CURIEs instead.
-
-    use_curies_foreign_concepts (default=False): For `fhirjson` only. Typical FHIR CodeSystems do not contain any
-    concepts that are not native to that CodeSystem. In cases where they do appear, this converter defaults to URIs for
-    references, unless this flag is present, in which case the converter will attempt to construct CURIEs.
-
-    predicate_period_replacement (default=False): For `fhirjson` only. Predicates URIs populated into `CodeSystem.
-    concept.property.code` and `CodeSystem.concept.property.code`, but the popular FHIR server "HAPI" has a bug in which
-    periods '.' cause errors. If this flag is present, periods will be replaced with underscores '_'.
-
-    Example:
-    {
-        "code_system_id": "HPO",
-        "code_system_url": "http://purl.obolibrary.org/obo/hp.owl",
-            "native_uri_stems": [
-                "http://purl.obolibrary.org/obo/HP_"
-            ],
-        "include_all_predicates": true,
-        "use_curies_native_concepts": false,
-        "use_curies_foreign_concepts": false,
-        "predicate_period_replacement": true
-    }""",
+    help="""Config file for additional params. Presently used by  `fhirjson` only.""",
 )
 @click.option(
     "--enforce-canonical-ordering/--no-enforce-canonical-ordering",
@@ -2354,7 +2316,15 @@ def dump(terms, output, output_type: str, config_file: str = None, **kwargs):
 
         runoak -i pato.owl dump -o pato.ttl -O turtle
 
+    You can also pass in a JSON configuration file to parameterize the dump process.
 
+    Currently this is only used for fhirjson dumps, the configuration options are specified here:
+
+    https://incatools.github.io/ontology-access-kit/converters/obo-graph-to-fhir.html
+
+    Example:
+
+        runoak -i pato.owl dump -o pato.ttl -O fhirjson -c fhir_config.json -o pato.fhir.json
 
     Currently each implementation only supports a subset of formats.
 

--- a/src/oaklib/converters/obo_graph_to_fhir_converter.py
+++ b/src/oaklib/converters/obo_graph_to_fhir_converter.py
@@ -87,23 +87,7 @@ class OboGraphToFHIRConverter(DataModelConverter):
 
         :param source: Source serialization.
         :param target: Target serialization.
-        :param code_system_id: The code system ID to use for identification on the server uploaded to.
-        See: https://hl7.org/fhir/resource-definitions.html#Resource.id
-        :param code_system_url: Canonical URL for the code system.
-        See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url
-        :param native_uri_stems: A comma-separated list of URI stems that will be used to determine whether a
-        concept is native to the CodeSystem. For example, for OMIM, the following URI stems are native:
-        https://omim.org/entry/, https://omim.org/phenotypicSeries/PS
-        :param include_all_predicates: Include the maximal amount of predicates. Changes the default behavior from only
-        exporting: IS_A
-        :param use_curies_native_concepts: FHIR conventionally uses codes for references to
-        concepts that are native to a given CodeSystem. With this option, references will be CURIEs instead.
-        :param use_curies_foreign_concepts: Typical FHIR CodeSystems do not contain any
-        concepts that are not native to that CodeSystem. In cases where they do appear, this converter defaults to URIs
-        for references, unless this flag is present, in which case the converter will attempt to construct CURIEs.
-        :param predicate_period_replacement: Predicates URIs populated into `CodeSystem.concept.property.code`
-        and `CodeSystem.concept.property.code`, but the popular FHIR server "HAPI" has a bug in whih periods '.' cause
-        errors. If this flag is present, periods will be replaced with underscores '_'.
+        :param kwargs: Additional keyword arguments passed to :ref:`convert`.
         """
         cs = self.convert(
             source,
@@ -153,7 +137,24 @@ class OboGraphToFHIRConverter(DataModelConverter):
             "designation": [
          ...
 
-        :return:
+        :param code_system_id: The code system ID to use for identification on the server uploaded to.
+        See: https://hl7.org/fhir/resource-definitions.html#Resource.id
+        :param code_system_url: Canonical URL for the code system.
+        See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url
+        :param native_uri_stems: A comma-separated list of URI stems that will be used to determine whether a
+        concept is native to the CodeSystem. For example, for OMIM, the following URI stems are native:
+        https://omim.org/entry/, https://omim.org/phenotypicSeries/PS
+        :param include_all_predicates: Include the maximal amount of predicates. Changes the default behavior from only
+        exporting: IS_A
+        :param use_curies_native_concepts: FHIR conventionally uses codes for references to
+        concepts that are native to a given CodeSystem. With this option, references will be CURIEs instead.
+        :param use_curies_foreign_concepts: Typical FHIR CodeSystems do not contain any
+        concepts that are not native to that CodeSystem. In cases where they do appear, this converter defaults to URIs
+        for references, unless this flag is present, in which case the converter will attempt to construct CURIEs.
+        :param predicate_period_replacement: Predicates URIs populated into `CodeSystem.concept.property.code`
+        and `CodeSystem.concept.property.code`, but the popular FHIR server "HAPI" has a bug in whih periods '.' cause
+        errors. If this flag is present, periods will be replaced with underscores '_'.
+        :return: FHIR CodeSystem object
         """
         if target is None:
             target = CodeSystem()

--- a/src/oaklib/converters/obo_graph_to_fhir_converter.py
+++ b/src/oaklib/converters/obo_graph_to_fhir_converter.py
@@ -53,11 +53,6 @@ SCOPE_DISPLAY = {
 
 @dataclass
 class OboGraphToFHIRConverter(DataModelConverter):
-    # TODO: change to inherit from OboGraphToOboFormatConverter instead?
-    # todo: Fix: these are currently unresolvable (noinspection PyUnresolvedReferences):
-    #  from oaklib.utilities.obograph_utils import load_obograph
-    #  from oaklib.utilities.curie_converter import CurieConverter
-    # noinspection PyUnresolvedReferences
     """Converts from OboGraph to FHIR.
 
     - An ontology is mapped to a FHIR `CodeSystem <https://build.fhir.org/codesystem.html>`_.
@@ -85,13 +80,6 @@ class OboGraphToFHIRConverter(DataModelConverter):
         self,
         source: GraphDocument,
         target: str = None,
-        code_system_id: str = None,
-        code_system_url: str = None,
-        include_all_predicates: bool = True,
-        native_uri_stems: List[str] = None,
-        use_curies_native_concepts: bool = False,
-        use_curies_foreign_concepts: bool = True,
-        predicate_period_replacement: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -119,13 +107,6 @@ class OboGraphToFHIRConverter(DataModelConverter):
         """
         cs = self.convert(
             source,
-            code_system_id=code_system_id,
-            code_system_url=code_system_url,
-            include_all_predicates=include_all_predicates,
-            native_uri_stems=native_uri_stems,
-            use_curies_native_concepts=use_curies_native_concepts,
-            use_curies_foreign_concepts=use_curies_foreign_concepts,
-            predicate_period_replacement=predicate_period_replacement,
             **kwargs,
         )
         json_str = json_dumper.dumps(cs, inject_type=False)

--- a/src/oaklib/converters/obo_graph_to_fhir_converter.py
+++ b/src/oaklib/converters/obo_graph_to_fhir_converter.py
@@ -6,7 +6,7 @@ Resources
 """
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 import rdflib
 from linkml_runtime.dumpers import json_dumper
@@ -27,7 +27,7 @@ from oaklib.datamodels.vocabulary import (
     HAS_NARROW_SYNONYM,
     HAS_RELATED_SYNONYM,
 )
-from oaklib.types import CURIE
+from oaklib.types import CURIE, URI
 from oaklib.utilities.obograph_utils import index_graph_edges_by_subject
 
 TRIPLE = Tuple[rdflib.URIRef, rdflib.URIRef, Any]
@@ -103,7 +103,7 @@ class OboGraphToFHIRConverter(DataModelConverter):
         include_all_predicates: bool = True,
         native_uri_stems: List[str] = None,
         use_curies_native_concepts: bool = False,
-        use_curies_foreign_concepts: bool = False,
+        use_curies_foreign_concepts: bool = True,
         **kwargs,
     ) -> None:
         """
@@ -143,7 +143,7 @@ class OboGraphToFHIRConverter(DataModelConverter):
         include_all_predicates: bool = True,
         native_uri_stems: List[str] = None,
         use_curies_native_concepts: bool = False,
-        use_curies_foreign_concepts: bool = False,
+        use_curies_foreign_concepts: bool = True,
         **kwargs,
     ) -> CodeSystem:
         """
@@ -190,7 +190,7 @@ class OboGraphToFHIRConverter(DataModelConverter):
         include_all_predicates: bool = True,
         native_uri_stems: List[str] = None,
         use_curies_native_concepts: bool = False,
-        use_curies_foreign_concepts: bool = False,
+        use_curies_foreign_concepts: bool = True,
     ) -> CodeSystem:
         target.id = source.id
         edges_by_subject = index_graph_edges_by_subject(source)
@@ -223,12 +223,12 @@ class OboGraphToFHIRConverter(DataModelConverter):
     def _convert_node(
         self,
         source: Node,
-        index: Dict[CURIE, List[Edge]],
+        index: Dict[Union[URI, CURIE], List[Edge]],
         target: CodeSystem,
         include_all_predicates: bool = True,
         native_uri_stems: List[str] = None,
         use_curies_native_concepts: bool = False,
-        use_curies_foreign_concepts: bool = False,
+        use_curies_foreign_concepts: bool = True,
     ) -> Concept:
         """Converts a node to a FHIR Concept. Also collects predicates to be included in CodeSystem.property."""
         # TODO: Use new flags

--- a/src/oaklib/converters/obo_graph_to_fhir_converter.py
+++ b/src/oaklib/converters/obo_graph_to_fhir_converter.py
@@ -64,25 +64,11 @@ class OboGraphToFHIRConverter(DataModelConverter):
     - Each node in the OboGraph is converted to a _FHIR Concept_.
     - Each CURIE/URI in the OboGraph is treated as a CURIE when it becomes a code (e.g. "HP:0000001")
 
-         - TODO: make this configurable
-
     - Each edge in the OboGraph is converted to a _FHIR ConceptProperty_ if the `include_all_predicates` param is
       True. Otherwise, will only convert edges if the predicate is in the `DIRECT_PREDICATE_MAP`.
     - Each synonym in the OboGraph is converted to a _FHIR ConceptDesignation_.
 
         - The synonym predicate is mapped to a _FHIR Coding_, using the `SCOPE_MAP`.
-
-    To use:
-
-        >>> from oaklib.converters.obo_graph_to_fhir_converter import OboGraphToFHIRConverter
-        >>> from oaklib.datamodels.obograph import GraphDocument
-        >>> from oaklib.utilities.obograph_utils import load_obograph
-        >>> from oaklib.utilities.curie_converter import CurieConverter
-        >>> from linkml_runtime.dumpers import json_dumper
-        >>> converter = OboGraphToFHIRConverter(curie_converter=CurieConverter())
-        >>> graph = load_obograph("hp.obo.json")
-        >>> code_system = converter.convert(graph)
-        >>> print(json_dumper.dumps(code_system))
 
     To run on the command line:
 
@@ -165,6 +151,26 @@ class OboGraphToFHIRConverter(DataModelConverter):
     ) -> CodeSystem:
         """
         Convert an OBO Graph Document to a FHIR CodingSystem
+
+        To use:
+
+        >>> from oaklib.converters.obo_graph_to_fhir_converter import OboGraphToFHIRConverter
+        >>> from oaklib.datamodels.obograph import GraphDocument
+        >>> from linkml_runtime.dumpers import json_dumper
+        >>> from linkml_runtime.loaders import json_loader
+        >>> converter = OboGraphToFHIRConverter()
+        >>> graph = json_loader.load("tests/input/hp_test.json", target_class=GraphDocument)
+        >>> code_system = converter.convert(graph)
+        >>> print(json_dumper.dumps(code_system))
+        <BLANKLINE>
+        ...
+         "concept": [
+            {
+            "code": "HP:0012639",
+            "display": "Abnormal nervous system morphology",
+            "definition": "A structural anomaly of the nervous system.",
+            "designation": [
+         ...
 
         :return:
         """

--- a/src/oaklib/converters/obo_graph_to_fhir_converter.py
+++ b/src/oaklib/converters/obo_graph_to_fhir_converter.py
@@ -138,22 +138,28 @@ class OboGraphToFHIRConverter(DataModelConverter):
          ...
 
         :param code_system_id: The code system ID to use for identification on the server uploaded to.
-        See: https://hl7.org/fhir/resource-definitions.html#Resource.id
+                               See: https://hl7.org/fhir/resource-definitions.html#Resource.id
         :param code_system_url: Canonical URL for the code system.
-        See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url
-        :param native_uri_stems: A comma-separated list of URI stems that will be used to determine whether a
-        concept is native to the CodeSystem. For example, for OMIM, the following URI stems are native:
-        https://omim.org/entry/, https://omim.org/phenotypicSeries/PS
-        :param include_all_predicates: Include the maximal amount of predicates. Changes the default behavior from only
-        exporting: IS_A
+                                See: https://hl7.org/fhir/codesystem-definitions.html#CodeSystem.url
+        :param native_uri_stems: A list of URI stems that will be used to determine whether a
+                                 concept is native to the CodeSystem. (not implemented)
+                                 For example, for OMIM, the following URI stems are native:
+                                 https://omim.org/entry/, https://omim.org/phenotypicSeries/PS
+        :param include_all_predicates: Include the maximal amount of predicates.
+                                       Changes the default behavior from only
+                                       exporting: IS_A (rdfs:subClassOf)
         :param use_curies_native_concepts: FHIR conventionally uses codes for references to
-        concepts that are native to a given CodeSystem. With this option, references will be CURIEs instead.
+                                           concepts that are native to a given CodeSystem. With this option,
+                                           references will be CURIEs instead. (not implemented)
         :param use_curies_foreign_concepts: Typical FHIR CodeSystems do not contain any
-        concepts that are not native to that CodeSystem. In cases where they do appear, this converter defaults to URIs
-        for references, unless this flag is present, in which case the converter will attempt to construct CURIEs.
+                                            concepts that are not native to that CodeSystem. In cases where they
+                                            do appear, this converter defaults to URIs
+                                            for references, unless this flag is present, in which case the converter
+                                            will attempt to construct CURIEs. (not implemented)
         :param predicate_period_replacement: Predicates URIs populated into `CodeSystem.concept.property.code`
-        and `CodeSystem.concept.property.code`, but the popular FHIR server "HAPI" has a bug in whih periods '.' cause
-        errors. If this flag is present, periods will be replaced with underscores '_'.
+                                             and `CodeSystem.concept.property.code`, but the popular FHIR server "HAPI"
+                                             has a bug in whih periods '.' cause errors. If this flag is present,
+                                             periods will be replaced with underscores '_'.
         :return: FHIR CodeSystem object
         """
         if target is None:
@@ -177,7 +183,13 @@ class OboGraphToFHIRConverter(DataModelConverter):
         return target
 
     def code(self, uri: CURIE) -> str:
-        """Convert a code"""
+        """Convert a code.
+
+        This is a wrapper onto curie_converter.compress
+
+        :param uri: URI or CURIE to convert
+        :return: CURIE
+        """
         if not self.curie_converter:
             return uri
         curie = self.curie_converter.compress(uri)

--- a/src/oaklib/datamodels/fhir.yaml
+++ b/src/oaklib/datamodels/fhir.yaml
@@ -131,11 +131,10 @@ classes:
         range: string  # Pattern: [^\s]+(\s[^\s]+)* / See: https://hl7.org/fhir/datatypes.html#code
         required: true
       uri:
-        range: uriorcurie
         required: false
+        range: uri
       description:
         range: string
-        required: false
       type:
         # TODO: type: an enum of: code | Coding | string | integer | boolean | dateTime | decimal
         #  https://hl7:org/fhir/valueset-concept-property-type.html

--- a/tests/input/fhir_config_example.json
+++ b/tests/input/fhir_config_example.json
@@ -1,0 +1,11 @@
+{
+    "code_system_id": "HPO",
+    "code_system_url": "http://purl.obolibrary.org/obo/hp.owl",
+    "native_uri_stems": [
+        "http://purl.obolibrary.org/obo/HP_"
+    ],
+    "include_all_predicates": true,
+    "use_curies_native_concepts": false,
+    "use_curies_foreign_concepts": false,
+    "predicate_period_replacement": true
+}

--- a/tests/input/hp_test.json
+++ b/tests/input/hp_test.json
@@ -1,0 +1,383 @@
+{
+  "graphs": [
+    {
+      "id": "obo:hp.owl-transformed",
+      "nodes": [
+        {
+          "id": "HP:0012639",
+          "lbl": "Abnormal nervous system morphology",
+          "type": "CLASS",
+          "meta": {
+            "definition": {
+              "val": "A structural anomaly of the nervous system."
+            },
+            "xrefs": [
+              {
+                "val": "Fyler:4135"
+              },
+              {
+                "val": "Fyler:4300"
+              },
+              {
+                "val": "UMLS:C4022810"
+              }
+            ],
+            "synonyms": [
+              {
+                "pred": "hasExactSynonym",
+                "val": "Abnormal shape of nervous system"
+              },
+              {
+                "pred": "hasExactSynonym",
+                "val": "Abnormality of nervous system morphology"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "oio:created_by",
+                "val": "peter"
+              },
+              {
+                "pred": "oio:creation_date",
+                "val": "2014-01-19T08:03:08Z"
+              },
+              {
+                "pred": "oio:id",
+                "val": "HP:0012639"
+              },
+              {
+                "pred": "owl:equivalentClass",
+                "val": "_:riog00127440"
+              }
+            ]
+          }
+        },
+        {
+          "id": "HP:0001291",
+          "lbl": "Abnormal cranial nerve morphology",
+          "type": "CLASS",
+          "meta": {
+            "definition": {
+              "val": "Structural abnormality affecting one or more of the cranial nerves, which emerge directly from the brain stem."
+            },
+            "xrefs": [
+              {
+                "val": "UMLS:C1854510"
+              },
+              {
+                "val": "UMLS:C4020872"
+              }
+            ],
+            "synonyms": [
+              {
+                "pred": "hasExactSynonym",
+                "val": "Abnormality of cranial nerve"
+              },
+              {
+                "pred": "hasExactSynonym",
+                "val": "Abnormality of the cranial nerves"
+              },
+              {
+                "pred": "hasExactSynonym",
+                "val": "Cranial nerve disease"
+              },
+              {
+                "pred": "hasExactSynonym",
+                "val": "Cranial nerve involvement"
+              },
+              {
+                "pred": "hasRelatedSynonym",
+                "val": "Cranial nerve abnormality"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "oio:hasAlternativeId",
+                "val": "HP:0003480"
+              },
+              {
+                "pred": "oio:id",
+                "val": "HP:0001291"
+              },
+              {
+                "pred": "owl:equivalentClass",
+                "val": "_:riog00067504"
+              }
+            ]
+          }
+        },
+        {
+          "id": "HP:0000707",
+          "lbl": "Abnormality of the nervous system",
+          "type": "CLASS",
+          "meta": {
+            "definition": {
+              "val": "An abnormality of the nervous system."
+            },
+            "xrefs": [
+              {
+                "val": "MSH:D009421"
+              },
+              {
+                "val": "SNOMEDCT_US:88425004"
+              },
+              {
+                "val": "UMLS:C0497552"
+              }
+            ],
+            "synonyms": [
+              {
+                "pred": "hasBroadSynonym",
+                "val": "Brain and/or spinal cord issue"
+              },
+              {
+                "pred": "hasExactSynonym",
+                "val": "Abnormality of the nervous system"
+              },
+              {
+                "pred": "hasExactSynonym",
+                "val": "Neurologic abnormalities"
+              },
+              {
+                "pred": "hasExactSynonym",
+                "val": "Neurological abnormality"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "oio:hasAlternativeId",
+                "val": "HP:0001333"
+              },
+              {
+                "pred": "oio:hasAlternativeId",
+                "val": "HP:0006987"
+              },
+              {
+                "pred": "oio:id",
+                "val": "HP:0000707"
+              },
+              {
+                "pred": "owl:equivalentClass",
+                "val": "_:riog00064112"
+              },
+              {
+                "pred": "rdfs:comment",
+                "val": "The nervous system comprises the neuraxis (brain, spinal cord, and ventricles), the autonomic nervous system, the enteric nervous system, and the peripheral nervous system."
+              }
+            ]
+          }
+        },
+        {
+          "id": "HP:0045010",
+          "lbl": "Abnormality of peripheral nerves",
+          "type": "CLASS",
+          "meta": {
+            "xrefs": [
+              {
+                "val": "UMLS:C4022400"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "oio:created_by",
+                "val": "HPO:skoehler"
+              },
+              {
+                "pred": "owl:equivalentClass",
+                "val": "_:riog00145143"
+              }
+            ]
+          }
+        },
+        {
+          "id": "HP:0000759",
+          "lbl": "Abnormal peripheral nervous system morphology",
+          "type": "CLASS",
+          "meta": {
+            "definition": {
+              "val": "A structural abnormality of the peripheral nervous system, which is composed of the nerves that lead to or branch off from the central nervous system. This includes the cranial nerves (olfactory and optic nerves are technically part of the central nervous system)."
+            },
+            "xrefs": [
+              {
+                "val": "MSH:D010523"
+              },
+              {
+                "val": "SNOMEDCT_US:302226006"
+              },
+              {
+                "val": "SNOMEDCT_US:42658009"
+              },
+              {
+                "val": "UMLS:C0031117"
+              },
+              {
+                "val": "UMLS:C4025831"
+              }
+            ],
+            "synonyms": [
+              {
+                "pred": "hasExactSynonym",
+                "val": "Abnormal peripheral nervous system structure"
+              },
+              {
+                "pred": "hasRelatedSynonym",
+                "val": "Peripheral nervous system disease"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "oio:hasAlternativeId",
+                "val": "HP:0003483"
+              },
+              {
+                "pred": "oio:id",
+                "val": "HP:0000759"
+              },
+              {
+                "pred": "owl:equivalentClass",
+                "val": "_:riog00064522"
+              },
+              {
+                "pred": "rdfs:comment",
+                "val": "The peripheral nervous system is divided into autonomic and somatic components, which both include afferent (sensory) and efferent (motor) nerves."
+              }
+            ]
+          }
+        },
+        {
+          "id": "HP:0000118",
+          "lbl": "Phenotypic abnormality",
+          "type": "CLASS",
+          "meta": {
+            "definition": {
+              "val": "A phenotypic abnormality."
+            },
+            "xrefs": [
+              {
+                "val": "UMLS:C4021819"
+              }
+            ],
+            "synonyms": [
+              {
+                "pred": "hasExactSynonym",
+                "val": "Organ abnormality"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "oio:id",
+                "val": "HP:0000118"
+              },
+              {
+                "pred": "owl:equivalentClass",
+                "val": "_:riog00059340"
+              },
+              {
+                "pred": "rdfs:comment",
+                "val": "This is the root of the phenotypic abnormality subontology of the HPO."
+              }
+            ]
+          }
+        },
+        {
+          "id": "HP:0000001",
+          "lbl": "All",
+          "type": "CLASS",
+          "meta": {
+            "xrefs": [
+              {
+                "val": "UMLS:C0444868"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "oio:id",
+                "val": "HP:0000001"
+              },
+              {
+                "pred": "rdfs:comment",
+                "val": "Root of all terms in the Human Phenotype Ontology."
+              }
+            ]
+          }
+        },
+        {
+          "id": "HP:3000055",
+          "lbl": "Abnormality of inferior alveolar nerve",
+          "type": "CLASS",
+          "meta": {
+            "definition": {
+              "val": "An abnormality of an inferior alveolar nerve."
+            },
+            "xrefs": [
+              {
+                "val": "UMLS:C4073263"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "oio:created_by",
+                "val": "vasilevs"
+              },
+              {
+                "pred": "oio:creation_date",
+                "val": "2015-08-07T01:10:08Z"
+              },
+              {
+                "pred": "oio:id",
+                "val": "HP:3000055"
+              },
+              {
+                "pred": "owl:equivalentClass",
+                "val": "_:riog00159275"
+              }
+            ]
+          }
+        }
+      ],
+      "edges": [
+        {
+          "sub": "HP:0000118",
+          "pred": "rdfs:subClassOf",
+          "obj": "HP:0000001"
+        },
+        {
+          "sub": "HP:0000707",
+          "pred": "rdfs:subClassOf",
+          "obj": "HP:0000118"
+        },
+        {
+          "sub": "HP:0000759",
+          "pred": "rdfs:subClassOf",
+          "obj": "HP:0012639"
+        },
+        {
+          "sub": "HP:0001291",
+          "pred": "rdfs:subClassOf",
+          "obj": "HP:0000759"
+        },
+        {
+          "sub": "HP:0012639",
+          "pred": "rdfs:subClassOf",
+          "obj": "HP:0000707"
+        },
+        {
+          "sub": "HP:0045010",
+          "pred": "rdfs:subClassOf",
+          "obj": "HP:0000759"
+        },
+        {
+          "sub": "HP:3000055",
+          "pred": "rdfs:subClassOf",
+          "obj": "HP:0001291"
+        },
+        {
+          "sub": "HP:3000055",
+          "pred": "rdfs:subClassOf",
+          "obj": "HP:0045010"
+        }
+      ]
+    }
+  ],
+  "@type": "GraphDocument"
+}

--- a/tests/test_converters/test_obo_graph_to_fhir.py
+++ b/tests/test_converters/test_obo_graph_to_fhir.py
@@ -18,7 +18,9 @@ DOWNLOAD_TESTS_ON = True
 
 
 class OboGraphToFHIRTest(unittest.TestCase):
-    """Tests OBO JSON -> FHIR. Different ontologies have unique structures, so test some specifics for those."""
+    """Tests OBO JSON -> FHIR.
+
+    Different ontologies have unique structures, so test some specifics for those."""
 
     @staticmethod
     def _load_ontology(url: str, download_path: str, use_cache: bool = True) -> GraphDocument:
@@ -63,7 +65,7 @@ class OboGraphToFHIRTest(unittest.TestCase):
         self.compliance_tester = ComplianceTester(self)
 
     def test_convert_go_nucleus(self):
-        """General test & specifis for go nucleus."""
+        """General test & specific to go nucleus."""
         filename = "CodeSystem-go-nucleus"
         ont = INPUT_DIR / "go-nucleus.json"
         out = OUTPUT_DIR / f"{filename}.json"
@@ -82,6 +84,23 @@ class OboGraphToFHIRTest(unittest.TestCase):
         self.assertEqual(len(parents), 1)
         self.assertTrue(parents[0].valueCode == IMBO)
 
+    def test_convert_hp_subset(self):
+        """Test extracted subset of HPO."""
+        filename = "CodeSystem-hp_test"
+        ont = INPUT_DIR / "hp_test.json"
+        out = OUTPUT_DIR / f"{filename}.json"
+        cs: CodeSystem = self._load_and_convert(
+            out,
+            ont,
+            code_system_id=filename.replace("CodeSystem-", ""),
+            code_system_url="http://purl.obolibrary.org/obo/hp.owl",
+            native_uri_stems=["http://purl.obolibrary.org/obo/HP_"],
+        )
+        self.assertEqual("CodeSystem", cs.resourceType)
+        [nucleus_concept] = [c for c in cs.concept if c.code == "HP:0012639"]
+        self.assertEqual("Abnormal nervous system morphology", nucleus_concept.display)
+
+    @unittest.skip("TODO: change to an integration test")
     def test_convert_mondo(self):
         """Tests specific to Mondo."""
         if DOWNLOAD_TESTS_ON:
@@ -104,6 +123,7 @@ class OboGraphToFHIRTest(unittest.TestCase):
             prop_uris: List[str] = [p.uri for p in cs.property]
             self.assertIn("http://purl.obolibrary.org/obo/RO_0002353", prop_uris)
 
+    @unittest.skip("TODO: change to an integration test")
     def test_convert_hpo(self):
         """Tests specific to HPO."""
         if DOWNLOAD_TESTS_ON:
@@ -126,6 +146,7 @@ class OboGraphToFHIRTest(unittest.TestCase):
             prop_uris: List[str] = [p.uri for p in cs.property]
             self.assertIn("http://purl.obolibrary.org/obo/RO_0002353", prop_uris)
 
+    @unittest.skip("TODO: change to an integration test")
     def test_convert_comploinc(self):
         """Tests specific to CompLOINC."""
         if DOWNLOAD_TESTS_ON:
@@ -149,6 +170,7 @@ class OboGraphToFHIRTest(unittest.TestCase):
             prop_uris: List[str] = [p.uri for p in cs.property]
             self.assertIn("https://loinc.org/hasComponent", prop_uris)
 
+    @unittest.skip("TODO: change to an integration test")
     def test_convert_rxnorm(self):
         """Tests specific to Bioportal RXNORM.ttl."""
         if DOWNLOAD_TESTS_ON:
@@ -173,6 +195,7 @@ class OboGraphToFHIRTest(unittest.TestCase):
             # prop_uris: List[str] = [p.uri for p in cs.property]
             # self.assertIn("", prop_uris)
 
+    @unittest.skip("TODO: change to an integration test")
     def test_convert_so(self):
         """Tests specific to Sequence Ontology (SO)."""
         if DOWNLOAD_TESTS_ON:

--- a/tests/test_converters/test_obo_graph_to_fhir.py
+++ b/tests/test_converters/test_obo_graph_to_fhir.py
@@ -47,11 +47,13 @@ class OboGraphToFHIRTest(unittest.TestCase):
         else:
             gd: GraphDocument = json_loader.load(str(obograph_path), target_class=GraphDocument)
         self.converter.dump(
-            gd, outpath,
+            gd,
+            outpath,
             code_system_id=code_system_id,
             code_system_url=code_system_url,
             include_all_predicates=True,
-            native_uri_stems=native_uri_stems)
+            native_uri_stems=native_uri_stems,
+        )
         return json_loader.load(str(outpath), target_class=CodeSystem)
 
     def setUp(self):
@@ -62,14 +64,15 @@ class OboGraphToFHIRTest(unittest.TestCase):
 
     def test_convert_go_nucleus(self):
         """General test & specifis for go nucleus."""
-        _id = "CodeSystem-go-nucleus"
+        filename = "CodeSystem-go-nucleus"
         ont = INPUT_DIR / "go-nucleus.json"
-        out = OUTPUT_DIR / f"{_id}.json"
+        out = OUTPUT_DIR / f"{filename}.json"
         cs: CodeSystem = self._load_and_convert(
-            out, ont,
-            code_system_id=_id,
-            code_system_url='http://purl.obolibrary.org/obo/go.owl',
-            native_uri_stems=["http://purl.obolibrary.org/obo/GO_"]
+            out,
+            ont,
+            code_system_id=filename.replace("CodeSystem-", ""),
+            code_system_url="http://purl.obolibrary.org/obo/go.owl",
+            native_uri_stems=["http://purl.obolibrary.org/obo/GO_"],
         )
         self.assertEqual("CodeSystem", cs.resourceType)
         [nucleus_concept] = [c for c in cs.concept if c.code == NUCLEUS]
@@ -82,19 +85,20 @@ class OboGraphToFHIRTest(unittest.TestCase):
     def test_convert_mondo(self):
         """Tests specific to Mondo."""
         if DOWNLOAD_TESTS_ON:
-            _id = "CodeSystem-Mondo"
+            filename = "CodeSystem-mondo"
             dl_url = (
                 "https://github.com/"
-                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-09/mondo.owl.obographs.json"
+                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-13/mondo.owl.obographs.json"
             )
             dl_path = OUTPUT_DIR / "mondo.owl.obographs.json"
-            out = OUTPUT_DIR / f"{_id}.json"
+            out = OUTPUT_DIR / f"{filename}.json"
             cs: CodeSystem = self._load_and_convert(
-                out, dl_path,
+                out,
+                dl_path,
                 dl_url=dl_url,
-                code_system_id=_id,
-                code_system_url='http://purl.obolibrary.org/obo/mondo.owl',
-                native_uri_stems=["http://purl.obolibrary.org/obo/MONDO_"]
+                code_system_id=filename.replace("CodeSystem-", ""),
+                code_system_url="http://purl.obolibrary.org/obo/mondo.owl",
+                native_uri_stems=["http://purl.obolibrary.org/obo/MONDO_"],
             )
             self.assertGreater(len(cs.concept), 40000)
             prop_uris: List[str] = [p.uri for p in cs.property]
@@ -103,19 +107,20 @@ class OboGraphToFHIRTest(unittest.TestCase):
     def test_convert_hpo(self):
         """Tests specific to HPO."""
         if DOWNLOAD_TESTS_ON:
-            _id = "CodeSystem-HPO"
+            filename = "CodeSystem-HPO"
             dl_url = (
                 "https://github.com/"
-                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-09/hpo.owl.obographs.json"
+                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-13/hpo.owl.obographs.json"
             )
             dl_path = OUTPUT_DIR / "hpo.owl.obographs.json"
-            out = OUTPUT_DIR / f"{_id}.json"
+            out = OUTPUT_DIR / f"{filename}.json"
             cs: CodeSystem = self._load_and_convert(
-                out, dl_path,
+                out,
+                dl_path,
                 dl_url=dl_url,
-                code_system_id=_id,
-                code_system_url='http://purl.obolibrary.org/obo/hp.owl',
-                native_uri_stems=["http://purl.obolibrary.org/obo/HP_"]
+                code_system_id=filename.replace("CodeSystem-", ""),
+                code_system_url="http://purl.obolibrary.org/obo/hp.owl",
+                native_uri_stems=["http://purl.obolibrary.org/obo/HP_"],
             )
             self.assertGreater(len(cs.concept), 30000)
             prop_uris: List[str] = [p.uri for p in cs.property]
@@ -124,20 +129,21 @@ class OboGraphToFHIRTest(unittest.TestCase):
     def test_convert_comploinc(self):
         """Tests specific to CompLOINC."""
         if DOWNLOAD_TESTS_ON:
-            _id = "CodeSystem-CompLOINC"
+            filename = "CodeSystem-comp-loinc"
             dl_url = (
                 "https://github.com/"
-                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-09/comploinc.owl.obographs.json"
+                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-13/comploinc.owl.obographs.json"
             )
             dl_path = OUTPUT_DIR / "comploinc.owl.obographs.json"
-            out = OUTPUT_DIR / f"{_id}.json"
+            out = OUTPUT_DIR / f"{filename}.json"
             cs: CodeSystem = self._load_and_convert(
-                out, dl_path,
+                out,
+                dl_path,
                 dl_url=dl_url,
-                code_system_id=_id,
-                code_system_url='https://github.com/'
-                                'loinc/comp-loinc/releases/latest/download/merged_reasoned_loinc.owl',
-                native_uri_stems=["https://loinc.org/"]
+                code_system_id=filename.replace("CodeSystem-", ""),
+                code_system_url="https://github.com/"
+                "loinc/comp-loinc/releases/latest/download/merged_reasoned_loinc.owl",
+                native_uri_stems=["https://loinc.org/"],
             )
             self.assertGreater(len(cs.concept), 5000)
             prop_uris: List[str] = [p.uri for p in cs.property]
@@ -146,21 +152,21 @@ class OboGraphToFHIRTest(unittest.TestCase):
     def test_convert_rxnorm(self):
         """Tests specific to Bioportal RXNORM.ttl."""
         if DOWNLOAD_TESTS_ON:
-            _id = "CodeSystem-RXNORM"
+            filename = "CodeSystem-rxnorm"
             dl_url = (
                 "https://github.com/"
-                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-09/RXNORM-fixed.ttl.obographs.json"
+                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-13/RXNORM-fixed.ttl.obographs.json"
             )
             dl_path = OUTPUT_DIR / "RXNORM-fixed.ttl.obographs.json"
-            out = OUTPUT_DIR / f"{_id}.json"
-            cs: CodeSystem = \
-                self._load_and_convert(
-                    out, dl_path,
-                    dl_url=dl_url,
-                    code_system_id=_id,
-                    code_system_url='http://purl.bioontology.org/ontology/RXNORM',
-                    native_uri_stems=["http://purl.bioontology.org/ontology/RXNORM/"]
-                )
+            out = OUTPUT_DIR / f"{filename}.json"
+            cs: CodeSystem = self._load_and_convert(
+                out,
+                dl_path,
+                dl_url=dl_url,
+                code_system_id=filename.replace("CodeSystem-", ""),
+                code_system_url="http://purl.bioontology.org/ontology/RXNORM",
+                native_uri_stems=["http://purl.bioontology.org/ontology/RXNORM/"],
+            )
             # TODO: choose a better threshold
             self.assertGreater(len(cs.concept), 100)
             # TODO: choose a property to assert
@@ -170,20 +176,21 @@ class OboGraphToFHIRTest(unittest.TestCase):
     def test_convert_so(self):
         """Tests specific to Sequence Ontology (SO)."""
         if DOWNLOAD_TESTS_ON:
-            _id = "CodeSystem-so"
+            filename = "CodeSystem-sequence-ontology"
             dl_url = (
                 "https://github.com/"
-                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-09/so.owl.obographs.json"
+                "HOT-Ecosystem/owl-on-fhir-content/releases/download/2023-01-13/so.owl.obographs.json"
             )
             dl_path = OUTPUT_DIR / "so.owl.obographs.json"
-            out = OUTPUT_DIR / f"{_id}.json"
-            cs: CodeSystem = \
-                self._load_and_convert(
-                    out, dl_path,
-                    dl_url=dl_url,
-                    code_system_id=_id,
-                    code_system_url='http://purl.obolibrary.org/obo/so.owl',
-                    native_uri_stems=["http://purl.obolibrary.org/obo/SO_"])
+            out = OUTPUT_DIR / f"{filename}.json"
+            cs: CodeSystem = self._load_and_convert(
+                out,
+                dl_path,
+                dl_url=dl_url,
+                code_system_id=filename.replace("CodeSystem-", ""),
+                code_system_url="http://purl.obolibrary.org/obo/so.owl",
+                native_uri_stems=["http://purl.obolibrary.org/obo/SO_"],
+            )
             # TODO: choose a better threshold
             self.assertGreater(len(cs.concept), 100)
             # TODO: choose a property to assert

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -11,7 +11,7 @@ from oaklib.resource import OntologyResource
 from tests import CELLULAR_COMPONENT, CYTOPLASM, DIGIT, VACUOLE
 
 
-@unittest.skip("Skipping until we replace with mock tests - https://github.com/INCATools/ontology-access-kit/issues/510")
+@unittest.skip("Skipping until we have mock tests - https://github.com/INCATools/ontology-access-kit/issues/510")
 class TestOlsImplementation(unittest.TestCase):
     def setUp(self) -> None:
         oi = OlsImplementation(OntologyResource("go"))

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -11,7 +11,9 @@ from oaklib.resource import OntologyResource
 from tests import CELLULAR_COMPONENT, CYTOPLASM, DIGIT, VACUOLE
 
 
-@unittest.skip("Skipping until we have mock tests - https://github.com/INCATools/ontology-access-kit/issues/510")
+@unittest.skip(
+    "Skipping until we have mock tests - https://github.com/INCATools/ontology-access-kit/issues/510"
+)
 class TestOlsImplementation(unittest.TestCase):
     def setUp(self) -> None:
         oi = OlsImplementation(OntologyResource("go"))

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -11,6 +11,7 @@ from oaklib.resource import OntologyResource
 from tests import CELLULAR_COMPONENT, CYTOPLASM, DIGIT, VACUOLE
 
 
+@unittest.skip("Skipping until we replace with mock tests - https://github.com/INCATools/ontology-access-kit/issues/510")
 class TestOlsImplementation(unittest.TestCase):
     def setUp(self) -> None:
         oi = OlsImplementation(OntologyResource("go"))


### PR DESCRIPTION
Updates
```
commit 0fe7a343c52975259d8e944e291a1c9ef4c89614 (HEAD -> fhir-updates-2)
    Obograph to FHIR updates
    - use_curies_foreign_concepts: default changed to True
    - test cases: updated release URIs
    - bugfix: IDs needed to be formatted in a different way

commit accb465957e2cd92cc3da5ac0fdd118508a2cb4c
    FHIR
    - Update: Changed concept references from CURIEs to codes (for native concepts) or URIs (for foreign concepts) by default.
    - Update: Removed @type appearing in CodeSystem output
    - Add: param: code_system_url
    - Add: param: code_system_id

    FHIR work-in-progress:
    - Add: param use_curies_native_concepts to allow for CURIEs for native concept references (WIP)
    - Add: param use_curies_foreign_concepts to allow for CURIEs for foreign concept references (WIP)
    - Add: param native_uri_stems to allow user to list URI stems. That is, for URIs of native concepts, they can be known to be native if their URI starts with one of these URI strings. (WIP)
    - Add: Unit tests: for RxNorm, SO (WIP)
```
