### PR TITLE
ontology only enrichment

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -646,7 +646,7 @@ def query_terms_iterator(query_terms: NESTED_LIST, impl: BasicOntologyInterface)
                 if x not in remaining:
                     yield x
             query_terms = []
-        elif term == ".not" or terms == ".minus":
+        elif term == ".not" or term == ".minus":
             # boolean term: consume the result of the query and subtract
             rest = list(query_terms_iterator(query_terms, impl))
             for x in results:
@@ -4130,10 +4130,14 @@ def rollup(
     "--ontology-only/--no-ontology-only",
     default=False,
     show_default=True,
-    help="If true, perform a degenerate analysis treating each term as an association",
+    help="If true, perform a pseudo-enrichment analysis treating each term as an association to itself.",
 )
 @click.option(
-    "--cutoff", type=click.FLOAT, default=0.05, show_default=True, help="The cutoff for the p-value"
+    "--cutoff",
+    type=click.FLOAT,
+    default=0.05,
+    show_default=True,
+    help="The cutoff for the p-value; any p-values greater than this are not reported.",
 )
 @click.option(
     "--sample-file",
@@ -4173,6 +4177,32 @@ def enrichment(
 ):
     """
     Run class enrichment analysis.
+
+    Given a sample file of identifiers (e.g. gene IDs), plus a set of associations (e.g. gene to term
+    associations, return the terms that are over-represented in the sample set.
+
+    Example:
+
+        runoak -i sqlite:obo:uberon -g gene2anat.txt -G g2t enrichment -U my-genes.txt -O csv
+
+    This runs an enrichment using Uberon on my-genes.txt, using the gene2anat.txt file as the
+    association file (assuming simple gene-to-term format). The output is in CSV format.
+
+    It is recommended you always provide a background set, including all the entity identifiers
+    considered in the experiment.
+
+    You can specify --filter-redundant to filter out redundant terms. This will block reporting
+    of any terms that are either subsumed by or subsume a lower p-value term that is already
+    reported.
+
+    For a full example, see:
+
+       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Enrichment.ipynb
+
+    Note that it is possible to run "pseudo-enrichments" on term lists only by passing
+    no associations and using --ontology-only. This creates a fake association set that is simply
+    reflexive relations between each term and itself. This can be useful for summarizing term lists,
+    but note that P-values may not be meaningful.
     """
     impl = settings.impl
     actual_predicates = _process_predicates_arg(predicates)

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -4126,10 +4126,12 @@ def rollup(
 @autolabel_option
 @output_type_option
 @output_option
-@click.option("--ontology-only/--no-ontology-only",
-              default=False,
-              show_default=True,
-              help="If true, perform a degenerate analysis treating each term as an association")
+@click.option(
+    "--ontology-only/--no-ontology-only",
+    default=False,
+    show_default=True,
+    help="If true, perform a degenerate analysis treating each term as an association",
+)
 @click.option(
     "--cutoff", type=click.FLOAT, default=0.05, show_default=True, help="The cutoff for the p-value"
 )
@@ -4153,7 +4155,8 @@ def rollup(
 @click.option(
     "--filter-redundant/--no-filter-redundant",
     default=False,
-    help="If true, filter out redundant terms")
+    help="If true, filter out redundant terms",
+)
 @click.argument("terms", nargs=-1)
 def enrichment(
     terms,
@@ -4199,7 +4202,6 @@ def enrichment(
     for result in results:
         writer.emit(result)
     writer.finish()
-
 
 
 @main.command()

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -55,7 +55,9 @@ from oaklib.interfaces.basic_ontology_interface import (
     RELATIONSHIP,
     RELATIONSHIP_MAP,
 )
-from oaklib.interfaces.class_enrichment_calculation_interface import ClassEnrichmentCalculationInterface
+from oaklib.interfaces.class_enrichment_calculation_interface import (
+    ClassEnrichmentCalculationInterface,
+)
 from oaklib.interfaces.differ_interface import DifferInterface
 from oaklib.interfaces.dumper_interface import DumperInterface
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -55,6 +55,7 @@ from oaklib.interfaces.basic_ontology_interface import (
     RELATIONSHIP,
     RELATIONSHIP_MAP,
 )
+from oaklib.interfaces.class_enrichment_calculation_interface import ClassEnrichmentCalculationInterface
 from oaklib.interfaces.differ_interface import DifferInterface
 from oaklib.interfaces.dumper_interface import DumperInterface
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
@@ -93,7 +94,8 @@ class ProntoImplementation(
     MappingProviderInterface,
     PatcherInterface,
     DifferInterface,
-    AssociationProviderInterface,
+    # AssociationProviderInterface,
+    ClassEnrichmentCalculationInterface,
     SemanticSimilarityInterface,
     TextAnnotatorInterface,
     SummaryStatisticsInterface,

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -45,8 +45,6 @@ from oaklib.datamodels.vocabulary import (
     TERMS_MERGED,
 )
 from oaklib.interfaces import TextAnnotatorInterface
-from oaklib.interfaces.association_provider_interface import (
-    AssociationProviderInterface,
 )
 from oaklib.interfaces.basic_ontology_interface import (
     ALIAS_MAP,

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -45,7 +45,6 @@ from oaklib.datamodels.vocabulary import (
     TERMS_MERGED,
 )
 from oaklib.interfaces import TextAnnotatorInterface
-)
 from oaklib.interfaces.basic_ontology_interface import (
     ALIAS_MAP,
     METADATA_MAP,

--- a/src/oaklib/interfaces/association_provider_interface.py
+++ b/src/oaklib/interfaces/association_provider_interface.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC
 from collections import defaultdict
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
@@ -81,6 +82,9 @@ class AssociationProviderInterface(BasicOntologyInterface, ABC):
             else:
                 raise NotImplementedError
         ix = self._association_index
+        if ix is None:
+            logging.warning("No association index")
+            return
         for a in ix.lookup(subjects, predicates, objects):
             yield a
 

--- a/src/oaklib/interfaces/class_enrichment_calculation_interface.py
+++ b/src/oaklib/interfaces/class_enrichment_calculation_interface.py
@@ -136,14 +136,18 @@ class ClassEnrichmentCalculationInterface(AssociationProviderInterface, ABC):
         yielded_ancs = set()
         for r in results:
             if filter_redundant:
-                if yielded.intersection(set(self.ancestors(r.class_id, predicates=object_closure_predicates))):
+                if yielded.intersection(
+                    set(self.ancestors(r.class_id, predicates=object_closure_predicates))
+                ):
                     continue
                 if r.class_id in yielded_ancs:
                     continue
             yield r
             if filter_redundant:
                 yielded.add(r.class_id)
-                yielded_ancs.update(list(self.ancestors(r.class_id, predicates=object_closure_predicates)))
+                yielded_ancs.update(
+                    list(self.ancestors(r.class_id, predicates=object_closure_predicates))
+                )
 
     def create_self_associations(self):
         """

--- a/src/oaklib/interfaces/class_enrichment_calculation_interface.py
+++ b/src/oaklib/interfaces/class_enrichment_calculation_interface.py
@@ -3,7 +3,9 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Iterable, Iterator, List, Optional
 
+from oaklib.datamodels.association import Association
 from oaklib.datamodels.class_enrichment import ClassEnrichmentResult
+from oaklib.datamodels.vocabulary import EQUIVALENT_CLASS
 from oaklib.interfaces.association_provider_interface import (
     AssociationProviderInterface,
 )
@@ -32,6 +34,7 @@ class ClassEnrichmentCalculationInterface(AssociationProviderInterface, ABC):
         hypotheses: Iterable[CURIE] = None,
         cutoff=0.05,
         autolabel=False,
+        filter_redundant=False,
         sort_by: str = None,
         direction="greater",
     ) -> Iterator[ClassEnrichmentResult]:
@@ -43,6 +46,9 @@ class ClassEnrichmentCalculationInterface(AssociationProviderInterface, ABC):
         :param hypotheses: The set of classes to test for overrepresentation
         :param cutoff: The threshold to use for significance
         :param labels: Whether to include labels for the classes
+        :param direction: The direction of the test. One of 'greater', 'less', 'two-sided'
+        :param filter_redundant: Whether to filter out redundant hypotheses
+        :param sort_by: The field to sort by. One of 'p_value', 'sample_count', 'background_count', 'odds_ratio'
         :param direction: The direction of the test. One of 'greater', 'less', 'two-sided'
         :return: An iterator over ClassEnrichmentResult objects
         """
@@ -126,5 +132,37 @@ class ClassEnrichmentCalculationInterface(AssociationProviderInterface, ABC):
         else:
             anc_counts = {}
         results.sort(key=lambda x: (x.p_value, -anc_counts.get(x.class_id, 0)))
+        yielded = set()
+        yielded_ancs = set()
         for r in results:
+            if filter_redundant:
+                if yielded.intersection(set(self.ancestors(r.class_id, predicates=object_closure_predicates))):
+                    continue
+                if r.class_id in yielded_ancs:
+                    continue
             yield r
+            if filter_redundant:
+                yielded.add(r.class_id)
+                yielded_ancs.update(list(self.ancestors(r.class_id, predicates=object_closure_predicates)))
+
+    def create_self_associations(self):
+        """
+        Create self associations for all terms in the ontology.
+
+        >>> from oaklib import get_adapter
+        >>> adapter = get_adapter("tests/input/go-nucleus.obo")
+        >>> adapter.create_self_associations()
+        >>> terms = ["GO:0034357", "GO:0031965", "GO:0005773"]
+        >>> for r in adapter.enriched_classes(terms, autolabel=True, filter_redundant=True):
+        ...     print(r.class_id, r.class_label, round(r.p_value_adjusted,3))
+        GO:0016020 membrane 0.004
+        ...
+
+
+        This is useful for simple over-representation tests over term sets without any annotations.
+        """
+        assocs = []
+        for e in self.entities(filter_obsoletes=True):
+            assoc = Association(subject=e, predicate=EQUIVALENT_CLASS, object=e)
+            assocs.append(assoc)
+        self.add_associations(assocs)

--- a/src/oaklib/parsers/__init__.py
+++ b/src/oaklib/parsers/__init__.py
@@ -22,15 +22,31 @@ from oaklib.parsers.hpoa_g2p_association_parser import HpoaG2PAssociationParser
 from oaklib.parsers.pairwise_association_parser import PairwiseAssociationParser
 
 GAF = "gaf"
+"""Gene Ontology GAF syntax"""
+
 G2T = "g2t"
+"""Simple pairwise gene to term 2 column syntax"""
+
 HPOA = "hpoa"
+"""HPO Annotation syntax"""
+
 HPOA_G2P = "hpoa_g2p"
+"""HPO Gene-to-Phenotype syntax"""
+
 KGX = "kgx"
+"""KGX TSV syntax"""
+
 PHAF = "phaf"
+"""PomBase Phenotype Association Format"""
 
 
 @cache
 def get_association_parser_resolver() -> ClassResolver[AssociationParser]:
+    """
+    Get a class resolver for association parsers.
+
+    :return: ClassResolver
+    """
     association_parser_resolver: ClassResolver[AssociationParser] = ClassResolver.from_subclasses(
         AssociationParser,
         suffix="AssociationParser",

--- a/src/oaklib/parsers/association_parser_factory.py
+++ b/src/oaklib/parsers/association_parser_factory.py
@@ -4,6 +4,14 @@ from oaklib.parsers import AssociationParser
 
 
 def get_association_parser(syntax: str, *args, **kwargs) -> Type[AssociationParser]:
+    """
+    Get an association parser for a given syntax
+
+    :param syntax:
+    :param args:
+    :param kwargs:
+    :return:
+    """
     from oaklib.parsers import get_association_parser_resolver
 
     cls = get_association_parser_resolver().lookup(syntax)


### PR DESCRIPTION
This PR adds the ability to do an ontology-only pseudoenrichment. This can be useful for quickly summarizing a term list to a set of grouping terms that 'best' stratify the set.

E.g. given:

```
$ cat terms.txt
id	label
UBERON:0000955	brain
UBERON:0001466	pedal digit
UBERON:0002136	hilus of dentate gyrus
UBERON:0002389	manual digit
UBERON:0002928	dentate gyrus polymorphic layer
UBERON:0003881	CA1 field of hippocampus
UBERON:0003882	CA2 field of hippocampus
UBERON:0003883	CA3 field of hippocampus
UBERON:0003884	CA4 field of hippocampus
UBERON:6110636	insect adult cerebral ganglion
UBERON:0001238	lamina propria of small intestine
UBERON:0001239	muscularis mucosae of large intestine
UBERON:0001240	muscularis mucosae of intestine
UBERON:0001241	crypt of Lieberkuhn of small intestine
UBERON:0001243	serosa of intestine
UBERON:0001262	wall of intestine
UBERON:0001278	epithelium of large intestine
UBERON:0001902	epithelium of small intestine
UBERON:0001984	crypt of Lieberkuhn of large intestine
```

Only col1 is required, but col2 is included for explanatory purposes. This is a bit of an ad-hoc list, consisting of 2 major clusters around hippocampus and intestine, with a few digits and a random insect brain thrown in for good measure.

What are some of the commonalities? We can run a pseudo-enrichment in `ontology-only` mode, which makes a "fake" association set consistent of each term annotated once to itself.

running:

`uberon enrichment --filter-redundant -p i,p -U terms.txt --ontology-only -O csv`

yields:

|class_id|p_value|class_label|p_value_adjusted|false_discovery_rate|fold_enrichment|sample_count|sample_total|background_count|background_total|
|---|---|---|---|---|---|---|---|---|---|
|UBERON:0001262|2.440738013008377e-14|wall of intestine|4.1736620022443245e-12|None|None|9|20|209|25180|
|UBERON:0004786|7.097751629920268e-11|gastrointestinal system mucosa|1.2137155287163657e-08|None|None|7|20|184|25180|
|UBERON:0002421|3.602070818589215e-10|hippocampal formation|6.159541099787557e-08|None|None|6|20|119|25180|
|UBERON:0002108|5.484929739803873e-05|small intestine|0.009379229855064623|None|None|3|20|94|25180|


If you change `--cutoff` to be more permissive (>0.05) then you will also get groupings for other terms like `digit`.

__NOTE__ p-value is not particularly meaningful when running enrichment with `--ontology-only`

you can also pass in a list of terms to be considered, as a static list or as a query. For example if you don't like the groupings you were given, you can exclude them:

```
uberon enrichment --filter-redundant -p i,p -U terms.txt --ontology-only -O csv .all .minus [ UBERON:0002421 UBERON:0001262 ] 
```

This queries is for the set of `.all` terms, `.minus` the two terms in the list:

|class_id|p_value|class_label|p_value_adjusted|false_discovery_rate|fold_enrichment|sample_count|sample_total|background_count|background_total|
|---|---|---|---|---|---|---|---|---|---|
|UBERON:0000328|5.036525589178182e-13|gut wall|8.511728245711127e-11|None|None|9|20|292|25180|
|UBERON:0000160|9.965467248361818e-13|intestine|1.6841639649731472e-10|None|None|9|20|315|25180|
|UBERON:0004786|7.097751629920268e-11|gastrointestinal system mucosa|1.1995200254565252e-08|None|None|7|20|184|25180|
|UBERON:0003876|2.8753312477949465e-07|hippocampal field|4.85930980877346e-05|None|None|4|20|72|25180|
|UBERON:0001885|3.936980261042668e-05|dentate gyrus of hippocampal formation|0.00665349664116211|None|None|2|20|12|25180|
|UBERON:0013765|0.00014463568312920875|digestive system element|0.02444343044883628|None|None|6|20|1084|25180|