### PR TITLE
`ChefBuildError` fix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,7 +80,9 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: |
+          poetry add setuptools@latest
+          poetry install --no-interaction --no-root
 
       #----------------------------------------------
       #    install your root project, if required


### PR DESCRIPTION
This seems to be the solution for random errors in GitHub workflows due to poetry .

Another reference where this fix worked: https://github.com/mapping-commons/sssom-py/pull/433#issuecomment-1747314542