### PR TITLE
Add definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ notebooks/api-key.txt
 .coverage.*
 .coverage
 coverage.*
+tests/input/fhirjson_conf.json

--- a/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
@@ -796,13 +796,16 @@ class SimpleOboImplementation(
             modified_entities.append(patch.about_node)
         elif isinstance(patch, kgcl.NodeTextDefinitionChange):
             t = self._stanza(patch.about_node, strict=True)
-            for tv in t.tag_values:
-                if tv == TAG_DEFINITION:
-                    tv.replace_quoted_part(patch.new_value)
-        elif isinstance(patch, kgcl.NewTextDefinition):
-            t = self._stanza(patch.about_node, strict=True)
-            t.add_tag_value(TAG_DEFINITION, patch.new_value)
-            modified_entities.append(patch.about_node)
+            if TAG_DEFINITION in t.tag_values:
+                for tv in t.tag_values:
+                    if tv.tag == TAG_DEFINITION:
+                        tv.replace_quoted_part(patch.new_value.strip("'"))
+            elif isinstance(patch, kgcl.NewTextDefinition):
+                t = self._stanza(patch.about_node, strict=True)
+                t.add_tag_value(TAG_DEFINITION, patch.new_value)
+                modified_entities.append(patch.about_node)
+            else:
+                logging.info(f"{patch} does nothing.")
         elif isinstance(patch, kgcl.NewSynonym):
             t = self._stanza(patch.about_node, strict=True)
             # Get scope from patch.qualifier


### PR DESCRIPTION
- Handle adding definition to an existing class
- Replaces class definition if already exists
- `NewTextDefinition` is a child of `NodeTextDefinitionChange`. Hence
```
isinstance(patch, kgcl.NewTextDefinition) == isinstance(patch, kgcl.NodeTextDefinitionChange)
```

Because of this, combining them makes more sense and gives expected results.
 