### PR TITLE
Include title and definition in vskit expand

### DIFF
--- a/src/oaklib/utilities/subsets/value_set_expander.py
+++ b/src/oaklib/utilities/subsets/value_set_expander.py
@@ -182,6 +182,7 @@ class ValueSetExpander(BasicOntologyInterface, ABC):
         oi: BasicOntologyInterface,
         enum_definition: EnumDefinition = None,
     ) -> PermissibleValue:
+        definition = oi.definition(curie)
         label = oi.label(curie)
         pv_formula = enum_definition.pv_formula if enum_definition else None
         if str(pv_formula) == "CURIE":
@@ -194,7 +195,7 @@ class ValueSetExpander(BasicOntologyInterface, ABC):
             text = curie.split(":")[1]
         else:
             text = curie
-        return PermissibleValue(text=text, meaning=curie, description=label)
+        return PermissibleValue(text=text, meaning=curie, description=definition, title=label)
 
     def expand_in_place(
         self,


### PR DESCRIPTION
This PR changes how linkml dynamic enums are rendered from the `vskit` command. 

- First, the generated permissible value will always include a `title` slot with the human readable label 
- and second it will include the definition for the `description` slot. 
- the text slot remains configurable using the `pv_formula` (and this [PR](https://github.com/linkml/linkml-model/pull/171) will enable using the human readable value as the permissible value)

This would add a bit of bloat to how enums are rendered. For my use case, I want to surface enums and definitions in our linkml-based documentation, so having a definition would be useful. If that is too much bloat, it make sense to add an additional flag or configuration option for mapping properties from the `BasicOntologyInterface` to their selected slots in the `PermissibleValue` schema. Curious if anyone has thoughts on the best way to implement that.

Here's an example of what the new generated enum doc would look like:

```yaml
enums:
  AssayEnum:
    description: >-
      AssayEnum is an enumeration of the different types of assays that can be performed
      on a sample.
    pv_formula: LABEL
    reachable_from:
      source_ontology: obo:efo
      source_nodes:
      - OBI:0000070   # assay
      include_self: true
      relationship_types:
      - rdfs:subClassOf
    permissible_values:
      TSA-seq:
        text: TSA-seq
        description: TSA-seq is an assay that uses tyramide signal amplification (TSA)
          to assess distance of DNA regions to a targeted nuclear compartment or protein,
          typically on a scale of 100-1000 nm.
        meaning: EFO:0009971
        title: TSA-seq
```