### PR TITLE
Fix for #606 - omit lower-case prefixes from SqlImplementation prefixmap if upper-case already present

### DIFF
--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -386,11 +386,17 @@ class SqlImplementation(
         return has_view
 
     def prefix_map(self) -> PREFIX_MAP:
+
+        def entity_prefix(curie: CURIE):
+            if ":" in curie:
+                return curie.split(":")[0]
+        
         if self._prefix_map is None:
             self._prefix_map = {row.prefix: row.base for row in self.session.query(Prefix)}
             prefixes = self._prefix_map.keys()
 
             # Check for duplicates, or they may raise an error in curies package
+            # If they are not present in the input then remove them from the prefixmap
             # see https://github.com/INCATools/ontology-access-kit/issues/606
             duplicate_prefixes = {
                 k: v
@@ -399,8 +405,10 @@ class SqlImplementation(
             }
             if bool(duplicate_prefixes):
                 logging.warning(f"Found duplicate prefixes in SqlImplementation's prefix map: {duplicate_prefixes}")
+                used_terms = list(set([entity_prefix(e) for e in self.entities() if e]))
                 for prefix in duplicate_prefixes:
-                    if prefix.islower():
+                    if prefix.islower() and not prefix in used_terms:
+                        logging.warning(f"Will remove prefix '{prefix}' as it is not used in the input.")
                         self._prefix_map.pop(prefix)
         return self._prefix_map
 

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -388,6 +388,19 @@ class SqlImplementation(
     def prefix_map(self) -> PREFIX_MAP:
         if self._prefix_map is None:
             self._prefix_map = {row.prefix: row.base for row in self.session.query(Prefix)}
+            prefixes = self._prefix_map.keys()
+
+            # Check for duplicates, or they may raise an error in curies package
+            # see https://github.com/INCATools/ontology-access-kit/issues/606
+            duplicate_prefixes = {
+                k: v
+                for k, v in self._prefix_map.items()
+                if (k.upper() in prefixes and k.lower() in prefixes)
+            }
+            if bool(duplicate_prefixes):
+                for prefix in duplicate_prefixes:
+                    if prefix.islower():
+                        self._prefix_map.pop(prefix)
         return self._prefix_map
 
     def languages(self) -> Iterable[LANGUAGE_TAG]:

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -386,11 +386,10 @@ class SqlImplementation(
         return has_view
 
     def prefix_map(self) -> PREFIX_MAP:
-
         def entity_prefix(curie: CURIE):
             if ":" in curie:
                 return curie.split(":")[0]
-        
+
         if self._prefix_map is None:
             self._prefix_map = {row.prefix: row.base for row in self.session.query(Prefix)}
             prefixes = self._prefix_map.keys()
@@ -404,11 +403,15 @@ class SqlImplementation(
                 if (k.upper() in prefixes and k.lower() in prefixes)
             }
             if bool(duplicate_prefixes):
-                logging.warning(f"Found duplicate prefixes in SqlImplementation's prefix map: {duplicate_prefixes}")
+                logging.warning(
+                    f"Found duplicate prefixes in SqlImplementation's prefix map: {duplicate_prefixes}"
+                )
                 used_terms = list(set([entity_prefix(e) for e in self.entities() if e]))
                 for prefix in duplicate_prefixes:
-                    if prefix.islower() and not prefix in used_terms:
-                        logging.warning(f"Will remove prefix '{prefix}' as it is not used in the input.")
+                    if prefix.islower() and prefix not in used_terms:
+                        logging.warning(
+                            f"Will remove prefix '{prefix}' as it is not used in the input."
+                        )
                         self._prefix_map.pop(prefix)
         return self._prefix_map
 

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -398,6 +398,7 @@ class SqlImplementation(
                 if (k.upper() in prefixes and k.lower() in prefixes)
             }
             if bool(duplicate_prefixes):
+                logging.warning(f"Found duplicate prefixes in SqlImplementation's prefix map: {duplicate_prefixes}")
                 for prefix in duplicate_prefixes:
                     if prefix.islower():
                         self._prefix_map.pop(prefix)


### PR DESCRIPTION
Something strange currently happens with ontologies retrieved as sql db - they contain a single duplicate prefix in their prefixmap, so a `curies` error gets raised. This PR avoids the error by removing duplicate prefixes from that prefixmap, where a duplicate is any lower-case version of an upper-case prefix in the map.