### PR TITLE
`lexical_index_to_sssom()` EPM param

### DIFF
--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -247,6 +247,7 @@ def lexical_index_to_sssom(
     ruleset: MappingRuleCollection = None,
     meta: Optional[Dict[str, t.Any]] = None,
     prefix_map: Union[None, Converter, t.Mapping[str, str]] = None,
+    extended_prefix_map: t.Iterable[Dict[str, t.Any]] = None,
     subjects: Collection[CURIE] = None,
     objects: Collection[CURIE] = None,
     symmetric: bool = False,
@@ -265,6 +266,9 @@ def lexical_index_to_sssom(
     :param ensure_strict_prefixes: If true, prefixes & mappings in SSSOM MappingSetDataFrame will be filtred.
     :return: SSSOM MappingSetDataFrame object.
     """
+    if prefix_map and extended_prefix_map:
+        raise ValueError("Can only pass prefix_map or extended_prefix_map, but not both.")
+
     mappings = []
     logging.info("Converting lexical index to SSSOM")
     if subjects:
@@ -313,7 +317,11 @@ def lexical_index_to_sssom(
 
     converter = curies.chain(
         [
-            Converter.from_prefix_map((meta or {}).pop(CURIE_MAP, {})),
+            Converter.from_extended_prefix_map(extended_prefix_map)
+            if extended_prefix_map
+            else Converter.from_prefix_map(prefix_map)
+            if prefix_map
+            else Converter.from_prefix_map((meta or {}).pop(CURIE_MAP, {})),
             ensure_converter(prefix_map, use_defaults=False),
             oi.converter,
         ]


### PR DESCRIPTION
## Changes
- Update: lexical_index_to_sssom(): Added param for extended prefix map

## Context
I was working on this https://github.com/monarch-initiative/mondo-ingest/pull/394 and was getting errors in both `sssom-py` and `ontology-access-kit`. For `sssom-py`, that resulted in some necessary changes (https://github.com/mapping-commons/sssom-py/pull/485). And at first, I also thought that OAK needed some changes / bugfixes, but it turns out that is not the case. What's here are not bugfixes, but some extended prefix map (EPM) support that might be nice to have.

Why no GH issue?
The reason this does not have an associated issue is because this is the result of me working locally trying to fix a bug, and this is the resulting code at the end of that process. The only change of possible value left over is EPM support being added to `lexical_index_to_sssom()`. Thus, if I were to make an issue for this, it'd be something like, general "EPM support".

Why no tests?
As this PR does not include any bugfix as I'd originally thought, it is now a low priority. Thus I'm submitting it in the state I left it. If people think this is worth merging and want a test, I can try to find the time to add.