### PR TITLE
synonymizer refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ OAK provides a collection of [interfaces](https://incatools.github.io/ontology-a
  - identify lexical matches and export as SSSOM mapping tables
  - perform more advanced operations, such as graph traversal, OWL axiom processing, or text annotation
 
-These interfaces are *separated* from any particular [backend](https://incatools.github.io/ontology-access-kit/implementations/index.html). This means the same API can be used regardless of whether the ontology:
+These interfaces are *separated* from any particular backend, for which there a number of different [adapters](https://incatools.github.io/ontology-access-kit/implementations/index.html).
+This means the same Python API and command line can be used regardless of whether the ontology:
 
  - is served by a remote API such as OLS or BioPortal
  - is present locally on the filesystem in owl, obo, obojson, or sqlite formats
@@ -31,8 +32,9 @@ These interfaces are *separated* from any particular [backend](https://incatools
 ## Documentation:
 
 - [incatools.github.io/ontology-access-kit](https://incatools.github.io/ontology-access-kit)
-- [Inaugural OAK Workshop slides](https://www.slideshare.net/cmungall/ontology-access-kit-workshop-intro-slidespptx)
-- [OBO Tools Session slides](https://docs.google.com/presentation/d/1m0vFK0F-1StCiVNCCJRdvj3aSjF2gXw-oIF4Jezmsso/edit#slide=id.p)
+- Presentations:
+   - [Using the OAK command line](https://doi.org/10.5281/zenodo.7708962) *OBO Academy 2023*
+   - [Introduction to OAK](https://doi.org/10.5281/zenodo.7765088) *OAK workshop 2022*
 
 ## Contributing
 
@@ -42,31 +44,49 @@ All contributors are expected to uphold our [Code of Conduct](.github/CODE_OF_CO
 ## Usage
 
 ```python
-from oaklib import OntologyResource
+from oaklib import get_adapter
 
-ontology_resource = OntologyResource(slug='tests/input/go-nucleus.db', local=True)
-ontology_interface = ontology_resource.materialize("sql")
-# can also pass an implementation class explicitly instead of a string.
+# connect to the CL sqlite database adapter
+# (will first download if not already downloaded)
+adapter = get_adapter("sqlite:obo:cl")
 
-for curie in ontology_interface.basic_search("cell"):
-    print(f'{curie} ! {ontology_interface.label(curie)}')
-    for rel, fillers in ontology_interface.outgoing_relationship_map(curie).items():
-        print(f'  RELATION: {rel} ! {ontology_interface.label(rel)}')
-        for filler in fillers:
-            print(f'     * {filler} ! {ontology_interface.label(filler)}')
+NEURON = "CL:0000540"
+
+print('## Basic info')
+print(f'ID: {NEURON}')
+print(f'Label: {adapter.label(NEURON)}')
+
+for alias in adapter.entity_aliases(NEURON):
+    print(f'Alias: {alias}')
+
+print('## Relationships (direct)')
+for relationship in adapter.relationships([NEURON]):
+    print(f' * {relationship.predicate} -> {relationship.object} "{adapter.label(relationship.object)}"')
+    
+print('## Ancestors (over IS_A and PART_OF)')
+from oaklib.datamodels.vocabulary import IS_A, PART_OF
+from oaklib.interfaces import OboGraphInterface
+
+if not isinstance(adapter, OboGraphInterface):
+    raise ValueError('This adapter does not support graph operations')
+
+for ancestor in adapter.ancestors(NEURON, predicates=[IS_A, PART_OF]):
+    print(f' * ANCESTOR: "{adapter.label(ancestor)}"')
 ```
 
 For more examples, see
 
 - [demo notebook](https://github.com/incatools/ontology-access-kit/blob/main/notebooks/basic-demo.ipynb)
+- [tutorial part 2](https://incatools.github.io/ontology-access-kit/intro/tutorial02.html)
 
-### Command Line
+## Command Line
 
-Documentation here is incomplete.
+See:
 
-See [CLI docs](https://incatools.github.io/ontology-access-kit/cli.html)
+ - [CLI docs](https://incatools.github.io/ontology-access-kit/cli.html)
+ - [Example notebooks](https://github.com/INCATools/ontology-access-kit/tree/main/notebooks/Commands
 
-### Search
+## Search
 
 Use the pronto backend to fetch and parse an ontology from the OBO library, then use the `search` command
 
@@ -226,33 +246,3 @@ runoak -i obolibrary:go.obo  viz GO:0005773
 OAK uses [`pystow`](https://github.com/cthoyt/pystow) for caching. By default,
 this goes inside `~/.data/`, but can be configured following
 [these instructions](https://github.com/cthoyt/pystow#%EF%B8%8F%EF%B8%8F-configuration).
-
-## Developer notes
-
-### Local project setup
-Prerequisites:
-1. Python 3.9+
-2. [Poetry](https://python-poetry.org/)
-
-Setup steps:
-```shell
-git clone https://github.com/INCATools/ontology-access-kit.git
-cd ontology-access-kit
-poetry install
-```
-
-Testing locally:
-```shell
-poetry run python -m unittest discover
-```
-
-Code quality locally:
-```shell   
-poetry run tox
-```
-
-
-### Potential Refactoring
-Currently all implementations exist in this repo/module, this results in a lot of dependencies
-
-One possibility is to split out each implementation into its own repo and use a plugin architecture

--- a/docs/implementations/bioportal.rst
+++ b/docs/implementations/bioportal.rst
@@ -12,9 +12,9 @@ any OntoPortal endpoint.
 
 So far this only implements:
 
-- :ref:`SearchInterface`
-- :ref:`TextAnnotatorInterface`
-- :ref:`MappingProviderInterface`
+- :ref:`search_interface`
+- :ref:`text_annotator_interface`
+- :ref:`mapping_provider_interface`
 
 API Keys
 --------------------

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -1466,6 +1466,11 @@ def term_metadata(terms, predicates, additional_metadata: bool, output_type: str
     help="Text file or list of tokens to filter from input prior to annotation.\
         If passed as text file, each newline separated entry is a distinct text.",
 )
+@click.option(
+    "--rules-file",
+    "-R",
+    help="path to rules file. Conforms to https://w3id.org/oak/mapping-rules-datamodel",
+)
 @output_option
 @output_type_option
 def annotate(
@@ -1475,6 +1480,7 @@ def annotate(
     matches_whole_text: bool,
     include_aliases: bool,
     exclude_tokens: str,
+    rules_file: str,
     text_file: TextIO,
     model: str,
     output_type: str,
@@ -1530,36 +1536,36 @@ def annotate(
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter, datamodels.text_annotator)
     writer.output = output
-
-    if isinstance(impl, TextAnnotatorInterface):
-        if lexical_index_file:
-            if not Path(lexical_index_file).exists():
-                logging.info(f"Creating new index: {lexical_index_file}")
-                impl.lexical_index = create_lexical_index(impl)
-                save_lexical_index(impl.lexical_index, lexical_index_file)
-            else:
-                impl.lexical_index = load_lexical_index(lexical_index_file)
-        configuration = TextAnnotationConfiguration(matches_whole_text=matches_whole_text)
-        if exclude_tokens:
-            token_exclusion_list = get_exclusion_token_list(exclude_tokens)
-            configuration.token_exclusion_list = token_exclusion_list
-        if model:
-            configuration.model = model
-        configuration.include_aliases = include_aliases
-        # if plugin_config:
-        #     with open(plugin_config, "r") as p:
-        #         configuration.plugin_configuration = yaml.safe_load(p)
-        if words and text_file:
-            raise ValueError("Specify EITHER text-file OR a list of words as arguments")
-        if text_file:
-            for ann in impl.annotate_file(text_file, configuration):
-                writer.emit(ann)
-        else:
-            logging.info(f"Annotating: {words}")
-            for ann in impl.annotate_text(" ".join(list(words)), configuration):
-                writer.emit(ann)
-    else:
+    if not isinstance(impl, TextAnnotatorInterface):
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")
+    if rules_file:
+        impl.rule_collection = load_mapping_rules(rules_file)
+    if lexical_index_file:
+        if not Path(lexical_index_file).exists():
+            logging.info(f"Creating new index: {lexical_index_file}")
+            impl.lexical_index = create_lexical_index(impl)
+            save_lexical_index(impl.lexical_index, lexical_index_file)
+        else:
+            impl.lexical_index = load_lexical_index(lexical_index_file)
+    configuration = TextAnnotationConfiguration(matches_whole_text=matches_whole_text)
+    if exclude_tokens:
+        token_exclusion_list = get_exclusion_token_list(exclude_tokens)
+        configuration.token_exclusion_list = token_exclusion_list
+    if model:
+        configuration.model = model
+    configuration.include_aliases = include_aliases
+    # if plugin_config:
+    #     with open(plugin_config, "r") as p:
+    #         configuration.plugin_configuration = yaml.safe_load(p)
+    if words and text_file:
+        raise ValueError("Specify EITHER text-file OR a list of words as arguments")
+    if text_file:
+        for ann in impl.annotate_file(text_file, configuration):
+            writer.emit(ann)
+    else:
+        logging.info(f"Annotating: {words}")
+        for ann in impl.annotate_text(" ".join(list(words)), configuration):
+            writer.emit(ann)
 
 
 @main.command()

--- a/src/oaklib/datamodels/lexical_index.py
+++ b/src/oaklib/datamodels/lexical_index.py
@@ -1,5 +1,5 @@
 # Auto generated from lexical_index.yaml by pythongen.py version: 0.9.0
-# Generation date: 2023-02-27T09:56:24
+# Generation date: 2023-03-23T19:29:20
 # Schema: lexical-index
 #
 # id: https://w3id.org/oak/lexical-index
@@ -72,6 +72,10 @@ class LexicalGroupingTerm(extended_str):
 
 
 class LexicalTransformationPipelineName(extended_str):
+    pass
+
+
+class ParameterName(extended_str):
     pass
 
 
@@ -269,16 +273,41 @@ class LexicalTransformation(Activity):
     class_model_uri: ClassVar[URIRef] = ONTOLEXINDEX.LexicalTransformation
 
     type: Optional[Union[str, "TransformationType"]] = None
-    params: Optional[str] = None
+    params: Optional[Union[Union[dict, "Any"], List[Union[dict, "Any"]]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self.type is not None and not isinstance(self.type, TransformationType):
             self.type = TransformationType(self.type)
 
-        if self.params is not None and not isinstance(self.params, str):
-            self.params = str(self.params)
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Parameter(YAMLRoot):
+    """
+    A parameter to be applied to a transformation
+    """
+
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = ONTOLEXINDEX.Parameter
+    class_class_curie: ClassVar[str] = "ontolexindex:Parameter"
+    class_name: ClassVar[str] = "Parameter"
+    class_model_uri: ClassVar[URIRef] = ONTOLEXINDEX.Parameter
+
+    name: Union[str, ParameterName] = None
+    value: Optional[Union[dict, "Any"]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.name):
+            self.MissingRequiredField("name")
+        if not isinstance(self.name, ParameterName):
+            self.name = ParameterName(self.name)
 
         super().__post_init__(**kwargs)
+
+
+Any = Any
 
 
 # Enumerations
@@ -472,5 +501,23 @@ slots.lexicalTransformation__params = Slot(
     curie=ONTOLEXINDEX.curie("params"),
     model_uri=ONTOLEXINDEX.lexicalTransformation__params,
     domain=None,
-    range=Optional[str],
+    range=Optional[Union[Union[dict, Any], List[Union[dict, Any]]]],
+)
+
+slots.parameter__name = Slot(
+    uri=ONTOLEXINDEX.name,
+    name="parameter__name",
+    curie=ONTOLEXINDEX.curie("name"),
+    model_uri=ONTOLEXINDEX.parameter__name,
+    domain=None,
+    range=URIRef,
+)
+
+slots.parameter__value = Slot(
+    uri=ONTOLEXINDEX.value,
+    name="parameter__value",
+    curie=ONTOLEXINDEX.curie("value"),
+    model_uri=ONTOLEXINDEX.parameter__value,
+    domain=None,
+    range=Optional[Union[dict, Any]],
 )

--- a/src/oaklib/datamodels/lexical_index.yaml
+++ b/src/oaklib/datamodels/lexical_index.yaml
@@ -102,6 +102,13 @@ classes:
         description: The type of transformation
       params:
         description: Any parameters to be applied to the transformation algorithm
+        range: Any
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+
+  Any:
+    class_uri: linkml:Any
 
 enums:
   TransformationType:

--- a/src/oaklib/datamodels/mapping_rules_datamodel.yaml
+++ b/src/oaklib/datamodels/mapping_rules_datamodel.yaml
@@ -83,6 +83,9 @@ classes:
         multivalued: true
       transformations_included_in:
         multivalued: true
+      predicate_id_one_of:
+        multivalued: true
+
 
   Postcondition:
     attributes:

--- a/src/oaklib/implementations/__init__.py
+++ b/src/oaklib/implementations/__init__.py
@@ -8,6 +8,7 @@ from class_resolver import ClassResolver
 from oaklib.implementations.cx.cx_implementation import CXImplementation
 from oaklib.implementations.funowl.funowl_implementation import FunOwlImplementation
 from oaklib.implementations.gilda import GildaImplementation
+from oaklib.implementations.kgx.kgx_implementation import KGXImplementation
 from oaklib.implementations.ols import (
     BaseOlsImplementation,
     OlsImplementation,
@@ -67,6 +68,7 @@ __all__ = [
     "WikidataImplementation",
     "FunOwlImplementation",
     "GildaImplementation",
+    "KGXImplementation",
     "OakMetaModelImplementation",
 ]
 

--- a/src/oaklib/implementations/kgx/kgx_implementation.py
+++ b/src/oaklib/implementations/kgx/kgx_implementation.py
@@ -419,6 +419,9 @@ class KGXImplementation(
         self.add_missing_property_values(curie, m)
         return dict(m)
 
+    def ontologies(self) -> Iterable[CURIE]:
+        yield "TODO"
+
     def ontology_metadata_map(self, ontology: CURIE) -> METADATA_MAP:
         return self.entity_metadata_map(ontology, include_all_triples=True)
 

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -289,7 +289,8 @@ class ProntoImplementation(
                 continue
             if owl_type and owl_type != OWL_OBJECT_PROPERTY:
                 continue
-            yield t.id
+            curie = self._get_pronto_relationship_type_curie(t)
+            yield curie
         for t in self.wrapped_ontology.synonym_types():
             if owl_type and owl_type != OIO_SYNONYM_TYPE_PROPERTY:
                 continue

--- a/src/oaklib/implementations/sparql/sparql_implementation.py
+++ b/src/oaklib/implementations/sparql/sparql_implementation.py
@@ -7,6 +7,7 @@ from oaklib import BasicOntologyInterface
 from oaklib.implementations.sparql.abstract_sparql_implementation import (
     AbstractSparqlImplementation,
 )
+from oaklib.interfaces import TextAnnotatorInterface
 from oaklib.interfaces.differ_interface import DifferInterface
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
 from oaklib.interfaces.merge_interface import MergeConfiguration, MergeInterface
@@ -28,6 +29,7 @@ class SparqlImplementation(
     OboGraphInterface,
     PatcherInterface,
     SemanticSimilarityInterface,
+    TextAnnotatorInterface,
     TaxonConstraintInterface,
     MergeInterface,
 ):

--- a/src/oaklib/interfaces/__init__.py
+++ b/src/oaklib/interfaces/__init__.py
@@ -1,5 +1,6 @@
 from oaklib.interfaces.basic_ontology_interface import BasicOntologyInterface
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
+from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.interfaces.ontology_interface import OntologyInterface
 from oaklib.interfaces.relation_graph_interface import RelationGraphInterface
 from oaklib.interfaces.search_interface import SearchInterface
@@ -9,6 +10,7 @@ from oaklib.interfaces.validator_interface import ValidatorInterface
 
 __all__ = [
     "BasicOntologyInterface",
+    "OboGraphInterface",
     "MappingProviderInterface",
     "OntologyInterface",
     "RelationGraphInterface",

--- a/src/oaklib/selector.py
+++ b/src/oaklib/selector.py
@@ -96,6 +96,12 @@ def get_implementation_from_shorthand(
 
 
 def get_implementation_class_from_scheme(scheme: str) -> Type[OntologyInterface]:
+    """
+    Given a selector schema (e.g. sqlite, ubergraph, pronto, etc.) return the adapter class.
+
+    :param scheme:
+    :return: adapter (implementation) class that implements the OntologyInterface
+    """
     if scheme == "http" or scheme == "https":
         raise NotImplementedError("Web requests not implemented yet")
     else:

--- a/tests/input/matcher_rules.yaml
+++ b/tests/input/matcher_rules.yaml
@@ -64,13 +64,13 @@ rules:
 
   - synonymizer:
       the_rule: Remove parentheses bound info from the label.
-      match: r'\([^)]*\)'
+      match: "\\([^)]*\\)"
       match_scope: "*"
       replacement: ""
 
   - synonymizer:
       the_rule: Remove box brackets bound info from the label.
-      match: r'\[[^)]*\]'
+      match: "\\[[^)]*\\]"
       match_scope: "*"
       replacement: ""
 

--- a/tests/test_implementations/__init__.py
+++ b/tests/test_implementations/__init__.py
@@ -49,7 +49,11 @@ from oaklib.datamodels.vocabulary import (
     TERM_REPLACED_BY,
     TERM_TRACKER_ITEM,
 )
-from oaklib.interfaces import MappingProviderInterface, SearchInterface
+from oaklib.interfaces import (
+    MappingProviderInterface,
+    SearchInterface,
+    TextAnnotatorInterface,
+)
 from oaklib.interfaces.association_provider_interface import (
     AssociationProviderInterface,
     associations_subjects,
@@ -1485,3 +1489,25 @@ class ComplianceTester:
                 abs(sim.average_score - expected_avg), error_range, f"TermSet: {ts} Sim: {sim}"
             )
             test.assertLess(abs(sim.best_score - expected_max), error_range)
+
+    # TextAnnotatorInterface tests
+    def test_annotate_text(self, oi: TextAnnotatorInterface):
+        test = self.test
+        cases = [
+            (
+                "The nucleus is the part of the cell that contains the DNA.",
+                3,
+                [(NUCLEUS, "nucleus", 5, 11), (PART_OF, "part of", 20, 26), (CELL, "cell", 32, 35)],
+            ),
+        ]
+        for text, n, expected in cases:
+            anns = list(oi.annotate_text(text))
+            anns = sorted(anns, key=lambda x: x.subject_start)
+            test.assertEqual(n, len(anns))
+            for i, ann in enumerate(anns):
+                print(ann)
+                object_id, object_label, subject_start, subject_end = expected[i]
+                test.assertEqual(object_id, ann.object_id)
+                test.assertEqual(object_label, ann.object_label)
+                test.assertEqual(subject_start, ann.subject_start)
+                test.assertEqual(subject_end, ann.subject_end)

--- a/tests/test_implementations/test_pronto.py
+++ b/tests/test_implementations/test_pronto.py
@@ -482,3 +482,9 @@ class TestProntoImplementation(unittest.TestCase):
         rule = TextAndLogicalDefinitionMatchOntologyRule()
         results = list(rule.evaluate(self.oi))
         self.assertGreater(len(results), 5)
+
+    # TextAnnotatorInterface tests
+
+    @unittest.skip("TODO: OP labels")
+    def test_annotate_text(self):
+        self.compliance_tester.test_annotate_text(self.oi)

--- a/tests/test_implementations/test_simple_obo.py
+++ b/tests/test_implementations/test_simple_obo.py
@@ -136,7 +136,7 @@ class TestSimpleOboImplementation(unittest.TestCase):
         entities = list(self.oi.entities())
         self.assertIn(NUCLEUS, entities)
         self.assertIn(CELLULAR_COMPONENT, entities)
-        self.assertIn("part_of", entities)
+        self.assertIn(PART_OF, entities)
 
     @unittest.skip("TODO")
     def test_relations(self):
@@ -517,3 +517,7 @@ class TestSimpleOboImplementation(unittest.TestCase):
                     alias_list.append(dict(curie=curie, pred=pred, alias=alias))
 
         self.assertEqual(len(alias_list), 3)
+
+    # TextAnnotatorInterface tests
+    def test_annotate_text(self):
+        self.compliance_tester.test_annotate_text(self.oi)

--- a/tests/test_implementations/test_sparql.py
+++ b/tests/test_implementations/test_sparql.py
@@ -322,3 +322,6 @@ class TestSparqlImplementation(unittest.TestCase):
     def test_merge(self):
         source = SparqlImplementation(OntologyResource(slug=str(INTERNEURON_RDF)))
         self.compliance_tester.test_merge(self.oi, source)
+
+    def test_annotate_text(self):
+        self.compliance_tester.test_annotate_text(self.oi)

--- a/tests/test_implementations/test_sqldb.py
+++ b/tests/test_implementations/test_sqldb.py
@@ -817,3 +817,7 @@ class TestSqlDatabaseImplementation(unittest.TestCase):
 
     def test_disjoint_with(self):
         self.compliance_tester.test_disjoint_with(self.oi)
+
+    # TextAnnotatorInterface tests
+    def test_annotate_text(self):
+        self.compliance_tester.test_annotate_text(self.oi)

--- a/tests/test_utilities/test_lexical_index.py
+++ b/tests/test_utilities/test_lexical_index.py
@@ -56,19 +56,19 @@ class TestLexicalIndex(unittest.TestCase):
         syn_param = [
             Synonymizer(
                 the_rule="Remove parentheses bound info from the label.",
-                match="r'\([^)]*\)'",  # noqa W605
+                match=r"\([^)]*\)",  # noqa W605
                 match_scope="*",
                 replacement="",
             ),
             Synonymizer(
                 the_rule="Remove box brackets bound info from the label.",
-                match="r'\[[^)]*\]'",  # noqa W605
+                match=r"\[[^)]*\]",  # noqa W605
                 match_scope="*",
                 replacement="",
             ),
             Synonymizer(
                 the_rule="Broad match terms with the term 'other' in them.",
-                match="r'(?i)^Other '",  # noqa W605
+                match=r"(?i)^Other ",  # noqa W605
                 match_scope="*",
                 replacement="",
                 qualifier="broad",
@@ -159,7 +159,7 @@ class TestLexicalIndex(unittest.TestCase):
         syn_param = [
             Synonymizer(
                 the_rule="Broad match terms with the term 'other' in them.",
-                match="r'(?i)^Other '",  # noqa W605
+                match="(?i)^Other ",  # noqa W605
                 match_scope="*",
                 replacement="",
                 qualifier="broad",


### PR DESCRIPTION
* synonymizer refactor
   - no longer uses `eval`
   - this will break some synonymizer configs
       - previously they had some regexes like `r'...'`.
       - these should be changed to be a direct yaml string encoding of the regex
       - we can increment the minor version of OAK for this
* text annotator enhancements
    - allow caching of lexical indexes between runs (@vemonet this should help with some of the speed issues in ontogpt)
* documentation
    - made the README a bit more developer-friendly