### PR TITLE
Slight addition to handle KGCL `RemoveTextDefinition`

### DIFF
--- a/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
@@ -813,8 +813,12 @@ class SimpleOboImplementation(
             t = self._stanza(patch.about_node, strict=True)
             for tv in t.tag_values:
                 if tv.tag == TAG_DEFINITION:
-                    # The strip() portion is to handle a KGCL bug
-                    tv.replace_quoted_part(patch.new_value.strip("'"))
+                    if patch.new_value:
+                        # The strip() portion is to handle a KGCL bug
+                        tv.replace_quoted_part(patch.new_value.strip("'"))
+                    else:
+                        # This is a remove_definition request
+                        tv.value = ""
         elif isinstance(patch, kgcl.NewSynonym):
             t = self._stanza(patch.about_node, strict=True)
             # Get scope from patch.qualifier

--- a/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
@@ -814,7 +814,7 @@ class SimpleOboImplementation(
             for tv in t.tag_values:
                 if tv.tag == TAG_DEFINITION:
                     # This is a remove_definition request
-                    tv.value = ""
+                    t.remove_tag_quoted_value(TAG_DEFINITION, t._quoted_value(tv.value))
         elif isinstance(patch, kgcl.NodeTextDefinitionChange):
             t = self._stanza(patch.about_node, strict=True)
             for tv in t.tag_values:

--- a/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
@@ -809,16 +809,17 @@ class SimpleOboImplementation(
             t = self._stanza(patch.about_node, strict=True)
             t.add_quoted_tag_value(TAG_DEFINITION, patch.new_value.strip("'"), xrefs=[])
             modified_entities.append(patch.about_node)
+        elif isinstance(patch, kgcl.RemoveTextDefinition):
+            t = self._stanza(patch.about_node, strict=True)
+            for tv in t.tag_values:
+                if tv.tag == TAG_DEFINITION:
+                    # This is a remove_definition request
+                    tv.value = ""
         elif isinstance(patch, kgcl.NodeTextDefinitionChange):
             t = self._stanza(patch.about_node, strict=True)
             for tv in t.tag_values:
                 if tv.tag == TAG_DEFINITION:
-                    if isinstance(patch, kgcl.RemoveTextDefinition):
-                        # This is a remove_definition request
-                        tv.value = ""
-                    else:
-                        # The strip() portion is to handle a KGCL bug
-                        tv.replace_quoted_part(patch.new_value.strip("'"))
+                    tv.replace_quoted_part(patch.new_value.strip("'"))
         elif isinstance(patch, kgcl.NewSynonym):
             t = self._stanza(patch.about_node, strict=True)
             # Get scope from patch.qualifier

--- a/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
@@ -813,12 +813,12 @@ class SimpleOboImplementation(
             t = self._stanza(patch.about_node, strict=True)
             for tv in t.tag_values:
                 if tv.tag == TAG_DEFINITION:
-                    if patch.new_value:
-                        # The strip() portion is to handle a KGCL bug
-                        tv.replace_quoted_part(patch.new_value.strip("'"))
-                    else:
+                    if isinstance(patch, kgcl.RemoveTextDefinition):
                         # This is a remove_definition request
                         tv.value = ""
+                    else:
+                        # The strip() portion is to handle a KGCL bug
+                        tv.replace_quoted_part(patch.new_value.strip("'"))
         elif isinstance(patch, kgcl.NewSynonym):
             t = self._stanza(patch.about_node, strict=True)
             # Get scope from patch.qualifier


### PR DESCRIPTION
Here, I'm replacing the definition entirely to "".

Example command:
```
remove definition for FBbt:00000001
```

Implements https://github.com/INCATools/kgcl/pull/28