### PR TITLE
Leave keys unsorted when exporting yaml

### DIFF
--- a/src/oaklib/io/streaming_yaml_writer.py
+++ b/src/oaklib/io/streaming_yaml_writer.py
@@ -39,4 +39,4 @@ class StreamingYamlWriter(StreamingWriter):
         self.object_count += 1
 
     def emit_dict(self, obj: dict, object_type: Type = None):
-        self.file.write(yaml.dump(obj))
+        self.file.write(yaml.dump(obj, sort_keys=False))


### PR DESCRIPTION
Fixes #529 