### PR TITLE
VSKit Permissible Value Label Fix

### DIFF
--- a/src/oaklib/utilities/subsets/value_set_expander.py
+++ b/src/oaklib/utilities/subsets/value_set_expander.py
@@ -188,7 +188,11 @@ class ValueSetExpander(BasicOntologyInterface, ABC):
         if str(pv_formula) == "CURIE":
             text = curie
         elif str(pv_formula) == "LABEL":
-            text = label
+            # not all ontologies will have text for every element
+            if label is not None:
+                text = label
+            else:
+                text = curie
         elif str(pv_formula) == "URI":
             text = curie
         elif str(pv_formula) == "CODE":


### PR DESCRIPTION
This is a small followup on https://github.com/INCATools/ontology-access-kit/pull/677

@nicholsn work was good, but sometimes ontologies do not have a valid value for Label/text, so this defaults to the CURIE if there is none.