### PR TITLE
Added OboLegacyInterface.

### DIFF
--- a/src/oaklib/datamodels/ontology_metadata.py
+++ b/src/oaklib/datamodels/ontology_metadata.py
@@ -1,5 +1,5 @@
 # Auto generated from ontology_metadata.yaml by pythongen.py version: 0.9.0
-# Generation date: 2022-11-22T11:41:06
+# Generation date: 2023-01-26T08:32:03
 # Schema: Ontology-Metadata
 #
 # id: http://purl.obolibrary.org/obo/omo/schema
@@ -8,6 +8,7 @@
 
 import dataclasses
 import re
+import sys
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
@@ -165,6 +166,14 @@ class NamedIndividualId(TermId):
 
 
 class HomoSapiensId(NamedIndividualId):
+    pass
+
+
+class AgentId(NamedIndividualId):
+    pass
+
+
+class ImageId(NamedIndividualId):
     pass
 
 
@@ -389,12 +398,8 @@ class HasProvenance(AnnotationPropertyMixin):
 
     created_by: Optional[str] = None
     creation_date: Optional[Union[str, List[str]]] = empty_list()
-    contributor: Optional[
-        Union[Union[str, HomoSapiensId], List[Union[str, HomoSapiensId]]]
-    ] = empty_list()
-    creator: Optional[
-        Union[Union[str, HomoSapiensId], List[Union[str, HomoSapiensId]]]
-    ] = empty_list()
+    contributor: Optional[Union[Union[str, AgentId], List[Union[str, AgentId]]]] = empty_list()
+    creator: Optional[Union[Union[str, AgentId], List[Union[str, AgentId]]]] = empty_list()
     created: Optional[str] = None
     date: Optional[Union[str, List[str]]] = empty_list()
     isDefinedBy: Optional[Union[str, OntologyId]] = None
@@ -419,15 +424,11 @@ class HasProvenance(AnnotationPropertyMixin):
 
         if not isinstance(self.contributor, list):
             self.contributor = [self.contributor] if self.contributor is not None else []
-        self.contributor = [
-            v if isinstance(v, HomoSapiensId) else HomoSapiensId(v) for v in self.contributor
-        ]
+        self.contributor = [v if isinstance(v, AgentId) else AgentId(v) for v in self.contributor]
 
         if not isinstance(self.creator, list):
             self.creator = [self.creator] if self.creator is not None else []
-        self.creator = [
-            v if isinstance(v, HomoSapiensId) else HomoSapiensId(v) for v in self.creator
-        ]
+        self.creator = [v if isinstance(v, AgentId) else AgentId(v) for v in self.creator]
 
         if self.created is not None and not isinstance(self.created, str):
             self.created = str(self.created)
@@ -599,7 +600,7 @@ class HasUserInformation(AnnotationPropertyMixin):
     example_of_usage: Optional[Union[str, List[str]]] = empty_list()
     curator_note: Optional[Union[str, List[str]]] = empty_list()
     has_curation_status: Optional[str] = None
