### PR TITLE
PHAF parser and tests added

### DIFF
--- a/src/oaklib/parsers/__init__.py
+++ b/src/oaklib/parsers/__init__.py
@@ -5,6 +5,7 @@ from class_resolver import ClassResolver
 from oaklib.parsers.association_parser import AssociationParser
 from oaklib.parsers.gaf_association_parser import GafAssociationParser
 from oaklib.parsers.hpoa_association_parser import HpoaAssociationParser
+from oaklib.parsers.phaf_association_parser import PhafAssociationParser
 
 __all__ = [
     "get_association_parser_resolver",
@@ -14,6 +15,7 @@ __all__ = [
     "GafAssociationParser",
     "HpoaAssociationParser",
     "HpoaG2PAssociationParser",
+    "PhafAssociationParser",
 ]
 
 from oaklib.parsers.hpoa_g2p_association_parser import HpoaG2PAssociationParser
@@ -24,6 +26,7 @@ G2T = "g2t"
 HPOA = "hpoa"
 HPOA_G2P = "hpoa_g2p"
 KGX = "kgx"
+PHAF = "phaf"
 
 
 @cache
@@ -38,6 +41,7 @@ def get_association_parser_resolver() -> ClassResolver[AssociationParser]:
             HPOA: HpoaAssociationParser,
             G2T: PairwiseAssociationParser,
             HPOA_G2P: HpoaG2PAssociationParser,
+            PHAF: PhafAssociationParser,
         }
     )
 

--- a/src/oaklib/parsers/phaf_association_parser.py
+++ b/src/oaklib/parsers/phaf_association_parser.py
@@ -1,0 +1,18 @@
+"""Parser for PomBase PHAF association formats"""
+from dataclasses import dataclass, field
+
+from oaklib.parsers.parser_base import ColumnReference
+from oaklib.parsers.xaf_association_parser import XafAssociationParser
+
+
+@dataclass
+class PhafAssociationParser(XafAssociationParser):
+    """Parsers for PHAF format."""
+
+    comment_character: str = "#"
+
+    subject_prefix_column: ColumnReference = field(default_factory=lambda: ColumnReference(0))
+    subject_column: ColumnReference = field(default_factory=lambda: ColumnReference(1))
+    predicate_column: ColumnReference = None
+    object_column: ColumnReference = field(default_factory=lambda: ColumnReference(2))
+    expected_object_prefixes = ["FYPO"]

--- a/tests/input/test.phaf.tsv
+++ b/tests/input/test.phaf.tsv
@@ -1,0 +1,3 @@
+#Database name	Gene systematic ID	FYPO ID	Allele description	Expression	Parental strain	Strain name (background)	Genotype description	Gene name	Allele name	Allele synonym	Allele type	Evidence	Condition	Penetrance	Severity	Extension	Reference	Taxon	Date	Ploidy
+PomBase	SPCC338.10c	FYPO:0000245			972 h-			cox5	cox5delta		deletion	cell growth assay evidence	FYECO:0000123,FYECO:0000005,FYECO:0000137				PMID:34250083	4896	2021-08-11	haploid
+PomBase	SPCC338.10c	FYPO:0002060			972 h-			cox5	cox5delta		deletion	Microscopy	FYECO:0000137,FYECO:0000005				PMID:20473289	4896	2010-04-06	haploid

--- a/tests/test_parsers/test_phaf_association_parser.py
+++ b/tests/test_parsers/test_phaf_association_parser.py
@@ -21,7 +21,10 @@ class PhafAssociationParserTest(unittest.TestCase):
                 logging.info(association)
             self.assertIn(
                 Association(
-                    subject="PomBase:SPCC338.10c", predicate=None, object="FYPO:0000245", property_values=[]
+                    subject="PomBase:SPCC338.10c",
+                    predicate=None,
+                    object="FYPO:0000245",
+                    property_values=[],
                 ),
                 assocs,
             )

--- a/tests/test_parsers/test_phaf_association_parser.py
+++ b/tests/test_parsers/test_phaf_association_parser.py
@@ -1,0 +1,27 @@
+import logging
+import unittest
+
+from oaklib.datamodels.association import Association
+from oaklib.parsers import PHAF
+from oaklib.parsers.association_parser_factory import get_association_parser
+from tests import INPUT_DIR
+
+PHAF_INPUT = INPUT_DIR / "test.phaf.tsv"
+
+
+class PhafAssociationParserTest(unittest.TestCase):
+    """Tests parsing of PHAF formats."""
+
+    def test_parser(self):
+        """Tests parsing associations."""
+        parser = get_association_parser(PHAF)
+        with open(PHAF_INPUT) as file:
+            assocs = list(parser.parse(file))
+            for association in assocs:
+                logging.info(association)
+            self.assertIn(
+                Association(
+                    subject="PomBase:SPCC338.10c", predicate=None, object="FYPO:0000245", property_values=[]
+                ),
+                assocs,
+            )


### PR DESCRIPTION
Addresses #474

Includes the parser and analogous test to that in `tests/test_parsers/test_hpoa_association_parser.py`