### PR TITLE
Add `annotate_text()`and `annotate_file()` methods to `AggregatorImplementation`

### DIFF
--- a/src/oaklib/implementations/aggregator/aggregator_implementation.py
+++ b/src/oaklib/implementations/aggregator/aggregator_implementation.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
+from io import TextIOWrapper
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
 
 from sssom_schema import Mapping
@@ -128,3 +129,10 @@ class AggregatorImplementation(
         self, text: TEXT, configuration: Optional[TextAnnotationConfiguration] = None
     ) -> Iterable[TextAnnotation]:
         return self._delegate_iterator(lambda i: i.annotate_text(text, configuration))
+
+    def annotate_file(
+        self,
+        text_file: TextIOWrapper,
+        configuration: TextAnnotationConfiguration = None,
+    ) -> Iterator[TextAnnotation]:
+        return self._delegate_iterator(lambda i: i.annotate_file(text_file, configuration))

--- a/src/oaklib/implementations/aggregator/aggregator_implementation.py
+++ b/src/oaklib/implementations/aggregator/aggregator_implementation.py
@@ -6,6 +6,7 @@ from sssom_schema import Mapping
 
 from oaklib.datamodels.obograph import Node
 from oaklib.datamodels.search import SearchConfiguration
+from oaklib.datamodels.text_annotator import TextAnnotation, TextAnnotationConfiguration
 from oaklib.datamodels.validation_datamodel import (
     ValidationConfiguration,
     ValidationResult,
@@ -22,7 +23,7 @@ from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.interfaces.rdf_interface import RdfInterface
 from oaklib.interfaces.relation_graph_interface import RelationGraphInterface
 from oaklib.interfaces.search_interface import SearchInterface
-from oaklib.interfaces.text_annotator_interface import TextAnnotatorInterface
+from oaklib.interfaces.text_annotator_interface import TEXT, TextAnnotatorInterface
 from oaklib.interfaces.validator_interface import ValidatorInterface
 from oaklib.types import CURIE, SUBSET_CURIE
 
@@ -122,3 +123,8 @@ class AggregatorImplementation(
 
     def incoming_relationship_map(self, curie: CURIE) -> RELATIONSHIP_MAP:
         return self._delegate_simple_tuple_map(lambda i: i.incoming_relationship_map(curie))
+
+    def annotate_text(
+        self, text: TEXT, configuration: Optional[TextAnnotationConfiguration] = None
+    ) -> Iterable[TextAnnotation]:
+        return self._delegate_iterator(lambda i: i.annotate_text(text, configuration))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -412,7 +412,7 @@ class TestCommandLineInterface(unittest.TestCase):
                 "-o",
                 mappings_output,
             ],
-            shell=shell, # noqa
+            shell=shell,  # noqa
         )
         self.assertEqual(0, result.returncode)
         msdf = parse_sssom_table(mappings_output)


### PR DESCRIPTION
This is useful to choose appropriate `annotate_text()` and `annotate_file()` methods depending on the implementation type.