### PR TITLE
value_set_names is None rather than ()

### DIFF
--- a/src/oaklib/implementations/semsimian/semsimian_implementation.py
+++ b/src/oaklib/implementations/semsimian/semsimian_implementation.py
@@ -5,7 +5,6 @@ import logging
 import math
 from dataclasses import dataclass, field
 from typing import (
-    TYPE_CHECKING,
     ClassVar,
     Dict,
     Iterable,
@@ -16,8 +15,8 @@ from typing import (
     Union,
 )
 
-if TYPE_CHECKING:
-    from semsimian import Semsimian
+
+from semsimian import Semsimian
 
 from oaklib.datamodels.similarity import (
     BestMatch,

--- a/src/oaklib/utilities/subsets/value_set_expander.py
+++ b/src/oaklib/utilities/subsets/value_set_expander.py
@@ -285,6 +285,7 @@ def expand(config: str, schema: str, value_set_names: List[str], output: str):
 
         vskit expand -c config.yaml -s schema.yaml -o expanded.yaml my_value_set1 my_value_set2
     """
+    value_set_names = None if not value_set_names else value_set_names
     expander = ValueSetExpander()
     if config:
         expander.configuration = yaml_loader.load(config, target_class=ValueSetConfiguration)


### PR DESCRIPTION
Fixes #701

When `value_set_names` param was not provided, it was passed as an empty tuple since it accepts multiple arguments. This PR forces it to be `None` instead on `()`