-    depicted_by: Optional[Union[str, List[str]]] = empty_list()
+    depicted_by: Optional[Union[Union[str, ImageId], List[Union[str, ImageId]]]] = empty_list()
     page: Optional[Union[str, List[str]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
@@ -629,7 +630,7 @@ class HasUserInformation(AnnotationPropertyMixin):
 
         if not isinstance(self.depicted_by, list):
             self.depicted_by = [self.depicted_by] if self.depicted_by is not None else []
-        self.depicted_by = [v if isinstance(v, str) else str(v) for v in self.depicted_by]
+        self.depicted_by = [v if isinstance(v, ImageId) else ImageId(v) for v in self.depicted_by]
 
         if not isinstance(self.page, list):
             self.page = [self.page] if self.page is not None else []
@@ -704,9 +705,7 @@ class Ontology(NamedObject):
     ] = empty_list()
     source: Optional[Union[str, List[str]]] = empty_list()
     comment: Optional[Union[str, List[str]]] = empty_list()
-    creator: Optional[
-        Union[Union[str, HomoSapiensId], List[Union[str, HomoSapiensId]]]
-    ] = empty_list()
+    creator: Optional[Union[Union[str, AgentId], List[Union[str, AgentId]]]] = empty_list()
     created: Optional[str] = None
     imports: Optional[str] = None
 
@@ -754,9 +753,7 @@ class Ontology(NamedObject):
 
         if not isinstance(self.creator, list):
             self.creator = [self.creator] if self.creator is not None else []
-        self.creator = [
-            v if isinstance(v, HomoSapiensId) else HomoSapiensId(v) for v in self.creator
-        ]
+        self.creator = [v if isinstance(v, AgentId) else AgentId(v) for v in self.creator]
 
         if self.created is not None and not isinstance(self.created, str):
             self.created = str(self.created)
@@ -813,12 +810,8 @@ class Term(NamedObject):
     should_conform_to: Optional[Union[dict, Thing]] = None
     created_by: Optional[str] = None
     creation_date: Optional[Union[str, List[str]]] = empty_list()
-    contributor: Optional[
-        Union[Union[str, HomoSapiensId], List[Union[str, HomoSapiensId]]]
-    ] = empty_list()
-    creator: Optional[
-        Union[Union[str, HomoSapiensId], List[Union[str, HomoSapiensId]]]
-    ] = empty_list()
+    contributor: Optional[Union[Union[str, AgentId], List[Union[str, AgentId]]]] = empty_list()
+    creator: Optional[Union[Union[str, AgentId], List[Union[str, AgentId]]]] = empty_list()
     created: Optional[str] = None
     date: Optional[Union[str, List[str]]] = empty_list()
     isDefinedBy: Optional[Union[str, OntologyId]] = None
@@ -849,7 +842,7 @@ class Term(NamedObject):
     example_of_usage: Optional[Union[str, List[str]]] = empty_list()
     curator_note: Optional[Union[str, List[str]]] = empty_list()
     has_curation_status: Optional[str] = None
-    depicted_by: Optional[Union[str, List[str]]] = empty_list()
+    depicted_by: Optional[Union[Union[str, ImageId], List[Union[str, ImageId]]]] = empty_list()
     page: Optional[Union[str, List[str]]] = empty_list()
     label: Optional[Union[str, LabelType]] = None
     definition: Optional[
@@ -974,15 +967,11 @@ class Term(NamedObject):
 
         if not isinstance(self.contributor, list):
             self.contributor = [self.contributor] if self.contributor is not None else []
-        self.contributor = [
-            v if isinstance(v, HomoSapiensId) else HomoSapiensId(v) for v in self.contributor
-        ]
+        self.contributor = [v if isinstance(v, AgentId) else AgentId(v) for v in self.contributor]
 
         if not isinstance(self.creator, list):
             self.creator = [self.creator] if self.creator is not None else []
-        self.creator = [
-            v if isinstance(v, HomoSapiensId) else HomoSapiensId(v) for v in self.creator
-        ]
+        self.creator = [v if isinstance(v, AgentId) else AgentId(v) for v in self.creator]
 
         if self.created is not None and not isinstance(self.created, str):
             self.created = str(self.created)
@@ -1112,7 +1101,7 @@ class Term(NamedObject):
 
         if not isinstance(self.depicted_by, list):
             self.depicted_by = [self.depicted_by] if self.depicted_by is not None else []
-        self.depicted_by = [v if isinstance(v, str) else str(v) for v in self.depicted_by]
+        self.depicted_by = [v if isinstance(v, ImageId) else ImageId(v) for v in self.depicted_by]
 
         if not isinstance(self.page, list):
             self.page = [self.page] if self.page is not None else []
@@ -1494,6 +1483,46 @@ class HomoSapiens(NamedIndividual):
             self.MissingRequiredField("id")
         if not isinstance(self.id, HomoSapiensId):
             self.id = HomoSapiensId(self.id)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Agent(NamedIndividual):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PROV.Agent
+    class_class_curie: ClassVar[str] = "prov:Agent"
+    class_name: ClassVar[str] = "Agent"
+    class_model_uri: ClassVar[URIRef] = OMOSCHEMA.Agent
+
+    id: Union[str, AgentId] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, AgentId):
+            self.id = AgentId(self.id)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Image(NamedIndividual):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = IAO["0000101"]
+    class_class_curie: ClassVar[str] = "IAO:0000101"
+    class_name: ClassVar[str] = "Image"
+    class_model_uri: ClassVar[URIRef] = OMOSCHEMA.Image
+
+    id: Union[str, ImageId] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ImageId):
+            self.id = ImageId(self.id)
 
         super().__post_init__(**kwargs)
 
