### PR TITLE
VSKit  - description newline replacement

### DIFF
--- a/src/oaklib/utilities/subsets/value_set_expander.py
+++ b/src/oaklib/utilities/subsets/value_set_expander.py
@@ -183,6 +183,8 @@ class ValueSetExpander(BasicOntologyInterface, ABC):
         enum_definition: EnumDefinition = None,
     ) -> PermissibleValue:
         definition = oi.definition(curie)
+        # \n can break some downstream tooling like LinkML's gen-pydantic (v1.6.6)
+        definition = definition.replace('\n',' ')
         label = oi.label(curie)
         pv_formula = enum_definition.pv_formula if enum_definition else None
         if str(pv_formula) == "CURIE":

--- a/src/oaklib/utilities/subsets/value_set_expander.py
+++ b/src/oaklib/utilities/subsets/value_set_expander.py
@@ -184,7 +184,7 @@ class ValueSetExpander(BasicOntologyInterface, ABC):
     ) -> PermissibleValue:
         definition = oi.definition(curie)
         # \n can break some downstream tooling like LinkML's gen-pydantic (v1.6.6)
-        definition = definition.replace('\n',' ')
+        definition = definition.replace("\n", " ")
         label = oi.label(curie)
         pv_formula = enum_definition.pv_formula if enum_definition else None
         if str(pv_formula) == "CURIE":

--- a/src/oaklib/utilities/subsets/value_set_expander.py
+++ b/src/oaklib/utilities/subsets/value_set_expander.py
@@ -184,7 +184,8 @@ class ValueSetExpander(BasicOntologyInterface, ABC):
     ) -> PermissibleValue:
         definition = oi.definition(curie)
         # \n can break some downstream tooling like LinkML's gen-pydantic (v1.6.6)
-        definition = definition.replace("\n", " ")
+        if definition is not None:
+            definition = definition.replace("\n", " ")
         label = oi.label(curie)
         pv_formula = enum_definition.pv_formula if enum_definition else None
         if str(pv_formula) == "CURIE":


### PR DESCRIPTION
VSKit generates "descriptions" for LinkML from ontologies. Sometimes, those descriptions contain newline characters. These newline characters break downstream LinkML tooling such as the Pydantic generator. 

I believe that it is appropriate to replace those newline characters with spaces at this point in the flow. 


An example of this newline phenomenon is the permissible value IP-seq from EFO:

```
      IP-seq:
        text: IP-seq
        description: "IP-seq is an assay in which immunoprecipitation with high throughput\
          \ sequencing is used to identify the DNA/RNA-associated proteins or protein\
          \ complexes.\nAs an immunoprecipitation it can be ChIP, RIP or another immunoprecipitation\
          \ process."
        meaning: EFO:0005032
        title: IP-seq
```

Which does not look the same as, for example, its rendering on EBI
https://www.ebi.ac.uk/ols4/ontologies/efo/classes?short_form=EFO_0005032
