### PR TITLE
Make `ensure_strict_prefixes` default to `False` in `lexmatch`

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -4889,7 +4889,7 @@ def cache_clear(days_old: int):
 )
 @click.option(
     "--ensure-strict-prefixes/--no-ensure-strict-prefixes",
-    default=True,
+    default=False,
     show_default=True,
     help="Clean prefix map and mappings before generating an output.",
 )


### PR DESCRIPTION
Fixes #587 