### PR TITLE
Fix non-stopping CI on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Why is this file here in OAK? -> https://github.com/linkml/schema-automator/pull/104#issuecomment-1307388416
+# This file may be removed after funowl is fixed to work with platform-specific line endings.
+
+# https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+# Declare files that will always have LF line endings on checkout.
+*.ofn text eol=lf

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,6 +95,7 @@ jobs:
           poetry run coverage combine
           poetry run coverage xml
           poetry run coverage report -m
+        shell: bash
         env:
           BIOPORTAL_API_KEY: ${{ secrets.BIOPORTAL_API_KEY }}
 


### PR DESCRIPTION
The bug can be seen here: https://github.com/INCATools/ontology-access-kit/actions/runs/4209345211/jobs/7306256452

Same fix as in https://github.com/linkml/linkml/pull/1202