### PR TITLE
Fix testing with tox on windows

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import difflib
 import math
 from pathlib import Path
 from typing import List
@@ -128,3 +129,14 @@ def object_is_subsumed_by_member_of(obj: YAMLRoot, obj_list: List[YAMLRoot], **k
         if object_subsumed_by(o, obj, **kwargs):
             return True
     return False
+
+
+def filecmp_difflib(left_path: Path, right_path: Path) -> bool:
+    """Platfom neutral filecmp.cmp(..) function for text files
+     
+    Files are read in text mode to ignore newline differences.
+    """
+    with open(left_path) as left, open(right_path) as right:
+        diff = difflib.unified_diff(left.readlines(), right.readlines())
+
+    return list(diff) == []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -133,7 +133,7 @@ def object_is_subsumed_by_member_of(obj: YAMLRoot, obj_list: List[YAMLRoot], **k
 
 def filecmp_difflib(left_path: Path, right_path: Path) -> bool:
     """Platfom neutral filecmp.cmp(..) function for text files
-     
+
     Files are read in text mode to ignore newline differences.
     """
     with open(left_path) as left, open(right_path) as right:

--- a/tests/test_implementations/test_pronto.py
+++ b/tests/test_implementations/test_pronto.py
@@ -1,4 +1,3 @@
-import filecmp
 import logging
 import unittest
 
@@ -37,6 +36,7 @@ from tests import (
     ORGANELLE_MEMBRANE,
     OUTPUT_DIR,
     VACUOLE,
+    filecmp_difflib,
 )
 from tests.test_implementations import ComplianceTester
 
@@ -377,7 +377,7 @@ class TestProntoImplementation(unittest.TestCase):
         oi = ProntoImplementation(resource)
         OUTPUT_DIR.mkdir(exist_ok=True)
         oi.dump(output_path, syntax="obo")
-        self.assertTrue(filecmp.cmp(input_path, output_path))
+        self.assertTrue(filecmp_difflib(input_path, output_path))
 
     def test_reflexive_diff(self):
         self.compliance_tester.test_reflexive_diff(self.oi)

--- a/tests/test_implementations/test_simple_obo.py
+++ b/tests/test_implementations/test_simple_obo.py
@@ -1,4 +1,3 @@
-import filecmp
 import logging
 import unittest
 from copy import deepcopy
@@ -52,6 +51,7 @@ from tests import (
     ORGANELLE_MEMBRANE,
     OUTPUT_DIR,
     VACUOLE,
+    filecmp_difflib,
 )
 from tests.test_implementations import ComplianceTester
 
@@ -351,11 +351,11 @@ class TestSimpleOboImplementation(unittest.TestCase):
         oi = SimpleOboImplementation(resource)
         OUTPUT_DIR.mkdir(exist_ok=True)
         oi.dump(output_path, syntax="obo")
-        self.assertTrue(filecmp.cmp(input_path, output_path))
+        self.assertTrue(filecmp_difflib(input_path, output_path))
         # try ordering stanzas (but do not ordering within a stanza)
         oi.obo_document.order_stanzas()
         oi.dump(output_path, syntax="obo")
-        self.assertTrue(filecmp.cmp(input_path, output_path))
+        self.assertTrue(filecmp_difflib(input_path, output_path))
 
     @unittest.skip(
         "Currently not guaranteed same as OWLAPI: see https://github.com/owlcollab/oboformat/issues/138"
@@ -371,7 +371,7 @@ class TestSimpleOboImplementation(unittest.TestCase):
         oi.obo_document.normalize_line_order()
         OUTPUT_DIR.mkdir(exist_ok=True)
         oi.dump(output_path, syntax="obo")
-        self.assertTrue(filecmp.cmp(input_path, output_path))
+        self.assertTrue(filecmp_difflib(input_path, output_path))
 
     def test_merge(self):
         resource1 = OntologyResource(slug=TEST_ONT, directory=INPUT_DIR, local=True)

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,12 @@ envlist =
     py
 
 [testenv]
+# forward env.vars to tox env for tests\test_implementations\test_sqldb.py
+passenv =
+    LNAME
+    LOGNAME
+    USER
+    USERNAME
 commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine


### PR DESCRIPTION
Observed failures:

```
========================== short test summary info ========================== 
FAILED tests/test_cli.py::TestCommandLineInterface::test_statistics - AssertionError: 0 != 1

FAILED tests/test_implementations/test_simple_obo.py::TestSimpleOboImplementation::test_sort_order_no_edits - AssertionError: False is not true

FAILED tests/test_implementations/test_sqldb.py::TestSqlDatabaseImplementation::test_summary_statistics - ModuleNotFoundError: No module named 'pwd'
```
One failure was related to missing env vars (tox clears them). The others were related to filecomp.cmp which does compare files in binary mode. So text files with the same content but different EOL chars compared as different. I added a version to compare files ignoring EOL chars.