### PR TITLE
FHIR: Output NPM format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .tox/
 __pycache__/
 .ipynb_checkpoints/
-tests/output/
 dist/
 db/
 
@@ -25,7 +24,8 @@ notebooks/api-key.txt
 .coverage.*
 .coverage
 coverage.*
-tests/input/fhirjson_conf.json
+tests/input/*_conf.json
+tests/output/
 
 oak_hp.profile
 oak_semsimian_hp.profile

--- a/docs/packages/converters/obo-graph-to-fhir.rst
+++ b/docs/packages/converters/obo-graph-to-fhir.rst
@@ -5,5 +5,5 @@ OBO Graph to FHIR Converter
 
 .. currentmodule:: oaklib.converters.obo_graph_to_fhir_converter
                    
-.. autoclass:: OboGraphToFHIRConverter
+.. autoclass:: OboGraphToFhirJsonConverter
     :members:

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -125,7 +125,10 @@ from oaklib.io.obograph_writer import write_graph
 from oaklib.io.rollup_report_writer import write_report
 from oaklib.io.streaming_axiom_writer import StreamingAxiomWriter
 from oaklib.io.streaming_csv_writer import StreamingCsvWriter
-from oaklib.io.streaming_fhir_writer import StreamingFHIRWriter
+from oaklib.io.streaming_fhir_writer import (
+    StreamingFhirJsonWriter,
+    StreamingFhirNpmWriter,
+)
 from oaklib.io.streaming_info_writer import StreamingInfoWriter
 from oaklib.io.streaming_json_writer import StreamingJsonWriter
 from oaklib.io.streaming_kgcl_writer import StreamingKGCLWriter
@@ -212,6 +215,7 @@ OWLFUN_FORMAT = "ofn"
 NL_FORMAT = "nl"
 KGCL_FORMAT = "kgcl"
 FHIR_JSON_FORMAT = "fhirjson"
+FHIR_NPM_FORMAT = "fhirnpm"
 HEATMAP_FORMAT = "heatmap"
 
 ONT_FORMATS = [
@@ -222,6 +226,7 @@ ONT_FORMATS = [
     JSON_FORMAT,
     YAML_FORMAT,
     FHIR_JSON_FORMAT,
+    FHIR_NPM_FORMAT,
     CSV_FORMAT,
     NL_FORMAT,
 ]
@@ -238,7 +243,8 @@ WRITERS = {
     JSONL_FORMAT: StreamingJsonWriter,
     YAML_FORMAT: StreamingYamlWriter,
     SSSOM_FORMAT: StreamingSssomWriter,
-    FHIR_JSON_FORMAT: StreamingFHIRWriter,
+    FHIR_JSON_FORMAT: StreamingFhirJsonWriter,
+    FHIR_NPM_FORMAT: StreamingFhirNpmWriter,
     INFO_FORMAT: StreamingInfoWriter,
     NL_FORMAT: StreamingNaturalLanguageWriter,
     KGCL_FORMAT: StreamingKGCLWriter,

--- a/src/oaklib/interfaces/dumper_interface.py
+++ b/src/oaklib/interfaces/dumper_interface.py
@@ -5,7 +5,10 @@ from typing import Any, Dict
 from linkml_runtime.dumpers import json_dumper
 
 from oaklib.converters.obo_graph_to_cx_converter import OboGraphToCXConverter
-from oaklib.converters.obo_graph_to_fhir_converter import OboGraphToFHIRConverter
+from oaklib.converters.obo_graph_to_fhir_converter import (
+    OboGraphToFhirJsonConverter,
+    OboGraphToFhirNpmConverter,
+)
 from oaklib.converters.obo_graph_to_obo_format_converter import (
     OboGraphToOboFormatConverter,
 )
@@ -18,7 +21,8 @@ SUMMARY_STATISTICS_MAP = Dict[str, Any]
 
 OBOGRAPH_CONVERTERS = {
     "obo": OboGraphToOboFormatConverter,
-    "fhirjson": OboGraphToFHIRConverter,
+    "fhirjson": OboGraphToFhirJsonConverter,
+    "fhirnpm": OboGraphToFhirNpmConverter,
     "owl": OboGraphToRdfOwlConverter,
     "turtle": OboGraphToRdfOwlConverter,
     "rdf": OboGraphToRdfOwlConverter,

--- a/src/oaklib/io/streaming_fhir_writer.py
+++ b/src/oaklib/io/streaming_fhir_writer.py
@@ -4,7 +4,7 @@ from typing import Iterable
 
 from linkml_runtime.dumpers import json_dumper
 
-from oaklib.converters.obo_graph_to_fhir_converter import OboGraphToFHIRConverter
+from oaklib.converters.obo_graph_to_fhir_converter import OboGraphToFhirJsonConverter
 from oaklib.datamodels.obograph import GraphDocument
 from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.io.streaming_writer import StreamingWriter
@@ -12,7 +12,7 @@ from oaklib.types import CURIE
 
 
 @dataclass
-class StreamingFHIRWriter(StreamingWriter):
+class StreamingFhirJsonWriter(StreamingWriter):
     """
     A writer that emits FHIR CodeSystem objects or Concept objects
     """
@@ -24,10 +24,31 @@ class StreamingFHIRWriter(StreamingWriter):
             g = oi.extract_graph(list(entities), include_metadata=True)
             gd = GraphDocument(graphs=[g])
             logging.info(f"Converting {len(g.nodes)} nodes to OBO")
-            converter = OboGraphToFHIRConverter()
+            converter = OboGraphToFhirJsonConverter()
             converter.curie_converter = oi.converter
             code_system = converter.convert(gd)
             logging.info(f"Writing {len(code_system.concept)} Concepts")
+            # TODO: Should not this call OboGraphToFhirJsonConverter.dump()?
             self.file.write(json_dumper.dumps(code_system))
+        else:
+            super().emit_multiple(entities, **kwargs)
+
+
+# TODO:
+@dataclass
+class StreamingFhirNpmWriter(StreamingWriter):
+    """
+    A writer that emits FHIR CodeSystem objects or Concept objects
+    """
+
+    def emit_multiple(self, entities: Iterable[CURIE], **kwargs):
+        oi = self.ontology_interface
+        if isinstance(oi, OboGraphInterface):
+            logging.info("Extracting graph")
+            g = oi.extract_graph(list(entities), include_metadata=True)
+            gd = GraphDocument(graphs=[g])
+            logging.info(f"Converting {len(g.nodes)} nodes to OBO")
+            converter = None
+            print(gd, converter)
         else:
             super().emit_multiple(entities, **kwargs)

--- a/tests/input/fhir_npm_manifest_so.json
+++ b/tests/input/fhir_npm_manifest_so.json
@@ -1,0 +1,24 @@
+{
+    "name": "sequence-ontology",
+    "version": "0.1.0",
+    "canonical": "http://purl.obolibrary.org/obo/so.owl",
+    "title": "Sequence Ontology",
+    "description": "The Sequence Ontology is a set of terms and relationships used to describe the features and attributes of biological sequence.",
+    "homepage": "http://www.sequenceontology.org/",
+    "keywords": [
+        "SO",
+        "Sequence Ontology"
+    ],
+    "author": "TIMS",
+    "maintainers": [
+        {
+            "name": "Joe Flack",
+            "email": "jflack@jhu.edu"
+        },
+        {
+            "name": "Shahim Essaid",
+            "email": "shahim@essaid.com"
+        }
+    ],
+    "license": "MIT"
+}


### PR DESCRIPTION
## Updates
<details><summary>Details</summary>
<p>

FHIR: Output as NPM package
- Rename: OboGraphToFHIRConverter --> OboGraphToFhirJsonConverter
- Add: OboGraphToFhirNpmConverter: Saves in FHIR NPM package format.
- Add: New CLI output_type option: fhirnpm
- Add: StreamingFhirNpmWriter (WIP)
- Add: Test file: tests/input/fhir_npm_manifest_so.json
- Add: Test helper function: _load_and_convert_npm()
- Add: Unit test: test_convert_so_package()
- Update: .gitignore: tests/input/*_conf.json

FHIR: Output ConceptMap JSONs
- Update: OboGraphToFhirJsonConverter: Now also saves ConceptMaps


</p>
</details> 