### PR TITLE
Add missing writer.finish() to commands in cli.py

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -3470,7 +3470,7 @@ def mappings(terms, maps_to_source, autolabel: bool, output, output_type):
                 if autolabel:
                     impl.inject_mapping_labels([mapping])
                 writer.emit(mapping)
-    # writer.finish()
+    writer.finish()
 
 
 @main.command()

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -3470,7 +3470,7 @@ def mappings(terms, maps_to_source, autolabel: bool, output, output_type):
                 if autolabel:
                     impl.inject_mapping_labels([mapping])
                 writer.emit(mapping)
-    writer.finish()
+    # writer.finish()
 
 
 @main.command()

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -1566,6 +1566,7 @@ def annotate(
         logging.info(f"Annotating: {words}")
         for ann in impl.annotate_text(" ".join(list(words)), configuration):
             writer.emit(ann)
+    writer.finish()
 
 
 @main.command()
@@ -1974,6 +1975,7 @@ def ancestors(
                 raise NotImplementedError
     else:
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")
+    writer.finish()
 
 
 @main.command()
@@ -2274,6 +2276,7 @@ def descendants(
         curies, predicates=actual_predicates, method=graph_traversal_method
     )
     writer.emit_multiple(result_it)
+    writer.finish()
 
 
 @main.command()
@@ -2528,6 +2531,7 @@ def similarity_pair(terms, predicates, autolabel: bool, output: TextIO, output_t
         writer.emit(sim)
     else:
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")
+    writer.finish()
 
 
 @main.command()
@@ -3466,6 +3470,7 @@ def mappings(terms, maps_to_source, autolabel: bool, output, output_type):
                 if autolabel:
                     impl.inject_mapping_labels([mapping])
                 writer.emit(mapping)
+    writer.finish()
 
 
 @main.command()
@@ -3569,6 +3574,7 @@ def aliases(terms, output, output_type, obo_model):
                         writer.emit(dict(curie=curie, pred=pred, alias=alias))
         else:
             raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")
+    writer.finish()
 
 
 @main.command()

--- a/src/oaklib/io/streaming_writer.py
+++ b/src/oaklib/io/streaming_writer.py
@@ -100,7 +100,7 @@ class StreamingWriter(ABC):
         pass
 
     def finish(self):
-        # always ensure a file is writter
+        # always ensure a file is writer
         self.file.write("")
 
     def line(self, v: str):

--- a/src/oaklib/utilities/mapping/sssom_utils.py
+++ b/src/oaklib/utilities/mapping/sssom_utils.py
@@ -73,7 +73,7 @@ class StreamingSssomWriter(StreamingWriter):
     def emit(self, obj: Mapping):
         self.mappings.append(obj)
 
-    def close(self):
+    def finish(self):
         mset = MappingSet(
             mapping_set_id="temp", mappings=self.mappings, license=UNSPECIFIED_MAPPING_SET_ID
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -420,7 +420,6 @@ class TestCommandLineInterface(unittest.TestCase):
         self.assertEqual(len(msdf.prefix_map), 14)
         self.assertIn("BFO", msdf.prefix_map)
 
-
     def test_mappings_json(self):
         mappings_output = OUTPUT_DIR.joinpath("test_mappings.json")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -420,6 +420,34 @@ class TestCommandLineInterface(unittest.TestCase):
         self.assertEqual(len(msdf.prefix_map), 14)
         self.assertIn("BFO", msdf.prefix_map)
 
+
+    def test_mappings_json(self):
+        mappings_output = OUTPUT_DIR.joinpath("test_mappings.json")
+
+        if os.name == "nt":
+            shell = True
+        else:
+            shell = False
+        result = subprocess.run(
+            [
+                "runoak",
+                "-i",
+                f"sqlite:{TEST_DB}",
+                "mappings",
+                "-O",
+                "json",
+                "-o",
+                mappings_output,
+            ],
+            shell=shell,  # noqa
+        )
+
+        self.assertEqual(0, result.returncode)
+
+        with open(mappings_output) as f:
+            parsed_mapping = json.load(f)
+            self.assertEqual(len(parsed_mapping), 123)
+
     # DUMPER
     def test_dump(self):
         obojson_input = f"obograph:{TEST_OBOJSON}"


### PR DESCRIPTION
(Replaces INCATools/ontology-access-kit#498)

This fixes invalid JSON output from some commands defined in `cli.py`. The closing "]" was missing with "-O json".

For example, both of these commands produce invalid JSON:

```
runoak -i bioportal: annotate -O json "enlarged nucleus in T-cells from peripheral blood"
```
```
runoak -i sqlite:obo:fypo aliases -O json FYPO:0009021
```

This PR is my guess at a fix for annotation(), aliases(), mappings(), ancestors(), descendants() and similarity_pair().