@@ -2201,7 +2230,7 @@ slots.depicted_by = Slot(
     curie=FOAF.curie("depicted_by"),
     model_uri=OMOSCHEMA.depicted_by,
     domain=None,
-    range=Optional[Union[str, List[str]]],
+    range=Optional[Union[Union[str, ImageId], List[Union[str, ImageId]]]],
 )
 
 slots.page = Slot(
@@ -2345,7 +2374,7 @@ slots.contributor = Slot(
     curie=DCTERMS.curie("contributor"),
     model_uri=OMOSCHEMA.contributor,
     domain=None,
-    range=Optional[Union[Union[str, HomoSapiensId], List[Union[str, HomoSapiensId]]]],
+    range=Optional[Union[Union[str, AgentId], List[Union[str, AgentId]]]],
 )
 
 slots.creator = Slot(
@@ -2354,7 +2383,7 @@ slots.creator = Slot(
     curie=DCTERMS.curie("creator"),
     model_uri=OMOSCHEMA.creator,
     domain=None,
-    range=Optional[Union[Union[str, HomoSapiensId], List[Union[str, HomoSapiensId]]]],
+    range=Optional[Union[Union[str, AgentId], List[Union[str, AgentId]]]],
 )
 
 slots.created = Slot(
@@ -3300,6 +3329,16 @@ slots.HomoSapiens_id = Slot(
     model_uri=OMOSCHEMA.HomoSapiens_id,
     domain=HomoSapiens,
     range=Union[str, HomoSapiensId],
+    pattern=re.compile(r"^orcid:.*"),
+)
+
+slots.Agent_id = Slot(
+    uri=OMOSCHEMA.id,
+    name="Agent_id",
+    curie=OMOSCHEMA.curie("id"),
+    model_uri=OMOSCHEMA.Agent_id,
+    domain=Agent,
+    range=Union[str, AgentId],
     pattern=re.compile(r"^orcid:.*"),
 )
 

--- a/src/oaklib/datamodels/ontology_metadata.yaml
+++ b/src/oaklib/datamodels/ontology_metadata.yaml
@@ -364,6 +364,19 @@ classes:
       id:
         pattern: "^orcid:.*"
 
+  Agent:
+    is_a: NamedIndividual
+    class_uri: prov:Agent
+    id_prefixes:
+      - orcid
+    slot_usage:
+      id:
+        pattern: "^orcid:.*"
+
+  Image:
+    is_a: NamedIndividual
+    class_uri: IAO:0000101
+
   Annotation:
     description: A reified property-object pair
     represents_relationship: true
@@ -635,6 +648,7 @@ slots:
     is_a: informative_property
     slot_uri: foaf:depicted_by
     multivalued: true
+    range: Image
   page:
     is_a: informative_property
     slot_uri: foaf:page
@@ -735,7 +749,7 @@ slots:
     is_a: provenance_property
     slot_uri: dcterms:contributor
     multivalued: true
-    range: HomoSapiens
+    range: Agent
     close_mappings:
       - prov:wasAttributedTo
     structured_pattern:
@@ -746,7 +760,7 @@ slots:
     is_a: provenance_property
     slot_uri: dcterms:creator
     multivalued: true
-    range: HomoSapiens
+    range: Agent
     close_mappings:
       - prov:wasAttributedTo
     structured_pattern:

--- a/src/oaklib/datamodels/vocabulary.py
+++ b/src/oaklib/datamodels/vocabulary.py
@@ -103,6 +103,8 @@ SKOS_DEFINITION_CURIE = "skos:definition"
 DEFINITION_SOURCE = omd.slots.definition_source.curie
 ENTITY_LEVEL_DEFINITION_PREDICATES = [DEFINITION_SOURCE]
 
+TERM_TRACKER_ITEM = omd.slots.term_tracker_item.curie
+
 OIO_CREATED_BY = "oio:created_by"
 OIO_CREATION_DATE = "oio:creation_date"
 CONTRIBUTOR = "dcterms:contributor"

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -56,6 +56,7 @@ from oaklib.interfaces.differ_interface import DifferInterface
 from oaklib.interfaces.dumper_interface import DumperInterface
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
 from oaklib.interfaces.obograph_interface import OboGraphInterface
+from oaklib.interfaces.obolegacy_interface import OboLegacyInterface
 from oaklib.interfaces.patcher_interface import PatcherInterface
 from oaklib.interfaces.rdf_interface import RdfInterface
 from oaklib.interfaces.search_interface import SearchInterface
@@ -83,6 +84,7 @@ class ProntoImplementation(
     ValidatorInterface,
     RdfInterface,
     OboGraphInterface,
+    OboLegacyInterface,
     SearchInterface,
     MappingProviderInterface,
     PatcherInterface,
@@ -235,6 +237,7 @@ class ProntoImplementation(
 
     def _entity(self, curie: CURIE, strict=False):
         for r in self.wrapped_ontology.relationships():
+            # TODO: use OboLegacyInterface
             # see https://owlcollab.github.io/oboformat/doc/obo-syntax.html#4.4.1
             # pronto gives relations shorthand IDs for RO and BFO, as it is providing
             # oboformat as a level of abstraction. We want to map these back to the CURIEs

--- a/src/oaklib/implementations/simpleobo/simple_obo_parser.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_parser.py
@@ -59,8 +59,10 @@ TAG_INVERSE_OF = "inverse_of"
 TAG_EQUIVALENT_TO = "equivalent_to"
 TAG_RELATIONSHIP = "relationship"
 TAG_INTERSECTION_OF = "intersection_of"
+TAG_CREATED_BY = "created_by"
+TAG_CREATION_DATE = "creation_date"
 SYNONYM_TUPLE = Tuple[PRED_CURIE, str, Optional[str], List[CURIE]]
-PROPERTY_VALUE_TUPLE = Tuple[PRED_CURIE, str, Optional[CURIE], List[CURIE]]
+PROPERTY_VALUE_TUPLE = Tuple[PRED_CURIE, str, Optional[CURIE], Optional[List[CURIE]]]
 
 
 def _parse_list(as_str: str) -> List[str]:
@@ -113,11 +115,13 @@ class TagValue:
             return
         m = re_property_value1.match(self.value)
         if m:
+            # includes datatype (literal annotation)
             pv = m.groups()
         else:
+            # no datatype
             m = re_property_value2.match(self.value)
             if m:
-                pv = m.group(1), None, m.group(2), None
+                pv = m.group(1), m.group(2), None, None
             else:
                 raise ValueError(f"Bad property value: {self.value}")
         return pv[0], pv[1], pv[2], None

--- a/src/oaklib/interfaces/metadata_interface.py
+++ b/src/oaklib/interfaces/metadata_interface.py
@@ -6,6 +6,8 @@ from oaklib.datamodels.vocabulary import HAS_DEFINITION_CURIE
 from oaklib.interfaces.basic_ontology_interface import BasicOntologyInterface
 from oaklib.types import CURIE
 
+ENTITY_AGENT_PAIR = Tuple[CURIE, om.AgentId]
+
 
 class MetadataInterface(BasicOntologyInterface, ABC):
     def statements_with_annotations(self, curie: CURIE) -> Iterable[om.Axiom]:
@@ -39,3 +41,46 @@ class MetadataInterface(BasicOntologyInterface, ABC):
                 yield curie, defn_obj[0], defn_obj[1]
             else:
                 yield curie, None, None
+
+    def entities_contributors(
+        self, curies: Iterable[CURIE], include_creator=True
+    ) -> Iterator[ENTITY_AGENT_PAIR]:
+        """
+        Get the contributors of a set of entities.
+
+        This SHOULD perform AnnotationPropertyNormalization, using all possible annotation properties,
+        including:
+
+        - dcterms:contributor
+        - IAO:0000117 term editor
+
+        By default, the creator (as defined by :ref:`entities_creators`) is included in the results.
+
+        While there is no consensus on when and how to distinguish creators and contributors, the current
+        emerging consensus of the OBO Ontology Metadata group is that these are hard to separate, and that
+        it makes no sense to distinguish them in the metadata.
+
+        See: https://github.com/information-artifact-ontology/ontology-metadata/issues/120
+
+        :param curies: collection of entities to be looked up
+        :param include_creator: if True, then the creator is included in the results
+        :return:
+        """
+        raise NotImplementedError
+
+    def entities_creators(self, curies: Iterable[CURIE]) -> Iterator[ENTITY_AGENT_PAIR]:
+        """
+        Get the creators of a set of entities.
+
+        This SHOULD perform AnnotationPropertyNormalization, using all possible annotation properties,
+        including:
+
+        - oboInOwl:created_by
+        - dcterms:creator
+
+        See :ref:`entities_contributors` for more information on the difference between creators and contributors.
+
+        :param curies: collection of entities to be looked up
+        :return:
+        """
+        raise NotImplementedError

--- a/src/oaklib/interfaces/obolegacy_interface.py
+++ b/src/oaklib/interfaces/obolegacy_interface.py
@@ -1,0 +1,35 @@
+from abc import ABC
+from typing import Union
+
+from oaklib.interfaces.basic_ontology_interface import BasicOntologyInterface
+from oaklib.types import PRED_CURIE
+
+PRED_CODE = Union[str, PRED_CURIE]
+
+
+class OboLegacyInterface(BasicOntologyInterface, ABC):
+    """
+    A BasicOntologyInterface that provides a bridge to legacy OBO Format concepts
+
+    See <https://owlcollab.github.io/oboformat/doc/obo-syntax.html>_
+    """
+
+    def map_shorthand_to_curie(self, rel_code: PRED_CODE) -> PRED_CURIE:
+        """
+        Maps either a true relationship type CURIE or a shorthand code to a CURIE.
+
+        See `section 5.9 <https://owlcollab.github.io/oboformat/doc/obo-syntax.html#5.9>`_
+
+        :param rel_code:
+        :return:
+        """
+        raise NotImplementedError
+
+    def map_curie_to_shorthand(self, rel_type: PRED_CURIE) -> PRED_CODE:
+        """
+        Reciprocal of `_get_relationship_type_curie`
+
+        :param rel_type:
+        :return:
+        """
+        raise NotImplementedError

--- a/src/oaklib/interfaces/patcher_interface.py
+++ b/src/oaklib/interfaces/patcher_interface.py
@@ -147,3 +147,39 @@ class PatcherInterface(BasicOntologyInterface, ABC):
                     ch = EdgeDeletion(generate_change_id(), subject=s, predicate=p, object=o)
                     changes.append(ch)
         return changes
+
+    def undo(self, changes: List[Change], expand=False, strict=True, **kwargs) -> List[Change]:
+        """
+        Undo a list of changes
+
+        :param changes:
+        :param kwargs:
+        :return:
+        """
+        reversed = self.reverse_changes(changes)
+        if expand:
+            reversed = self.expand_changes(reversed)
+        applied_changes = []
+        while reversed:
+            change = reversed.pop()
+            applied_change = self.apply_patch(change, **kwargs)
+            if applied_change:
+                applied_changes.append(applied_change)
+            elif strict:
+                raise ValueError(f"Could not apply {change}")
+        return applied_changes
+
+    def reverse_changes(self, changes: List[Change]) -> List[Change]:
+        """
+        Creates reciprocal Undo operations for a list of changes
+
+        :param changes:
+        :return:
+        """
+        raise NotImplementedError
+
+    def add_contributors(self, curie: CURIE, agents: List[CURIE]) -> None:
+        raise NotImplementedError
+
+    def set_creator(self, curie: CURIE, agent: CURIE) -> None:
+        raise NotImplementedError

--- a/tests/test_implementations/__init__.py
+++ b/tests/test_implementations/__init__.py
@@ -41,7 +41,7 @@ from oaklib.datamodels.vocabulary import (
     OWL_CLASS,
     OWL_THING,
     PART_OF,
-    TERM_REPLACED_BY,
+    TERM_REPLACED_BY, TERM_TRACKER_ITEM,
 )
 from oaklib.interfaces import MappingProviderInterface, SearchInterface
 from oaklib.interfaces.association_provider_interface import (
@@ -266,9 +266,9 @@ class ComplianceTester:
             m = oi.entity_metadata_map(curie)
             logging.info(f"{curie} {m}")
         m = oi.entity_metadata_map(INTRACELLULAR)
-        test.assertIn("term_tracker_item", m.keys())  # TODO: check this generalizes
+        test.assertIn(TERM_TRACKER_ITEM, m.keys())  # TODO: check this generalizes
         test.assertIn(
-            "https://github.com/geneontology/go-ontology/issues/17776", m["term_tracker_item"]
+            "https://github.com/geneontology/go-ontology/issues/17776", m[TERM_TRACKER_ITEM]
         )
 
     def test_obsolete_entities(self, oi: SearchInterface):

--- a/tests/test_implementations/__init__.py
+++ b/tests/test_implementations/__init__.py
@@ -41,7 +41,8 @@ from oaklib.datamodels.vocabulary import (
     OWL_CLASS,
     OWL_THING,
     PART_OF,
-    TERM_REPLACED_BY, TERM_TRACKER_ITEM,
+    TERM_REPLACED_BY,
+    TERM_TRACKER_ITEM,
 )
 from oaklib.interfaces import MappingProviderInterface, SearchInterface
 from oaklib.interfaces.association_provider_interface import (


### PR DESCRIPTION
This centralizes operations for mapping to legacy obo concepts,
such as shorthands for predicate CURIEs.

TYhis PR also adds a undo options to the patcher interface
