### PR TITLE
Remove flake8 and replace it by `ruff`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.12' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.9", "3.10", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11" ]
         exclude:
           - os: windows-latest
             python-version: "3.9"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,15 +25,15 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox
-      - name: Check code quality with flake8
-        run: tox -e flake8
+      - name: Check code quality with ruff
+        run: tox -e lint
 
   test:
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.9", "3.10" ]
+        python-version: [ "3.9", "3.10", "3.12" ]
         exclude:
           - os: windows-latest
             python-version: "3.9"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.12' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -6563,6 +6563,4 @@ semsimian = ["semsimian"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-
-content-hash = "41e6786f6cae2c8436d2ea845e2693ae1b971bb8b16a04db06acbe5e814dd2b7"
-
+content-hash = "4741a5db8b062457de5bc6ea86107f2a816cfa25f4bf29d4cee1cd9a66cb120d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6562,8 +6562,4 @@ seaborn = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-<<<<<<< Updated upstream
-content-hash = "49ae7f23beb97dabd2dbd035f1129f95749a10be3cfef954571e1536c7c3f6ee"
-=======
 content-hash = "41e6786f6cae2c8436d2ea845e2693ae1b971bb8b16a04db06acbe5e814dd2b7"
->>>>>>> Stashed changes

--- a/poetry.lock
+++ b/poetry.lock
@@ -3885,7 +3885,7 @@ xmp = ["defusedxml"]
 name = "pip"
 version = "24.0"
 description = "The PyPA recommended tool for installing Python packages."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "pip-24.0-py3-none-any.whl", hash = "sha256:ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc"},
@@ -6562,4 +6562,8 @@ seaborn = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
+<<<<<<< Updated upstream
 content-hash = "49ae7f23beb97dabd2dbd035f1129f95749a10be3cfef954571e1536c7c3f6ee"
+=======
+content-hash = "41e6786f6cae2c8436d2ea845e2693ae1b971bb8b16a04db06acbe5e814dd2b7"
+>>>>>>> Stashed changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ tox = "*"
 
 [tool.poetry.group.dev.dependencies]
 seaborn = "^0.12.2"
+pip = "^24.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ ignore-words-list = 'ptd,ot,nd,ser,oger,gard,te,fo,fof,bu,ue,ois,processus,infar
 lint.extend-ignore = [
     "D211",  # `no-blank-line-before-class`
     "D212",  # `multi-line-summary-first-line`
+    "E731",  # Do not assign a `lambda` expression, use a `def`
     "B005",  # Using `.strip()` with multi-character strings is misleading the reader
     "S101",  # Use of `assert` detected
     "S607",  # Starting a process with a partial executable path
@@ -113,7 +114,7 @@ lint.fixable = ["ALL"]
 lint.select = [
     # "B",  # bugbear
     # "D",  # pydocstyle
-    # "E",  # pycodestyle errors
+    "E",  # pycodestyle errors
     "F",  # Pyflakes
     "I",  # isort 
     "S",  # flake8-bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,33 @@ reverse_relative = true
 skip = '.git,*.pdf,*.svg,poetry.lock,*.obo,*.ttl,*.ofn,*.gaf,*.tsv,*.json,input'
 ignore-regex = '(^\s*"image/\S+": ".*|[a-z]*\.\.\.)'
 ignore-words-list = 'ptd,ot,nd,ser,oger,gard,te,fo,fof,bu,ue,ois,processus,infarction,infarctions'
+
+[tool.ruff]
+lint.extend-ignore = [
+    "D211",  # `no-blank-line-before-class`
+    "D212",  # `multi-line-summary-first-line`
+    "B005",  # Using `.strip()` with multi-character strings is misleading the reader
+    ]
+lint.exclude = ["src/oaklib/datamodels/*"]
+line-length = 120
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+lint.fixable = ["ALL"]
+
+# Select or ignore from https://beta.ruff.rs/docs/rules/
+lint.select = [
+    # "B",  # bugbear
+    # "D",  # pydocstyle
+    # "E",  # pycodestyle errors
+    "F",  # Pyflakes
+    "I",  # isort 
+    # "S",  # flake8-bandit
+    "W",  # Warning
+]
+
+lint.unfixable = []
+target-version = "py310"
+
+[tool.ruff.lint.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,10 @@ lint.extend-ignore = [
     "D211",  # `no-blank-line-before-class`
     "D212",  # `multi-line-summary-first-line`
     "B005",  # Using `.strip()` with multi-character strings is misleading the reader
+    "S101",  # Use of `assert` detected
+    "S607",  # Starting a process with a partial executable path
+    "S608",  # Possible SQL injection vector through string-based query construction
+    "S603",  # `subprocess` call: check for execution of untrusted input
     ]
 lint.exclude = ["src/oaklib/datamodels/*"]
 line-length = 120
@@ -112,7 +116,7 @@ lint.select = [
     # "E",  # pycodestyle errors
     "F",  # Pyflakes
     "I",  # isort 
-    # "S",  # flake8-bandit
+    "S",  # flake8-bandit
     "W",  # Warning
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ lint.fixable = ["ALL"]
 
 # Select or ignore from https://beta.ruff.rs/docs/rules/
 lint.select = [
-    # "B",  # bugbear
+    "B",  # bugbear
     # "D",  # pydocstyle
     "E",  # pycodestyle errors
     "F",  # Pyflakes

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -7,6 +7,7 @@ Executed using "runoak" command
 
 # TODO: order commands.
 # See https://stackoverflow.com/questions/47972638/how-can-i-define-the-order-of-click-sub-commands-in-help
+import ast
 import itertools
 import json
 import logging
@@ -767,7 +768,7 @@ def query_terms_iterator(query_terms: NESTED_LIST, impl: BasicOntologyInterface)
             # arbitrary python expression
             expr = query_terms[0]
             query_terms = query_terms[1:]
-            chain_results(eval(expr, {"impl": impl, "terms": results}))
+            chain_results(ast.literal_eval(expr, {"impl": impl, "terms": results}))
         elif term.startswith(".query"):
             # arbitrary SPARQL query
             params = _parse_params(term)

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -7,7 +7,6 @@ Executed using "runoak" command
 
 # TODO: order commands.
 # See https://stackoverflow.com/questions/47972638/how-can-i-define-the-order-of-click-sub-commands-in-help
-import ast
 import itertools
 import json
 import logging
@@ -768,7 +767,7 @@ def query_terms_iterator(query_terms: NESTED_LIST, impl: BasicOntologyInterface)
             # arbitrary python expression
             expr = query_terms[0]
             query_terms = query_terms[1:]
-            chain_results(ast.literal_eval(expr, {"impl": impl, "terms": results}))
+            chain_results(eval(expr, {"impl": impl, "terms": results}))  # noqa
         elif term.startswith(".query"):
             # arbitrary SPARQL query
             params = _parse_params(term)

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -4819,7 +4819,7 @@ def rollup(
         split_ids = [o.split(",", 1) for o in object_group]
         primary_ids = (s[0] for s in split_ids)
         secondary_ids = (s[1].split(",") if len(s) > 1 else [] for s in split_ids)
-        objects_dict = dict(zip(primary_ids, secondary_ids))
+        objects_dict = dict(zip(primary_ids, secondary_ids, strict=False))
 
         object_closure_predicates = _process_predicates_arg(predicates)
 

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -944,7 +944,8 @@ def main(
     import_depth: Optional[int],
     **kwargs,
 ):
-    """Run the oaklib Command Line.
+    """
+    Run the oaklib Command Line.
 
     A subcommand must be passed - for example: ancestors, terms, ...
 
@@ -1043,7 +1044,7 @@ def search(terms, output_type: str, autolabel, output: TextIO):
     Searches ontology for entities that have a label, alias, or other property matching a search term.
 
     Example:
-
+    -------
         runoak -i uberon.obo search limb
 
     This uses the Pronto implementation to load uberon from disk, and does a basic substring
@@ -1108,11 +1109,11 @@ def subsets(output: str):
     Shows information on subsets
 
     Example:
-
+    -------
         runoak -i obolibrary:go.obo subsets
 
     Example:
-
+    -------
         runoak -i cl.owl subsets
 
     For background on subsets, see https://incatools.github.io/ontology-access-kit/concepts.html#subsets
@@ -1121,16 +1122,17 @@ def subsets(output: str):
     terms (directly) in goslim_generic in GO:
 
     Example:
-
+    -------
         runoak -i sqlite:obo:go info .in goslim_generic
 
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/basic
 
-    See also:
-
+    See Also:
+    --------
         term-subsets command, which shows relationships of terms to subsets
+
     """
     impl = settings.impl
     if isinstance(impl, BasicOntologyInterface):
@@ -1163,25 +1165,25 @@ def obsoletes(
     Shows all obsolete entities.
 
     Example:
-
+    -------
         runoak -i obolibrary:go.obo obsoletes
 
     To exclude *merged terms*, use the ``--no-include-merged`` flag
 
     Example:
-
+    -------
         runoak -i obolibrary:go.obo obsoletes --no-include-merged
 
     To show migration relationships, use the ``--show-migration-relationships`` flag
 
     Example:
-
+    -------
         runoak -i obolibrary:go.obo obsoletes --show-migration-relationships
 
     You can also specify terms to show obsoletes for:
 
     Example:
-
+    -------
         runoak -i obolibrary:go.obo obsoletes --show-migration-relationships GO:0000187 GO:0000188
 
     More examples:
@@ -1191,6 +1193,7 @@ def obsoletes(
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/basic
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -1255,7 +1258,7 @@ def statistics(
     Shows all descriptive/summary statistics
 
     Example:
-
+    -------
         runoak -i sqlite:obo:pr statistics
 
     By default, this will show combined summary statistics for all terms
@@ -1269,7 +1272,7 @@ def statistics(
     - by prefix (e.g. GO, PR, CL, OBI)
 
     Example:
-
+    -------
         runoak -i sqlite:obo:pr statistics -p oio:hasOBONamespace
 
     Note: the oio:hasOBONamespace is *not* the same as the ID prefix, it is
@@ -1304,7 +1307,7 @@ def statistics(
     option.
 
     Example:
-
+    -------
         runoak -i v2.obo statistics --group-by-obo-namespace --compare-with v1.obo
 
     This will also include change stats broken down by KGCL change types. If
@@ -1317,6 +1320,7 @@ def statistics(
     Data model:
 
        https://w3id.org/oak/summary-statistics
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter)
@@ -1420,7 +1424,7 @@ def ontology_versions(ontologies, output: str, all: bool):
     Currently only implemented for BioPortal
 
     Example:
-
+    -------
         runoak -i bioportal: ontology-versions mp
 
     All ontologies:
@@ -1430,6 +1434,7 @@ def ontology_versions(ontologies, output: str, all: bool):
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/basic
+
     """
     impl = settings.impl
     writer = StreamingCsvWriter(output)
@@ -1457,19 +1462,19 @@ def ontology_metadata(ontologies, output_type: str, output: str, all: bool):
     Shows ontology metadata
 
     Example:
-
+    -------
         runoak -i bioportal: ontology-metadata obi uberon foodon
 
     Use the ``--all`` option to show all ontologies
 
     Example:
-
+    -------
         runoak -i bioportal: ontology-metadata --all
 
     By default the output is YAML. You can get the results as TSV:
 
     Example:
-
+    -------
         runoak -i bioportal: ontology-metadata --all -O csv
 
     .. warning::
@@ -1479,6 +1484,7 @@ def ontology_metadata(ontologies, output_type: str, output: str, all: bool):
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/basic
+
     """
     impl = settings.impl
     if output_type is None or output_type == "yaml":
@@ -1514,7 +1520,7 @@ def term_metadata(terms, predicates, additional_metadata: bool, output_type: str
     Shows term metadata.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:uberon term-metadata lung heart
 
     You can filter the results for only selected predicates:
@@ -1532,6 +1538,7 @@ def term_metadata(terms, predicates, additional_metadata: bool, output_type: str
     Data model:
 
        https://w3id.org/oak/ontology-metadata
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter)
@@ -1632,14 +1639,14 @@ def annotate(
     in these cases the endpoint functionality is used:
 
     Example:
-
+    -------
         runoak -i bioportal: annotate "enlarged nucleus in T-cells from peripheral blood"
 
     For other endpoints, the built-in OAK annotator is used. This currently uses a basic
     algorithm based on lexical matching.
 
-     Example:
-
+    Example:
+    -------
         runoak -i sqlite:obo:cl annotate "enlarged nucleus in T-cells from peripheral blood"
 
     Using the builtin annotator can be slow, as the lexical index is re-built every time.
@@ -1653,7 +1660,7 @@ def annotate(
     as gilda only performs grounding.
 
     Example:
-
+    -------
         runoak -i gilda: annotate -W BRCA2
 
     Aliases can be listed in the output by setting the flag
@@ -1683,6 +1690,7 @@ def annotate(
     Data model:
 
        https://w3id.org/oak/text-annotator
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter, datamodels.text_annotator)
@@ -1795,7 +1803,7 @@ def viz(
        This requires that `obographviz <https://github.com/INCATools/obographviz>`_ is installed.
 
     Example:
-
+    -------
         runoak -i sqlite:cl.db viz CL:4023094
 
     Same query on ubergraph:
@@ -1831,6 +1839,7 @@ def viz(
     Data model:
 
        https://w3id.org/oak/obograph
+
     """
     impl = settings.impl
     if not isinstance(impl, OboGraphInterface):
@@ -1947,7 +1956,7 @@ def tree(
     For general instructions, see the viz command, which this is analogous too.
 
     Example:
-
+    -------
         runoak -i envo.db tree ENVO:00000372 -p i,p
 
     This produces output like:
@@ -1966,7 +1975,7 @@ def tree(
     You can use the --gap-fill option to create a minimal tree:
 
     Example:
-
+    -------
         runoak -i envo.db tree --gap-fill 'pyroclastic shield volcano' 'subglacial volcano' volcano -p i
 
     This will show the tree containing only these terms, and the most direct inferred relationships between them.
@@ -1975,7 +1984,7 @@ def tree(
     the most informative intermediate classes:
 
     Example:
-
+    -------
         runoak -i envo.db tree --add-mrcas --gap-fill 'pyroclastic shield volcano'\
             'subglacial volcano' 'mud volcano' -p i
 
@@ -2002,6 +2011,7 @@ def tree(
     Data model:
 
        https://w3id.org/oak/obograph
+
     """
     impl = settings.impl
     if configure:
@@ -2089,7 +2099,7 @@ def ancestors(
     a parent includes all relationship types, not just is-a.
 
     Example:
-
+    -------
         runoak -i cl.owl ancestors CL:4023094
 
     This will show ancestry over the full relationship graph. Like any relational
@@ -2113,6 +2123,7 @@ def ancestors(
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/obograph
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -2212,19 +2223,19 @@ def paths(
     List all paths between one or more start curies.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:go paths  -p i,p 'nuclear membrane'
 
     This shows all shortest paths from nuclear membrane to all ancestors
 
     Example:
-
+    -------
         runoak -i sqlite:obo:go paths  -p i,p 'nuclear membrane' --target cytoplasm
 
     This shows shortest paths between two nodes
 
     Example:
-
+    -------
         runoak -i sqlite:obo:go paths  -p i,p 'nuclear membrane' 'thylakoid' --target cytoplasm 'thylakoid membrane'
 
     This shows all shortest paths between 4 combinations of starts and ends
@@ -2238,7 +2249,7 @@ def paths(
     You can also pass in weights for each predicate, used when calculating shortest paths.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:go paths  -p i,p 'nuclear membrane' --target cytoplasm \
                 --predicate-weights "{i: 0.0001, p: 999}"
 
@@ -2249,7 +2260,7 @@ def paths(
     This command can be combined with others to visualize the paths.
 
     Example:
-
+    -------
         alias go="runoak -i sqlite:obo:go"
         go paths  -p i,p 'nuclear membrane' --target cytoplasm --narrow | go viz --fill-gaps -
 
@@ -2259,6 +2270,7 @@ def paths(
     More examples:
 
        https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Paths.ipynb
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -2397,11 +2409,12 @@ def siblings(terms, predicates, output_type: str, output: str):
     List all siblings of a specified term or terms
 
     Example:
-
+    -------
         runoak -i cl.owl siblings CL:4023094
 
     Note that siblings is by default over ALL relationship types, so we recommend
     always being explicit and passing a predicate using -p (--predicates)
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingInfoWriter)
@@ -2437,11 +2450,11 @@ def descendants(
     List all descendants of a term
 
     Example:
-
+    -------
         runoak -i sqlite:obo:obi descendants assay -p i
 
     Example:
-
+    -------
         runoak -i sqlite:obo:uberon descendants heart -p i,p
 
     This is the inverse of the 'ancestors' command; see the documentation for
@@ -2452,6 +2465,7 @@ def descendants(
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/obograph
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingInfoWriter)
@@ -2490,11 +2504,11 @@ def dump(terms, output, output_type: str, config_file: str = None, **kwargs):
     Exports (dumps) the entire contents of an ontology.
 
     Example:
-
+    -------
         runoak -i pato.obo dump -o pato.json -O json
 
     Example:
-
+    -------
         runoak -i pato.owl dump -o pato.ttl -O turtle
 
     You can also pass in a JSON configuration file to parameterize the dump process.
@@ -2504,7 +2518,7 @@ def dump(terms, output, output_type: str, config_file: str = None, **kwargs):
     https://incatools.github.io/ontology-access-kit/converters/obo-graph-to-fhir.html
 
     Example:
-
+    -------
         runoak -i pato.owl dump -o pato.ttl -O fhirjson -c fhir_config.json -o pato.fhir.json
 
     Currently each implementation only supports a subset of formats.
@@ -2515,6 +2529,7 @@ def dump(terms, output, output_type: str, config_file: str = None, **kwargs):
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/basic
+
     """
     if terms:
         raise NotImplementedError("Currently dump for a subset of terms is not supported")
@@ -2548,11 +2563,11 @@ def transform(terms, transform, output, output_type: str, config_file: str = Non
     Transforms an ontology
 
     Example:
-
+    -------
         runoak -i pato.obo dump -o pato.json -O json
 
     Example:
-
+    -------
         runoak -i pato.owl dump -o pato.ttl -O turtle
 
     You can also pass in a JSON configuration file to parameterize the dump process.
@@ -2562,7 +2577,7 @@ def transform(terms, transform, output, output_type: str, config_file: str = Non
     https://incatools.github.io/ontology-access-kit/converters/obo-graph-to-fhir.html
 
     Example:
-
+    -------
         runoak -i pato.owl dump -o pato.ttl -O fhirjson -c fhir_config.json -o pato.fhir.json
 
     Currently each implementation only supports a subset of formats.
@@ -2573,6 +2588,7 @@ def transform(terms, transform, output, output_type: str, config_file: str = Non
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/basic
+
     """
     if terms:
         raise NotImplementedError("Currently transform for a subset of terms is not supported")
@@ -2636,7 +2652,7 @@ def prefixes(terms, used_only: bool, output, output_type: str):
     prefix maps.
 
     Example:
-
+    -------
         runoak --named-prefix-map prefixcc prefixes
 
     If an ontology is loaded, then --used-only can be used to restrict to
@@ -2746,7 +2762,7 @@ def similarity_pair(terms, predicates, autolabel: bool, output: TextIO, output_t
     Note: We recommend always specifying explicit predicate lists
 
     Example:
-
+    -------
         runoak -i ubergraph: similarity-pair -p i,p CL:0000540 CL:0000000
 
     You can omit predicates if you like but be warned this may yield
@@ -2770,6 +2786,7 @@ def similarity_pair(terms, predicates, autolabel: bool, output: TextIO, output_t
     Data model:
 
        https://w3id.org/oak/similarity
+
     """
     if len(terms) != 2:
         raise ValueError(f"Need exactly 2 terms: {terms}")
@@ -2851,7 +2868,7 @@ def similarity(
     - via explicit lists of terms or queries
 
     Example:
-
+    -------
         runoak -i hp.db similarity -p i --set1-file HPO-TERMS1 --set2-file HPO-TERMS2 -O csv
 
     This will compare every term in TERMS1 vs TERMS2
@@ -2859,13 +2876,13 @@ def similarity(
     Alternatively standard OAK term queries can be used, with "@" separating the two lists
 
     Example:
-
+    -------
         runoak -i hp.db similarity -p i TERM_1 TERM_2 ... TERM_N @ TERM_N+1 ... TERM_M
 
     The .all term syntax can be used to select all terms in an ontology
 
     Example:
-
+    -------
         runoak -i ma.db similarity -p i,p .all @ .all
 
     This can be mixed with other term selectors; for example to calculate the similarity of "neuron"
@@ -2892,6 +2909,7 @@ def similarity(
     Data model:
 
        https://w3id.org/oak/similarity
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter, datamodels.similarity)
@@ -2967,7 +2985,7 @@ def termset_similarity(
     This calculates a similarity matrix for two sets of terms.
 
     Example:
-
+    -------
         runoak -i go.db termset-similarity -p i,p nucleus membrane @ "nuclear membrane" vacuole -p i,p
 
     Python API:
@@ -2977,6 +2995,7 @@ def termset_similarity(
     Data model:
 
        https://w3id.org/oak/similarity
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter, datamodels.similarity)
@@ -3021,7 +3040,7 @@ def information_content(
     Show information content for term or list of terms
 
     Example:
-
+    -------
         runoak -i cl.db information-content -p i .all
 
     Like all OAK commands that operate over graphs, the graph traversal is controlled
@@ -3033,6 +3052,7 @@ def information_content(
     You can use an association file as the corpus:
 
         runoak -g hpoa.tsv -G hpoa -i hp.db information-content -p i --use-associations .all
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -3069,7 +3089,7 @@ def info(terms, output: TextIO, display: str, output_type: str):
     Show information on term or set of terms
 
     Example:
-
+    -------
         runoak -i sqlite:obo:cl info CL:4023094
 
     The default output is minimal, showing only ID and label
@@ -3110,6 +3130,7 @@ def info(terms, output: TextIO, display: str, output_type: str):
     Info on all subtypes of "statistical hypothesis test" in STATO:
 
         runoak -i sqlite:obo:stato info .desc//p=i 'statistical hypothesis test'
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingInfoWriter)
@@ -3127,7 +3148,7 @@ def languages():
     Show available languages
 
     Example:
-
+    -------
         runoak languages
 
     """
@@ -3161,13 +3182,13 @@ def labels(
     Show labels for term or list of terms
 
     Example:
-
+    -------
         runoak -i cl.owl labels CL:4023093 CL:4023094
 
     You can use the ".all" selector to show all labels:
 
     Example:
-
+    -------
         runoak -i cl.owl labels .all
 
     (this may be blocked for remote endpoints)
@@ -3183,18 +3204,19 @@ def labels(
     a particular language.
 
     Example:
-
+    -------
         runoak --preferred-language fr -i sqlite:obo:hpinternational labels .ancestors HP:0020110
 
     You can also query for all languages, and see these pivoted:
 
     Example:
-
+    -------
         runoak  -i sqlite:obo:hpinternational labels .ancestors HP:0020110 --pivot-languages
 
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/labels
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -3264,13 +3286,13 @@ def definitions(
     Show textual definitions for term or set of terms
 
     Example:
-
+    -------
         runoak -i sqlite:obo:envo definitions 'tropical biome' 'temperate biome'
 
     You can use the ".all" selector to show all definitions for all terms in the ontology:
 
     Example:
-
+    -------
         runoak -i sqlite:obo:envo definitions .all
 
     You can also include definition metadata, such as provenance and source:
@@ -3375,25 +3397,25 @@ def relationships(
     By default, this shows all relationships where the input term(s) are the *subjects*
 
     Example:
-
+    -------
         runoak -i cl.db relationships CL:4023094
 
     Like all OAK commands, a label can be passed instead of a CURIE
 
     Example:
-
+    -------
         runoak -i cl.db relationships neuron
 
     To reverse the direction, and query where the search term(s) are *objects*, use the --direction flag:
 
     Example:
-
+    -------
         runoak -i cl.db relationships --direction down neuron
 
     Multiple terms can be passed
 
     Example:
-
+    -------
         runoak -i uberon.db relationships heart liver lung
 
     And like all OAK commands, a query can be passed rather than an explicit term list
@@ -3411,6 +3433,7 @@ def relationships(
     Python API:
 
        https://incatools.github.io/ontology-access-kit/interfaces/basic
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -3542,7 +3565,7 @@ def logical_definitions(
     You can also specify CSV to generate a flattened form of this.
 
     Example:
-
+    -------
         pato logical-definitions .all --output-type csv
 
     You can optionally choose to "--matrix-axes" to transform the output to a matrix form.
@@ -3550,12 +3573,12 @@ def logical_definitions(
     type: "f" for filler, "p" for predicate, "g" for genus, "d" for defined class.
 
     Example:
-
+    -------
     - Each property/predicate is a column
     - For repeated properties, columns of the form prop_1, prop_2, ... are generated
 
     Example:
-
+    -------
         pato logical-definitions .all  --matrix-axes d,p --output-type csv
 
     This will generate a row for each defined class with a logical definition, with columns
@@ -3579,6 +3602,7 @@ def logical_definitions(
     Data model:
 
        https://w3id.org/oak/obograph
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter)
@@ -3678,7 +3702,7 @@ def disjoints(
     serialization:
 
     Example:
-
+    -------
         runoak -i sqlite:obo:uberon disjoints
 
     Note that this will include pairwise disjoints, setwise disjoints,
@@ -3687,18 +3711,19 @@ def disjoints(
     A tabular format can be easier to browse, and includes labels by default:
 
     Example:
-
+    -------
         runoak -i sqlite:obo:uberon disjoints --autolabel -O csv
 
     To perform this on a subset:
 
-     Example:
-
+    Example:
+    -------
         runoak -i sqlite:obo:cl disjoints --autolabel -O csv  .desc//p=i "immune cell"
 
     Data model:
 
        https://w3id.org/oak/obograph
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter)
@@ -3794,7 +3819,7 @@ def terms(output: str, owl_type, filter_obsoletes: bool):
     List all terms in the ontology
 
     Example:
-
+    -------
         runoak -i db/cob.db terms
 
     All terms without obsoletes:
@@ -3814,6 +3839,7 @@ def terms(output: str, owl_type, filter_obsoletes: bool):
     Annotation properties:
 
         runoak -i sqlite:obo:omo terms --owl-type owl:AnnotationProperty
+
     """
     impl = settings.impl
     if isinstance(impl, BasicOntologyInterface):
@@ -3845,7 +3871,7 @@ def roots(output: str, output_type: str, predicates: str, has_prefix: str, annot
     and parameterizing
 
     Example:
-
+    -------
         runoak -i db/cob.db roots
 
     This command is a wrapper onto the "roots" command in the BasicOntologyInterface.
@@ -3882,13 +3908,14 @@ def leafs(output: str, predicates: str, filter_obsoletes: bool):
     Note that the default is to return the roots of the relation graph over *all* predicates
 
     Example:
-
+    -------
         runoak -i db/cob.db leafs
 
     This command is a wrapper onto the "leafs" command in the BasicOntologyInterface.
 
     - https://incatools.github.io/ontology-access-kit/interfaces/basic.html#
       oaklib.interfaces.basic_ontology_interface.BasicOntologyInterface.leafs
+
     """
     impl = settings.impl
     if isinstance(impl, OboGraphInterface):
@@ -3913,13 +3940,14 @@ def singletons(output: str, predicates: str, filter_obsoletes: bool):
     Obsoletes are filtered by default
 
     Example:
-
+    -------
         runoak -i db/cob.db singletons
 
     This command is a wrapper onto the "singletons" command in the BasicOntologyInterface.
 
     - https://incatools.github.io/ontology-access-kit/interfaces/basic.html#
       oaklib.interfaces.basic_ontology_interface.BasicOntologyInterface.singletons
+
     """
     impl = settings.impl
     if isinstance(impl, OboGraphInterface):
@@ -3949,7 +3977,7 @@ def mappings(terms, maps_to_source, autolabel: bool, output, output_type, mapper
     List all mappings encoded in the ontology
 
     Example:
-
+    -------
         runoak -i sqlite:obo:envo mappings
 
     The default output is SSSOM YAML. To use the (canonical) csv format:
@@ -3972,6 +4000,7 @@ def mappings(terms, maps_to_source, autolabel: bool, output, output_type, mapper
     Data model:
 
        https://w3id.org/oak/mapping-provider
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter, datamodel=sssom_schema)
@@ -4020,7 +4049,7 @@ def normalize(terms, maps_to_source, autolabel: bool, output, output_type):
     Normalize all input identifiers.
 
     Example:
-
+    -------
         runoak -i translator: normalize HGNC:1 HGNC:2 -M NCBIGene
 
     Python API:
@@ -4030,6 +4059,7 @@ def normalize(terms, maps_to_source, autolabel: bool, output, output_type):
     Data model:
 
        https://w3id.org/oak/mapping-provider
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -4062,7 +4092,7 @@ def aliases(terms, output, output_type, obo_model):
     List aliases for a term or set of terms.
 
     Example:
-
+    -------
         runoak -i ubergraph:uberon aliases UBERON:0001988
 
     TERMS should be either an explicit list of terms or queries, or can be a selector query,
@@ -4080,6 +4110,7 @@ def aliases(terms, output, output_type, obo_model):
     richer data if present in the ontology, including synonym categories/types, synonym provenance
 
     In future, this may become the default
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -4119,7 +4150,7 @@ def term_subsets(terms, output, output_type):
     List subsets for a term or set of terms.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:uberon term-subsets heart lung
 
     Python API:
@@ -4147,8 +4178,9 @@ def expand_subsets(subsets: list, output, predicates):
     For each subset provide a mapping of each term in the ontology to a subset
 
     Example:
-
+    -------
         runoak -i db/pato.db expand-subsets attribute_slim value_slim
+
     """
     impl = settings.impl
     # writer = StreamingCsvWriter(output)
@@ -4205,7 +4237,7 @@ def axioms(terms, output: str, output_type: str, axiom_type: str, about: str, re
     Filters axioms
 
     Example:
-
+    -------
         runoak -i cl.ofn axiom
 
     The above will write all axioms.
@@ -4213,10 +4245,11 @@ def axioms(terms, output: str, output_type: str, axiom_type: str, about: str, re
     You can filter by axiom type:
 
     Example:
-
+    -------
         runoak -i cl.ofn axiom --axiom-type SubClassOf
 
     Note this currently only works with the funowl adapter, on functional syntax files
+
     """
     impl = settings.impl
     writer = StreamingAxiomWriter(syntax=output_type, functional_writer=impl.functional_writer)
@@ -4283,11 +4316,11 @@ def taxon_constraints(
     of NCBI Taxonomy
 
     Example:
-
+    -------
         runoak -i db/go.db taxon-constraints GO:0034357 --include-redundant -p i,p
 
     Example:
-
+    -------
         runoak -i sqlite:obo:uberon taxon-constraints UBERON:0003884 UBERON:0003941 -p i,p
 
     More examples:
@@ -4297,6 +4330,7 @@ def taxon_constraints(
     This command is a wrapper onto taxon_constraints_utils:
 
     - https://incatools.github.io/ontology-access-kit/src/oaklib.utilities.taxon.taxon_constraints_utils
+
     """
     impl = settings.impl
     writer = _get_writer(
@@ -4348,7 +4382,7 @@ def apply_taxon_constraints(
     separated by periods.
 
     Example:
-
+    -------
         runoak  -i db/go.db apply-taxon-constraints -p i,p GO:0005743 only NCBITaxon:2759
         never NCBITaxon:2 . GO:0005634 only NCBITaxon:2
 
@@ -4360,7 +4394,7 @@ def apply_taxon_constraints(
         GO:0000229,Gain|NCBITaxon:1(root);>Loss|NCBITaxon:2759(Eukaryota);
 
     Example:
-
+    -------
         runoak  -i db/go.db eval-taxon-constraints -p i,p -E tests/input/go-evo-gains-losses.csv
 
     More examples:
@@ -4460,7 +4494,7 @@ def associations(
     Lookup associations from or to entities.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:hp -g test.hpoa -G hpoa associations
 
     The above will show all associations
@@ -4469,7 +4503,7 @@ def associations(
     terms or term queries, plus the closure predicate(s), e.g.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:hp -g test.hpoa -G hpoa associations -p i HP:0001392
 
     This shows all annotations either to "Abnormality of the liver" (HP:0001392), or
@@ -4483,12 +4517,13 @@ def associations(
     For example, the go-dictybase-input-spec combines go plus dictybase associations.
 
     Example:
-
+    -------
         runoak --i src/oaklib/conf/go-dictybase-input-spec.yaml associations -p i,p GO:0008104
 
     More examples:
 
        https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Associations.ipynb
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -4617,7 +4652,7 @@ def associations_counts(
     Count associations, grouped by subject or object
 
     Example:
-
+    -------
         runoak -i sqlite:obo:hp -g test.hpoa -G hpoa associations-counts
 
     This will default to summarzing by objects (HPO term), showing the number
@@ -4627,13 +4662,13 @@ def associations_counts(
     the closure predicate(s), e.g.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:hp -g test.hpoa -G hpoa associations -p i
 
     You can also group by other fields
 
     Example:
-
+    -------
         runoak -i sqlite:obo:hp -g test.hpoa -G hpoa associations-counts --group-by subject
 
     This will show the number of associations for each disease.
@@ -4653,6 +4688,7 @@ def associations_counts(
 
     This command accepts many of the same options as the associations command, see
     the docs for this command for details.
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -4727,12 +4763,13 @@ def associations_matrix(
     See: Wood V., Carbon S., et al, https://royalsocietypublishing.org/doi/10.1098/rsob.200149
 
     Example:
-
+    -------
         runoak  -i amigo:NCBITaxon:9606 associations-matrix -p i,p GO:0042416 GO:0014046
 
     As a heatmap:
 
         runoak  -i amigo:NCBITaxon:9606 associations-matrix -p i,p GO:0042416 GO:0014046 -o heatmap > /tmp/heatmap.png
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -4793,7 +4830,7 @@ def rollup(
     sub-groups.
 
     Example:
-
+    -------
         runoak -i sqlite:go.db -g wb.gaf -G gaf rollup \
             --object-group GO:0032502,GO:0007568,GO:0048869,GO:0098727 \
             --object-group GO:0008152,GO:0009056,GO:0044238,GO:1901275 \
@@ -4943,7 +4980,7 @@ def enrichment(
     associations, return the terms that are over-represented in the sample set.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:uberon -g gene2anat.txt -G g2t enrichment -U my-genes.txt -O csv
 
     This runs an enrichment using Uberon on my-genes.txt, using the gene2anat.txt file as the
@@ -4964,6 +5001,7 @@ def enrichment(
     no associations and using --ontology-only. This creates a fake association set that is simply
     reflexive relations between each term and itself. This can be useful for summarizing term lists,
     but note that P-values may not be meaningful.
+
     """
     impl = settings.impl
     actual_predicates = _process_predicates_arg(predicates)
@@ -5031,7 +5069,7 @@ def diff_associations(
     Diffs two association sources.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:go  -G gaf  diff-associations \
            --old-date ${date1} --new-date ${date2} \
            -g  "${download_dir}/${group}-${date1}.gaf" \
@@ -5042,6 +5080,7 @@ def diff_associations(
     See https://w3id.org/oak/association for the diff data model.
 
     NOTE: This functionality may move out of core
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
@@ -5129,7 +5168,7 @@ def validate(
     Implementation notes: Currently only works on SQLite
 
     Example:
-
+    -------
         runoak  -i db/ecto.db validate -o results.tsv
 
     The default validation performed is structural (conformance to the ontology_metadata schema)
@@ -5140,12 +5179,13 @@ def validate(
     To run these, pass --no-skip-ontology-rules
 
     Example:
-
+    -------
         runoak -i db/uberon.db validate --skip-structural-validation --no-skip-ontology-rules
 
     For more information, see the OAK how-to guide:
 
     - https://incatools.github.io/ontology-access-kit/howtos/validate-an-obo-ontology.html
+
     """
     impl = settings.impl
     writer = _get_writer(
@@ -5272,7 +5312,7 @@ def validate_definitions(terms, skip_text_annotation, output: str, output_type: 
     checks for presence of definitions, use --skip-text-annotation:
 
     Example:
-
+    -------
         runoak validate-definitions -i db/uberon.db --skip-text-annotation
 
     Like most OAK commands, this accepts lists of terms or term queries
@@ -5280,7 +5320,7 @@ def validate_definitions(terms, skip_text_annotation, output: str, output_type: 
     individual classes
 
     Example:
-
+    -------
          runoak validate-definitions -i db/cl.db CL:0002053
 
     Only on CL identifiers:
@@ -5300,9 +5340,10 @@ def validate_definitions(terms, skip_text_annotation, output: str, output_type: 
     The default serialization of the datamodel is CSV.
 
     Notes:
-
+    -----
     This command is largely redundant with the validate command, but is useful for
     targeted validation focused solely on definitions
+
     """
     impl = settings.impl
     writer = _get_writer(
@@ -5416,13 +5457,14 @@ def migrate_curies(curie_pairs, replace: bool, output_type, output: str):
     source and the target
 
     Example:
-
+    -------
         runoak -i db/uberon.db migrate-curies --replace SRC1=TGT1 SRC2=TGT2
 
     This command is a wrapper onto the "migrate_curies" command in the PatcherInterface
 
     - https://incatools.github.io/ontology-access-kit/interfaces/patcher.html#
     oaklib.interfaces.patcher_interface.PatcherInterface.migrate_curies
+
     """
     impl = settings.impl
     curie_map = {}
@@ -5447,9 +5489,11 @@ def set_apikey(endpoint, keyval):
     Sets an API key
 
     Example:
+    -------
         oak set-apikey -e bioportal MY-KEY-VALUE
 
     This is stored in an OS-dependent path
+
     """
     set_apikey_value(endpoint, keyval)
 
@@ -5536,8 +5580,8 @@ def lexmatch(
     """
     Performs lexical matching between pairs of terms in one more more ontologies.
 
-    Examples:
-
+    Examples
+    --------
         runoak -i foo.obo lexmatch -o foo.sssom.tsv
 
     In this example, the input ontology file is assumed to contain all pairs of terms to be mapped.
@@ -5582,6 +5626,7 @@ def lexmatch(
 
     - https://incatools.github.io/ontology-access-kit/packages/src/oaklib.utilities.lexical.lexical_indexer.html#
     module-oaklib.utilities.lexical.lexical_indexer
+
     """
     impl = settings.impl
     if rules_file:
@@ -5714,7 +5759,7 @@ def diff(
     Compute difference between two ontologies.
 
     Example:
-
+    -------
         runoak -i foo.obo diff -X bar.obo -o diff.yaml
 
     This will produce a list of Changes that are required to go from the main input ontology (--input)
@@ -5742,7 +5787,7 @@ def diff(
     the GO uses the oio:hasOBONamespace property to partition classes into 3 categories.
 
     Example:
-
+    -------
         runoak -i go.obo diff -X go-new.obo -o diff.yaml --statistics --group-by-property oio:hasOBONamespace
 
     This will produce a YAML dictionary, with outer keys being the values of the oio:hasOBONamespace property,
@@ -5848,7 +5893,7 @@ def apply(
     https://github.com/INCATools/kgcl
 
     Example:
-
+    -------
         runoak -i cl.owl.ttl apply "rename CL:0000561 to 'amacrine neuron'"  -o cl.owl.ttl -O ttl
 
     On an obo format file:
@@ -5861,12 +5906,13 @@ def apply(
           "rename <http://purl.obolibrary.org/obo/CL_0000561> from 'amacrine cell' to 'amacrine neuron'" \
            -o cl.owl.ttl -O ttl
 
-    WARNING:
-
+    Warning:
+    -------
     This command is still experimental. Some things to bear in mind:
 
     - for some ontologies, CURIEs may not work, instead specify a full URI surrounded by <>s
     - only a subset of KGCL commands are supported by each backend
+
     """
     impl = settings.impl
     configuration = kgcl.Configuration()
@@ -5940,7 +5986,7 @@ def apply_obsolete(output, output_type, expand: bool, terms, **kwargs):
     Sets an ontology element to be obsolete
 
     Example:
-
+    -------
         runoak -i my.obo apply-obsolete MY:0002200 -o my-modified.obo
 
     Multiple terms can be passed, as labels, IDs, or using OAK queries:
@@ -5953,6 +5999,7 @@ def apply_obsolete(output, output_type, expand: bool, terms, **kwargs):
         runoak -i my.db search 'l/^Foo/` | runoak -i my.db --autosave apply-obsolete -
 
     This command is partially redundant with the more general "apply" command
+
     """
     impl = settings.impl
     if not isinstance(impl, PatcherInterface):
@@ -5994,7 +6041,7 @@ def lint(output, output_type, report_format, dry_run: bool):
     By default, changes will be applied
 
     Example:
-
+    -------
         runoak -i my.obo lint
 
     This can be executed in dry-run mode, in which case changes are not applied:
@@ -6083,7 +6130,7 @@ def diff_via_mappings(
     command will perform a structural comparison of all mapped pairs of terms
 
     Example:
-
+    -------
         runoak -i sqlite:obo:uberon diff-via-mappings --other-input sqlite:obo:zfa  --source UBERON --source ZFA -O csv
 
     Note the above command does not have any mapping file specified; the mappings that are distributed within
@@ -6105,6 +6152,7 @@ def diff_via_mappings(
     (https://incatools.github.io/ontology-access-kit/datamodels/cross-ontology-diff/index.html)
 
     This can be serialized in YAML or TSV form
+
     """
     oi = settings.impl
     writer = _get_writer(
@@ -6229,7 +6277,7 @@ def fill_table(
     headers for a table of ontology elements (see later for configuration when you don't follow conventions)
 
     Example:
-
+    -------
         runoak -i cl.owl.ttl fill-table my-table.tsv
 
     (any implementation can be used)
@@ -6269,7 +6317,7 @@ def fill_table(
     given a TSV with columns cl_identifier and cl_display_label you can say:
 
     Example:
-
+    -------
         runoak -i cl.owl.ttl fill-table \
           --relation "{primary_key: cl_identifier, dependent_column: cl_display_label, relation: label}"
 
@@ -6297,6 +6345,7 @@ def fill_table(
     - TODO: add an option to detect inconsistencies
     - TODO: add logical for obsoletion/replaced by
     - TODO: use most optimized method for whichever backend
+
     """
     tf = TableFiller(settings.impl)
     with open(table_file) as input_file:
@@ -6390,16 +6439,17 @@ def generate_synonyms(terms, rules_file, apply_patch, patch, patch_format, outpu
     applied. Pass the `--patch` argument to lso get the patch file in KGCL format.
 
     Example:
-
+    -------
         runoak -i foo.obo generate-synonyms -R foo_rules.yaml --patch patch.kgcl --apply-patch -o foo_syn.obo
 
     If the `apply-patch` flag is NOT set then the main input will be KGCL commands
 
     Example:
-
+    -------
         runoak -i foo.obo generate-synonyms -R foo_rules.yaml -o changes.kgcl
 
     see https://github.com/INCATools/kgcl.
+
     """
     impl = settings.impl
     if apply_patch:
@@ -6486,13 +6536,13 @@ def generate_definitions(terms, apply_patch, patch, patch_format, output, output
     Currently this only works with the llm extension.
 
     Example:
-
+    -------
         runoak -i llm:sqlite:obo:foodon generate-definitions FOODON:03315258
 
     The --style-hints option can be used to provide hints to the definition generator.
 
     Example:
-
+    -------
         runoak -i llm:sqlite:obo:foodon generate-definitions FOODON:03315258 \
           --style-hints "Write the definition in the style of a pretentious food critic"
 
@@ -6676,12 +6726,13 @@ def generate_disjoints(
     Generate candidate disjointness axioms.
 
     Example:
-
+    -------
         runoak -i sqlite:obo:iao generate-disjoints -O obo
 
     To generate spatial disjointness axioms:
 
         runoak -i sqlite:obo:zfa generate-disjoints -O obo p i,p
+
     """
     impl = settings.impl
     writer = _get_writer(output_type, impl, StreamingYamlWriter, kgcl)

--- a/src/oaklib/constants.py
+++ b/src/oaklib/constants.py
@@ -7,3 +7,4 @@ __all__ = [
 ]
 
 OAKLIB_MODULE = pystow.module("oaklib")
+TIMEOUT_SECONDS = 30

--- a/src/oaklib/converters/data_model_converter.py
+++ b/src/oaklib/converters/data_model_converter.py
@@ -10,7 +10,8 @@ from oaklib.types import CURIE
 
 @dataclass(eq=False)
 class DataModelConverter(ABC):
-    """Base class for all inter-data model converters.
+    """
+    Base class for all inter-data model converters.
 
     Do not use this directly: use one of the subclasses.
     """

--- a/src/oaklib/converters/logical_definition_flattener.py
+++ b/src/oaklib/converters/logical_definition_flattener.py
@@ -63,7 +63,7 @@ class LogicalDefinitionFlattener(DataModelConverter):
     def _curie(self, iri: str) -> CURIE:
         return self.curie_converter.compress(iri, passthrough=True)
 
-    @lru_cache
+    @lru_cache  # noqa
     def _property_label(self, predicate: CURIE) -> str:
         lbl = self.labeler(predicate) if self.labeler else None
         return lbl if lbl else predicate

--- a/src/oaklib/converters/obo_graph_to_fhir_converter.py
+++ b/src/oaklib/converters/obo_graph_to_fhir_converter.py
@@ -1,4 +1,5 @@
-"""OboGraph to FHIR Converter
+"""
+OboGraph to FHIR Converter
 
 Resources
 - Updates issue: https://github.com/INCATools/ontology-access-kit/issues/369
@@ -54,7 +55,8 @@ SCOPE_DISPLAY = {
 
 @dataclass
 class OboGraphToFHIRConverter(DataModelConverter):
-    """Converts from OboGraph to FHIR.
+    """
+    Converts from OboGraph to FHIR.
 
     - An ontology is mapped to a FHIR `CodeSystem <https://build.fhir.org/codesystem.html>`_.
     - Each node in the OboGraph is converted to a _FHIR Concept_.
@@ -184,7 +186,8 @@ class OboGraphToFHIRConverter(DataModelConverter):
         return target
 
     def code(self, uri: CURIE) -> str:
-        """Convert a packages.
+        """
+        Convert a packages.
 
         This is a wrapper onto curie_converter.compress
 

--- a/src/oaklib/implementations/gilda.py
+++ b/src/oaklib/implementations/gilda.py
@@ -18,7 +18,8 @@ __all__ = [
 
 @dataclass
 class GildaImplementation(TextAnnotatorInterface):
-    """Perform named entity normalization on text strings with Gilda [gyori2021]_.
+    """
+    Perform named entity normalization on text strings with Gilda [gyori2021]_.
 
     .. [gyori2021] Benjamin M Gyori, Charles Tapley Hoyt, Albert Steppi (2021)
         `Gilda: biomedical entity text normalization with machine-learned

--- a/src/oaklib/implementations/kgx/kgx_implementation.py
+++ b/src/oaklib/implementations/kgx/kgx_implementation.py
@@ -218,10 +218,11 @@ class KGXImplementation(
     - :class:`NodeProperty`
     - :class:`Edge`
 
-    See also:
-
+    See Also
+    --------
     - `Tutorial <https://incatools.github.io/ontology-access-kit/intro/tutorial07.html>`_
     - `SQL Implementation <https://incatools.github.io/ontology-access-kit/implementations/sqldb.html>`_
+
     """
 
     # TODO: use SQLA types

--- a/src/oaklib/implementations/llm_implementation.py
+++ b/src/oaklib/implementations/llm_implementation.py
@@ -364,7 +364,8 @@ class LLMImplementation(
     def generate_definitions(
         self, curies: List[CURIE], style_hints="", **kwargs
     ) -> Iterator[Tuple[CURIE, DefinitionPropertyValue]]:
-        """Suggest definitions for the given curies.
+        """
+        Suggest definitions for the given curies.
 
         Wraps the LLM to suggest definitions for the given curies.
 

--- a/src/oaklib/implementations/ncbi/ncbi_gene_implementation.py
+++ b/src/oaklib/implementations/ncbi/ncbi_gene_implementation.py
@@ -7,6 +7,7 @@ from xml.etree import ElementTree  # noqa S405
 
 import requests
 
+from oaklib.constants import TIMEOUT_SECONDS
 from oaklib.datamodels.association import Association
 from oaklib.datamodels.search import SearchConfiguration
 from oaklib.datamodels.vocabulary import RDFS_LABEL
@@ -105,7 +106,7 @@ class NCBIGeneImplementation(
                 "id": gene_id,
                 "retmode": "xml",
             }
-            response = requests.get(EFETCH_URL, params)
+            response = requests.get(EFETCH_URL, params, timeout=TIMEOUT_SECONDS)
 
             # Parsing the XML file
             root = ElementTree.fromstring(response.content)  # noqa S314
@@ -173,7 +174,7 @@ class NCBIGeneImplementation(
             "retmax": "10",  # Number of results to return (adjust as needed)
         }
 
-        response = requests.get(ESEARCH_URL, params=search_params)
+        response = requests.get(ESEARCH_URL, params=search_params, timeout=TIMEOUT_SECONDS)
         if response.status_code != 200:
             raise Exception(f"Failed to search for gene '{search_term}'")
 

--- a/src/oaklib/implementations/ols/ols_implementation.py
+++ b/src/oaklib/implementations/ols/ols_implementation.py
@@ -6,6 +6,7 @@ import requests
 from ols_client import Client, EBIClient, TIBClient
 from sssom_schema import Mapping
 
+from oaklib.constants import TIMEOUT_SECONDS
 from oaklib.datamodels import oxo
 from oaklib.datamodels.oxo import ScopeEnum
 from oaklib.datamodels.search import SearchConfiguration, SearchProperty
@@ -141,7 +142,7 @@ class BaseOlsImplementation(TextAnnotatorInterface, SearchInterface, MappingProv
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     def get_sssom_mappings_by_curie(self, curie: Union[str, CURIE]) -> Iterator[Mapping]:
-        result = requests.get(self.base_url, params=dict(fromId=curie))
+        result = requests.get(self.base_url, params=dict(fromId=curie), timeout=TIMEOUT_SECONDS)
         obj = result.json()
         container = load_oxo_payload(obj)
         return self.convert_payload(container)

--- a/src/oaklib/implementations/ontobee/ontobee_implementation.py
+++ b/src/oaklib/implementations/ontobee/ontobee_implementation.py
@@ -69,11 +69,11 @@ class OntobeeImplementation(
 
     Notes
     -----
-
     This is a specialization the :ref:`sparql` implementation to
     allow access for ontologies on the `Ontobee <https://www.ontobee.org/>`_ linked data server.
 
     See: `<https://www.ontobee.org/>`_
+
     """
 
     def _default_url(self) -> str:

--- a/src/oaklib/implementations/ontoportal/bioportal_implementation.py
+++ b/src/oaklib/implementations/ontoportal/bioportal_implementation.py
@@ -13,7 +13,7 @@ class BioPortalImplementation(OntoPortalImplementationBase):
     A :ref:`OntoPortal` implementation that connects to a bioportal endpoint.
 
     Example:
-
+    -------
     .. packages :: python
 
         >>> from oaklib.implementations.ontoportal.bioportal_implementation import BioPortalImplementation
@@ -31,6 +31,7 @@ class BioPortalImplementation(OntoPortalImplementationBase):
         ...
 
     See `<https://data.bioontology.org/documentation>`_
+
     """
 
     ontoportal_client_class = BioPortalClient

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -249,7 +249,7 @@ class ProntoImplementation(
     @deprecated("Use this when we fix https://github.com/fastobo/fastobo/issues/42")
     def load_graph_using_jsondoc(self, graph: Graph, replace: True) -> None:
         tf = tempfile.NamedTemporaryFile()
-        tf_name = "/tmp/tf.json"
+        tf_name = "/tmp/tf.json"  # noqa
         gd = GraphDocument(graphs=[graph])
         json_dumper.dump(gd, to_file=tf_name)
         tf.flush()

--- a/src/oaklib/implementations/pronto/pronto_implementation.py
+++ b/src/oaklib/implementations/pronto/pronto_implementation.py
@@ -129,7 +129,6 @@ class ProntoImplementation(
 
     Examples
     --------
-
     >>> from oaklib.implementations import ProntoImplementation
     >>> resource = OntologyResource(slug='go-nucleus.obo', directory='tests/input', local=True)
     >>> adapter = ProntoImplementation(resource)

--- a/src/oaklib/implementations/semsimian/semsimian_implementation.py
+++ b/src/oaklib/implementations/semsimian/semsimian_implementation.py
@@ -230,7 +230,8 @@ class SemSimianImplementation(SearchInterface, SemanticSimilarityInterface, OboG
         predicates: List[PRED_CURIE] = None,
         labels=False,
     ) -> TermSetPairwiseSimilarity:
-        """Return TermSetPairwiseSimilarity object.
+        """
+        Return TermSetPairwiseSimilarity object.
 
         :param subjects: List of subject nodes.
         :param objects: List of object nodes.

--- a/src/oaklib/implementations/semsimian/semsimian_implementation.py
+++ b/src/oaklib/implementations/semsimian/semsimian_implementation.py
@@ -226,6 +226,7 @@ class SemSimianImplementation(SearchInterface, SemanticSimilarityInterface, OboG
         self,
         subjects: List[CURIE],
         objects: List[CURIE],
+        score_metric: str = None,
         predicates: List[PRED_CURIE] = None,
         labels=False,
     ) -> TermSetPairwiseSimilarity:
@@ -241,7 +242,7 @@ class SemSimianImplementation(SearchInterface, SemanticSimilarityInterface, OboG
             predicates=predicates, attributes=self.termset_pairwise_similarity_attributes
         )
         sim = TermSetPairwiseSimilarity()
-        semsimian_tsps = semsimian.termset_pairwise_similarity(set(subjects), set(objects))
+        semsimian_tsps = semsimian.termset_pairwise_similarity(set(subjects), set(objects), score_metric)
 
         # Assuming all keys for the dict semsimian_tsps are attributes for the class TermSetPairwiseSimilarity,
         # populate the object `sim`

--- a/src/oaklib/implementations/semsimian/semsimian_implementation.py
+++ b/src/oaklib/implementations/semsimian/semsimian_implementation.py
@@ -242,7 +242,9 @@ class SemSimianImplementation(SearchInterface, SemanticSimilarityInterface, OboG
             predicates=predicates, attributes=self.termset_pairwise_similarity_attributes
         )
         sim = TermSetPairwiseSimilarity()
-        semsimian_tsps = semsimian.termset_pairwise_similarity(set(subjects), set(objects), score_metric)
+        semsimian_tsps = semsimian.termset_pairwise_similarity(
+            set(subjects), set(objects), score_metric
+        )
 
         # Assuming all keys for the dict semsimian_tsps are attributes for the class TermSetPairwiseSimilarity,
         # populate the object `sim`

--- a/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
@@ -885,7 +885,7 @@ class SimpleOboImplementation(
             t = self._stanza(patch.about_node, strict=True)
             # Get scope from patch.qualifier
             # rather than forcing all synonyms to be related.
-            if type(patch.qualifier) == str:
+            if isinstance(patch.qualifier) == str:
                 scope = patch.qualifier.upper()
             else:
                 scope = str(patch.qualifier.value).upper() if patch.qualifier else "RELATED"

--- a/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_implementation.py
@@ -885,7 +885,7 @@ class SimpleOboImplementation(
             t = self._stanza(patch.about_node, strict=True)
             # Get scope from patch.qualifier
             # rather than forcing all synonyms to be related.
-            if isinstance(patch.qualifier) == str:
+            if isinstance(patch.qualifier, str):
                 scope = patch.qualifier.upper()
             else:
                 scope = str(patch.qualifier.value).upper() if patch.qualifier else "RELATED"

--- a/src/oaklib/implementations/simpleobo/simple_obo_parser.py
+++ b/src/oaklib/implementations/simpleobo/simple_obo_parser.py
@@ -668,7 +668,8 @@ class OboDocument:
             s.normalize_order()
 
     def dump(self, file: TextIO, ensure_sorted=False, normalize_line_order=False) -> None:
-        """Export to a file
+        """
+        Export to a file
 
         :param file:
         :param ensure_sorted: Sort stanzas

--- a/src/oaklib/implementations/sparql/sparql_query.py
+++ b/src/oaklib/implementations/sparql/sparql_query.py
@@ -76,7 +76,6 @@ class SparqlUpdate(SparqlQuery):
         Generate the SPARQL update string
         :return:
         """
-
         q = f"""
         DELETE {{ {self.delete_str()} }}
         INSERT {{ {self.insert_str()} }}

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -1219,7 +1219,7 @@ class SqlImplementation(
                 )
                 assocs.append(association)
             subjects = {a.subject for a in assocs}
-            label_map = {s: l for s, l in self.labels(subjects)}
+            label_map = {s: name for s, name in self.labels(subjects)}
             for association in assocs:
                 if association.subject in label_map:
                     association.subject_label = label_map[association.subject]

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -306,10 +306,11 @@ class SqlImplementation(
     - :class:`Statements`
     - :class:`Edge`
 
-    See also:
-
+    See Also
+    --------
     - `Tutorial <https://incatools.github.io/ontology-access-kit/intro/tutorial07.html>`_
     - `SQL Implementation <https://incatools.github.io/ontology-access-kit/implementations/sqldb.html>`_
+
     """
 
     # TODO: use SQLA types

--- a/src/oaklib/implementations/translator/translator_implementation.py
+++ b/src/oaklib/implementations/translator/translator_implementation.py
@@ -15,6 +15,7 @@ from typing import Iterable, List, Mapping, Optional, Union
 import requests
 import sssom_schema.datamodel.sssom_schema as sssom
 
+from oaklib.constants import TIMEOUT_SECONDS
 from oaklib.datamodels.search import SearchConfiguration
 from oaklib.datamodels.vocabulary import (
     HAS_RELATED_SYNONYM,
@@ -56,9 +57,17 @@ class TranslatorImplementation(
             curies = [curies]
         else:
             curies = list(curies)
-        r = requests.get(NODE_NORMALIZER_ENDPOINT, params={"curie": curies, "conflate": "false"})
+        r = requests.get(
+            NODE_NORMALIZER_ENDPOINT,
+            params={"curie": curies, "conflate": "false"},
+            timeout=TIMEOUT_SECONDS,
+        )
         non_conflated_results = r.json()
-        r = requests.get(NODE_NORMALIZER_ENDPOINT, params={"curie": curies, "conflate": "true"})
+        r = requests.get(
+            NODE_NORMALIZER_ENDPOINT,
+            params={"curie": curies, "conflate": "true"},
+            timeout=TIMEOUT_SECONDS,
+        )
         results = r.json()
         objects = set()
         subjects = set()
@@ -113,6 +122,7 @@ class TranslatorImplementation(
         r = requests.get(
             f"{NAME_NORMALIZER_ENDPOINT}/lookup",
             params={"string": search_term, "autocomplete": "true"},
+            timeout=TIMEOUT_SECONDS,
         )
         r.raise_for_status()
         results = r.json()
@@ -126,7 +136,11 @@ class TranslatorImplementation(
             raise NotImplementedError
         if self.property_cache.contains(curie, RDFS_LABEL):
             return self.property_cache.get(curie, RDFS_LABEL)
-        r = requests.get(f"{NAME_NORMALIZER_ENDPOINT}/reverse_lookup", params={"curies": curie})
+        r = requests.get(
+            f"{NAME_NORMALIZER_ENDPOINT}/reverse_lookup",
+            params={"curies": curie},
+            timeout=TIMEOUT_SECONDS,
+        )
         r.raise_for_status()
         results = r.json()
         if curie not in results:
@@ -134,7 +148,11 @@ class TranslatorImplementation(
         return results[curie]["preferred_name"]
 
     def entity_aliases(self, curie: CURIE) -> List[str]:
-        r = requests.get(f"{NAME_NORMALIZER_ENDPOINT}/reverse_lookup", params={"curies": curie})
+        r = requests.get(
+            f"{NAME_NORMALIZER_ENDPOINT}/reverse_lookup",
+            params={"curies": curie},
+            timeout=TIMEOUT_SECONDS,
+        )
         r.raise_for_status()
         results = r.json()
         if curie not in results:

--- a/src/oaklib/implementations/uniprot/uniprot_implementation.py
+++ b/src/oaklib/implementations/uniprot/uniprot_implementation.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 import requests
 
+from oaklib.constants import TIMEOUT_SECONDS
 from oaklib.datamodels.association import Association
 from oaklib.datamodels.vocabulary import OWL_SAME_AS, RDF_SEE_ALSO
 from oaklib.implementations.sparql.abstract_sparql_implementation import (
@@ -304,7 +305,7 @@ class UniprotImplementation(
             params = {
                 "format": "json",
             }
-            response = requests.get(f"{UNIPROT_API_URL}/{acc}", params)
+            response = requests.get(f"{UNIPROT_API_URL}/{acc}", params, timeout=TIMEOUT_SECONDS)
             logging.info(f"URL: {response.url}")
             if response.status_code != 200:
                 raise ValueError(f"Could not find {subject}")

--- a/src/oaklib/implementations/uniprot/uniprot_implementation.py
+++ b/src/oaklib/implementations/uniprot/uniprot_implementation.py
@@ -158,7 +158,6 @@ class UniprotImplementation(
         :param include_entailed: TODO
         :return:
         """
-
         exclude_predicates = [
             "up:mappedCitation",
             "up:mappedAnnotation",

--- a/src/oaklib/inference/reasoner.py
+++ b/src/oaklib/inference/reasoner.py
@@ -3,5 +3,5 @@ from dataclasses import dataclass
 
 
 @dataclass
-class Reasoner(ABC):
+class Reasoner(ABC):  # noqa
     pass

--- a/src/oaklib/interfaces/association_provider_interface.py
+++ b/src/oaklib/interfaces/association_provider_interface.py
@@ -204,7 +204,7 @@ class AssociationProviderInterface(BasicOntologyInterface, ABC):
         for assoc_it in chunk(association_iterator):
             associations = list(assoc_it)
             subjects = {a.subject for a in associations}
-            label_map = {s: l for s, l in self.labels(subjects)}
+            label_map = {s: name for s, name in self.labels(subjects)}
             logging.info(f"LABEL MAP: {label_map} for {subjects}")
             for association in associations:
                 if association.subject in label_map:

--- a/src/oaklib/interfaces/basic_ontology_interface.py
+++ b/src/oaklib/interfaces/basic_ontology_interface.py
@@ -191,7 +191,8 @@ class BasicOntologyInterface(OntologyInterface, ABC):
 
     @property
     def converter(self) -> curies.Converter:
-        """Get a converter for this ontology interface's prefix map.
+        """
+        Get a converter for this ontology interface's prefix map.
 
         >>> from oaklib import get_adapter
         >>> adapter = get_adapter('tests/input/go-nucleus.db')
@@ -462,7 +463,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         Yields all known entities that are obsolete.
 
         Example:
-
+        -------
         >>> from oaklib import get_adapter
         >>> adapter = get_adapter("sqlite:obo:cob")
         >>> for entity in adapter.obsoletes():
@@ -487,7 +488,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         To exclude merged terms, set ``include_merged=False``:
 
         Example:
-
+        -------
         >>> from oaklib import get_adapter
         >>> adapter = get_adapter("sqlite:obo:cob")
         >>> for entity in adapter.obsoletes(include_merged=False):
@@ -498,6 +499,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
 
         :param include_merged: If True, merged terms will be included
         :return: iterator over CURIEs
+
         """
         raise NotImplementedError
 
@@ -508,7 +510,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         Yields relationships between an obsolete entity and potential replacements.
 
         Example:
-
+        -------
         >>> from oaklib import get_adapter
         >>> adapter = get_adapter("sqlite:obo:cob")
         >>> for rel in adapter.obsoletes_migration_relationships(adapter.obsoletes()):
@@ -521,6 +523,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         - rdfs:seeAlso
 
         :return: iterator
+
         """
         for entity in entities:
             for prop, vals in self.entity_metadata_map(entity).items():
@@ -537,7 +540,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
         Yields all known entities in provided set that are dangling.
 
         Example:
-
+        -------
         This example is over an OBO file with one stanza:
 
         .. code-block:: obo
@@ -562,6 +565,7 @@ class BasicOntologyInterface(OntologyInterface, ABC):
 
         :param curies: CURIEs to check for dangling; if empty will check all
         :return: iterator over CURIEs
+
         """
         if curies is None:
             curies = self.entities(filter_obsoletes=False)

--- a/src/oaklib/interfaces/patcher_interface.py
+++ b/src/oaklib/interfaces/patcher_interface.py
@@ -94,14 +94,15 @@ class PatcherInterface(BasicOntologyInterface, ABC):
         """
         Expand a complex change object to a list of atomic changes.
 
-        Examples:
-
+        Examples
+        --------
         - An obsoletion command may also generate a label change and removal or rewiring of edges
         - A NameBecomesSynonym may generate a NewSynonym and a NodeRename
 
         :param change:
         :param configuration:
         :return:
+
         """
         changes = [change]
         if isinstance(change, NameBecomesSynonym):

--- a/src/oaklib/interfaces/text_annotator_interface.py
+++ b/src/oaklib/interfaces/text_annotator_interface.py
@@ -181,7 +181,8 @@ class TextAnnotatorInterface(BasicOntologyInterface, ABC):
         text_file: TextIOWrapper,
         configuration: TextAnnotationConfiguration = None,
     ) -> Iterator[TextAnnotation]:
-        """Annotate text in a file.
+        """
+        Annotate text in a file.
 
         :param text_file: Text file that is iterated line-by-line.
         :param configuration: Text annotation configuration, defaults to None.
@@ -203,7 +204,8 @@ class TextAnnotatorInterface(BasicOntologyInterface, ABC):
         match_multiple=False,
         include_unmatched=True,
     ) -> Iterator[Dict[str, str]]:
-        """Annotate text in a file.
+        """
+        Annotate text in a file.
 
         :param text_file: Text file that is iterated line-by-line.
         :param configuration: Text annotation configuration, defaults to None.

--- a/src/oaklib/io/streaming_writer.py
+++ b/src/oaklib/io/streaming_writer.py
@@ -105,7 +105,7 @@ class StreamingWriter(ABC):
         obj_as_dict = json_dumper.to_dict(obj)
         return self.emit(obj_as_dict)
 
-    def close(self):
+    def close(self):  # noqa
         pass
 
     def finish(self):

--- a/src/oaklib/parsers/gencc_association_parser.py
+++ b/src/oaklib/parsers/gencc_association_parser.py
@@ -14,7 +14,8 @@ from oaklib.parsers.xaf_association_parser import XafAssociationParser
 
 @dataclass
 class GenCCAssociationParser(XafAssociationParser):
-    """Parsers for GenCC CSV format.
+    """
+    Parsers for GenCC CSV format.
 
     .. warning ::
 

--- a/src/oaklib/parsers/hpoa_g2d_association_parser.py
+++ b/src/oaklib/parsers/hpoa_g2d_association_parser.py
@@ -10,7 +10,8 @@ from oaklib.parsers.xaf_association_parser import XafAssociationParser
 
 @dataclass
 class HpoaG2DAssociationParser(XafAssociationParser):
-    """Parsers for Hpoa G2D format.
+    """
+    Parsers for Hpoa G2D format.
 
     Usage:
 

--- a/src/oaklib/parsers/mim2gene_association_parser.py
+++ b/src/oaklib/parsers/mim2gene_association_parser.py
@@ -14,7 +14,8 @@ from oaklib.parsers.xaf_association_parser import XafAssociationParser
 
 @dataclass
 class MedgenMimG2DAssociationParser(XafAssociationParser):
-    """Parsers for MIM2GENE NCBI TSV format.
+    """
+    Parsers for MIM2GENE NCBI TSV format.
 
     See `<ftp://ftp.ncbi.nih.gov/gene/DATA/mim2gene_medgen>`_ for more information.
     """

--- a/src/oaklib/parsers/xaf_association_parser.py
+++ b/src/oaklib/parsers/xaf_association_parser.py
@@ -31,7 +31,8 @@ def _check_identifier(s: str, expected_prefixes: List[str], must_be_curie: bool)
 
 @dataclass
 class XafAssociationParser(AssociationParser):
-    """Parsers for GAF and GAF-like formats.
+    """
+    Parsers for GAF and GAF-like formats.
 
     Note that implementations should use a subclass of this, and override ClassVars to
     determine behavior.

--- a/src/oaklib/selector.py
+++ b/src/oaklib/selector.py
@@ -11,6 +11,7 @@ from linkml_runtime.loaders import yaml_loader
 
 from oaklib import BasicOntologyInterface
 from oaklib import datamodels as datamodels_package
+from oaklib.constants import TIMEOUT_SECONDS
 from oaklib.datamodels.input_specification import InputSpecification, Normalizer
 from oaklib.implementations import GildaImplementation
 from oaklib.implementations.funowl.funowl_implementation import FunOwlImplementation
@@ -271,7 +272,7 @@ def add_associations(
 
 
 def file_from_gzip_url(url, is_compressed=False):
-    with requests.get(url, stream=True) as response:
+    with requests.get(url, stream=True, timeout=TIMEOUT_SECONDS) as response:
         response.raise_for_status()  # Raise an exception if the response contains an HTTP error status code
         # Wrap the response's raw stream in a binary file-like object
         binary_file_like_object = io.BytesIO(response.raw.read())
@@ -281,7 +282,7 @@ def file_from_gzip_url(url, is_compressed=False):
 
 
 def file_from_url(url):
-    response = requests.get(url)
+    response = requests.get(url, timeout=TIMEOUT_SECONDS)
     response.raise_for_status()  # Raise an exception if the response contains an HTTP error status code
     # Create a file-like object using the response content
     file_like_object = io.StringIO(response.text)

--- a/src/oaklib/selector.py
+++ b/src/oaklib/selector.py
@@ -229,7 +229,7 @@ def add_associations(
         entry = ASSOCIATION_REGISTRY[scheme]
         params, format, url_template, compressed = entry
         if params:
-            param_vals = dict(zip(params, path.split("//")))
+            param_vals = dict(zip(params, path.split("//"), strict=False))
         else:
             param_vals = {}
         url = url_template.format(**param_vals)

--- a/src/oaklib/selector.py
+++ b/src/oaklib/selector.py
@@ -90,7 +90,7 @@ def get_adapter(
     resource or ontology within that scheme.
 
     Example:
-
+    -------
     .. packages :: python
 
         >>> from oaklib import get_adapter
@@ -141,6 +141,7 @@ def get_adapter(
     :param format: file format/syntax, e.g obo, turtle
     :param kwargs: Keyword arguments to pass through to the implementation class
     :return: An instantiated interface
+
     """
     if isinstance(descriptor, InputSpecification):
         return _get_adapter_from_specification(descriptor)

--- a/src/oaklib/transformers/edge_filter_transformer.py
+++ b/src/oaklib/transformers/edge_filter_transformer.py
@@ -27,7 +27,7 @@ class EdgeFilterTransformer(GraphTransformer):
         Filters edges from a graph.
 
         Example:
-
+        -------
         >>> from oaklib import get_adapter
         >>> from oaklib.transformers.transformers_factory import get_ontology_transformer
         >>> from oaklib.datamodels.vocabulary import IS_A
@@ -40,6 +40,7 @@ class EdgeFilterTransformer(GraphTransformer):
 
         :param graph:
         :return:
+
         """
         include_predicates = self.include_predicates
         exclude_predicates = self.exclude_predicates

--- a/src/oaklib/transformers/node_filter_transformer.py
+++ b/src/oaklib/transformers/node_filter_transformer.py
@@ -22,7 +22,7 @@ class NodeFilterTransformer(GraphTransformer):
         Filters Nodes from a graph.
 
         Example:
-
+        -------
         >>> from oaklib import get_adapter
         >>> from oaklib.transformers.node_filter_transformer import NodeFilterTransformer
         >>> from oaklib.datamodels.vocabulary import IS_A
@@ -37,8 +37,8 @@ class NodeFilterTransformer(GraphTransformer):
 
         :param graph:
         :return:
-        """
 
+        """
         new_nodes = []
         for node in source_ontology.nodes:
             if self.filter_function is not None:

--- a/src/oaklib/transformers/ontology_transformer.py
+++ b/src/oaklib/transformers/ontology_transformer.py
@@ -4,7 +4,7 @@ from typing import Any
 
 
 @dataclass
-class OntologyTransformer(ABC):
+class OntologyTransformer(ABC):  # noqa
     """
     A class for transforming ontologies
     """

--- a/src/oaklib/transformers/sep_transformer.py
+++ b/src/oaklib/transformers/sep_transformer.py
@@ -68,7 +68,7 @@ class SEPTransformer(GraphTransformer):
         Filters edges from a graph.
 
         Example:
-
+        -------
         >>> from oaklib import get_adapter
         >>> from oaklib.transformers.sep_transformer import SEPTransformer
         >>> from oaklib.datamodels.vocabulary import PART_OF
@@ -86,6 +86,7 @@ class SEPTransformer(GraphTransformer):
 
         :param source_ontology:
         :return:
+
         """
         subsumption_pred = "is_a"
         make_entity_top_node = self.make_entity_top_node

--- a/src/oaklib/utilities/axioms/logical_definition_analyzer.py
+++ b/src/oaklib/utilities/axioms/logical_definition_analyzer.py
@@ -97,7 +97,7 @@ def generate_descendant_logical_definitions(
             continue
         restrictions = [
             ExistentialRestrictionExpression(propertyId=pred, fillerId=filler)
-            for pred, filler in zip(props, tpl[num_genus_ids:])
+            for pred, filler in zip(props, tpl[num_genus_ids:], strict=False)
         ]
         curie = base64.b64encode(str(tpl).encode("ascii")).decode("utf-8")
         new_ldef = LogicalDefinitionAxiom(

--- a/src/oaklib/utilities/lexical/lexical_indexer.py
+++ b/src/oaklib/utilities/lexical/lexical_indexer.py
@@ -331,7 +331,8 @@ def create_mapping(
     pred: PRED_CURIE = SKOS_CLOSE_MATCH,
     confidence: float = None,
 ) -> Mapping:
-    """Create mappings between a pair of entities.
+    """
+    Create mappings between a pair of entities.
 
     :param term: Match string
     :param r1: Term relationship 1
@@ -444,7 +445,8 @@ def inverse_logit(weight: float) -> float:
 
 
 def invert_mapping_predicate(pred: PRED_CURIE) -> Optional[PRED_CURIE]:
-    """Return the opposite of predicate passed.
+    """
+    Return the opposite of predicate passed.
 
     :param pred: Predicate.
     :return: Opposite of the predicate.
@@ -496,7 +498,8 @@ def apply_transformation(
 
 
 def apply_synonymizer(term: str, rules: List[Synonymizer]) -> Tuple[bool, str, str]:
-    """Apply synonymizer rules declared in the given match-rules.yaml file.
+    """
+    Apply synonymizer rules declared in the given match-rules.yaml file.
 
     The basic concept is looking for regex in labels and replacing the ones that match
     with the string passed in 'match.replacement'. Also set qualifier ('match.qualifier')

--- a/src/oaklib/utilities/mapping/boomer_utils.py
+++ b/src/oaklib/utilities/mapping/boomer_utils.py
@@ -267,12 +267,13 @@ def mappings(input_report, **kwargs):
     Exports mappings from a boomer report.
 
     Example:
-
+    -------
         boomerang mappings tests/input/boomer-example.md
 
     To filter by confidence:
 
         boomerang mappings tests/input/boomer-example.md -L 0.8
+
     """
     ben = BoomerEngine()
     ben.load(input_report, prefix_map=global_prefix_map)
@@ -296,13 +297,13 @@ def report(input_report, output, output_type, **kwargs):
     Passing no options will just generate the input report in the desired format.
 
     Example:
-
+    -------
         boomerang report tests/input/boomer-example.md  report.yaml
 
     The generic LinkML rendered can be used:
 
     Example:
-
+    -------
         boomerang report tests/input/boomer-example.md -O html -o report.html
 
     To show the lowest confidence first:
@@ -345,7 +346,7 @@ def compare(input_report, input_ontology: str, **kwargs):
     Pass in as an argument the same ontology used in the boomer run.
 
     Example:
-
+    -------
         boomerang compare foo-boomer.md -i foo.db
 
     For any mapping marked NEW, this can be incorporated into the ontology.
@@ -356,7 +357,7 @@ def compare(input_report, input_ontology: str, **kwargs):
     To customize, e.g. stringent:
 
     Example:
-
+    -------
         boomerang compare foo-boomer.md -i foo.db -L 0.999
 
     For each high confidence boomer mapping, this is compared against current mappings and
@@ -371,7 +372,7 @@ def compare(input_report, input_ontology: str, **kwargs):
     boomer mapping FOR ANYTHING OTHER THAN exactMatch (including SiblingOf)
 
     Example:
-
+    -------
         boomerang compare foo-boomer.md -i foo.db -L 0.999 --reject-non-exact --promote-xref-to-exact
 
     The results here are straightforward, either REJECT, NEW, or OK
@@ -380,6 +381,7 @@ def compare(input_report, input_ontology: str, **kwargs):
     the interpretation you state is different from the interpretation in
 
     See https://github.com/INCATools/boomer/issues/334
+
     """
     writer = StreamingCsvWriter()
     adapter = get_implementation_from_shorthand(input_ontology)

--- a/src/oaklib/utilities/ner_utilities.py
+++ b/src/oaklib/utilities/ner_utilities.py
@@ -7,7 +7,8 @@ from typing import List, Union
 
 
 def get_exclusion_token_list(exclude_tokens: Union[str, Path]) -> List[str]:
-    """Return a list of token to be excluded from NER analysis.
+    """
+    Return a list of token to be excluded from NER analysis.
 
     :param exclude_tokens: Either a file path or the strings to be excluded.
     :return: A list of tokens to exclude.

--- a/src/oaklib/utilities/semsim/similarity_utils.py
+++ b/src/oaklib/utilities/semsim/similarity_utils.py
@@ -67,7 +67,7 @@ def load_information_content_map(path: str) -> Dict[CURIE, float]:
     Columns: id, information_content
 
     Example:
-
+    -------
     >>> from oaklib.utilities.semsim.similarity_utils import load_information_content_map
     >>> icmap = load_information_content_map("tests/input/go-nucleus.ic.tsv")
     >>> ic = icmap["GO:0016310"]
@@ -78,6 +78,7 @@ def load_information_content_map(path: str) -> Dict[CURIE, float]:
 
     :param path:
     :return: mapping from IDs to information content
+
     """
     with open(path) as f:
         dr = csv.DictReader(f, delimiter="\t")

--- a/src/oaklib/utilities/subsets/value_set_expander.py
+++ b/src/oaklib/utilities/subsets/value_set_expander.py
@@ -282,8 +282,9 @@ def expand(config: str, schema: str, value_set_names: List[str], output: str):
     render all value sets.
 
     Example:
-
+    -------
         vskit expand -c config.yaml -s schema.yaml -o expanded.yaml my_value_set1 my_value_set2
+
     """
     value_set_names = None if not value_set_names else value_set_names
     expander = ValueSetExpander()

--- a/src/oaklib/utilities/table_filler.py
+++ b/src/oaklib/utilities/table_filler.py
@@ -137,7 +137,8 @@ def write_table(
     list_delimiter="|",
     header: List[str] = None,
 ) -> None:
-    """Writes a list of rows to a file, replacing None values with empty strings.
+    """
+    Writes a list of rows to a file, replacing None values with empty strings.
 
     :param rows: List of rows in dict format.
     :param output_file: Target location to write output.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -140,7 +140,8 @@ def object_is_subsumed_by_member_of(obj: YAMLRoot, obj_list: List[YAMLRoot], **k
 
 
 def filecmp_difflib(left_path: Path, right_path: Path) -> bool:
-    """Platform neutral filecmp.cmp(..) function for text files
+    """
+    Platform neutral filecmp.cmp(..) function for text files
 
     Files are read in text mode to ignore newline differences.
     """

--- a/tests/integration_tests/test_sqlite_full.py
+++ b/tests/integration_tests/test_sqlite_full.py
@@ -6,6 +6,7 @@ from oaklib.resource import OntologyResource
 from oaklib.utilities.mapping.cross_ontology_diffs import (
     calculate_pairwise_relational_diff,
 )
+
 from tests import EXTERNAL_DB_DIR
 
 DB_FOLDER = EXTERNAL_DB_DIR / "unreciprocated-mapping-test.obo"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,7 @@ class TestCommandLineInterface(unittest.TestCase):
     def test_main_help(self):
         result = self.runner.invoke(main, ["--help"])
         out = result.stdout
-        result.stderr
+        print("STDERR", result.stderr)
         self.assertIn("search", out)
         self.assertIn("subset", out)
         self.assertIn("validate", out)
@@ -137,8 +137,8 @@ class TestCommandLineInterface(unittest.TestCase):
                 main,
                 ["-i", str(input_arg), "info", NUCLEUS, "-o", TEST_OUT, "-D", "x,d"],
             )
-            result.stdout
-            result.stderr
+            print("STDERR", result.stdout)
+            print("STDERR", result.stderr)
             self.assertEqual(0, result.exit_code)
             with open(TEST_OUT) as file:
                 contents = "\n".join(file.readlines())
@@ -148,8 +148,8 @@ class TestCommandLineInterface(unittest.TestCase):
             result = self.runner.invoke(
                 main, ["-i", str(input_arg), "info", NUCLEUS, "-o", TEST_OUT, "-D", "x"]
             )
-            result.stdout
-            result.stderr
+            print("STDERR", result.stdout)
+            print("STDERR", result.stderr)
             self.assertEqual(0, result.exit_code)
             with open(TEST_OUT) as file:
                 contents = "\n".join(file.readlines())
@@ -382,8 +382,8 @@ class TestCommandLineInterface(unittest.TestCase):
                 TEST_OUT,
             ],
         )
-        result.stdout
-        result.stderr
+        print("STDERR", result.stdout)
+        print("STDERR", result.stderr)
         self.assertEqual(0, result.exit_code)
         contents = self._out()
         self.assertIn(NUCLEUS, contents)
@@ -1037,8 +1037,8 @@ class TestCommandLineInterface(unittest.TestCase):
 
     def test_validate_help(self):
         result = self.runner.invoke(main, ["validate", "--help"])
-        result.stdout
-        result.stderr
+        print("STDERR", result.stdout)
+        print("STDERR", result.stderr)
         self.assertEqual(0, result.exit_code)
 
     def test_validate_bad_ontology(self):
@@ -1170,7 +1170,7 @@ class TestCommandLineInterface(unittest.TestCase):
                 "--no-ensure-strict-prefixes",
             ],
         )
-        result.stdout
+        print("STDERR", result.stdout)
         err = result.stderr
         self.assertEqual(0, result.exit_code)
         with open(outfile) as stream:
@@ -1198,7 +1198,7 @@ class TestCommandLineInterface(unittest.TestCase):
                 "--no-ensure-strict-prefixes",
             ],
         )
-        result.stdout
+        print("STDERR", result.stdout)
         err = result.stderr
         self.assertEqual("", err)
         self.assertEqual(0, result.exit_code)
@@ -1401,7 +1401,6 @@ class TestCommandLineInterface(unittest.TestCase):
                 ".all",
             ],
         )
-
         self.assertEqual(0, result.exit_code)
         with open(patch_file, "r") as p, open(outfile, "r") as t:
             patch = p.readlines()
@@ -1503,7 +1502,7 @@ class TestCommandLineInterface(unittest.TestCase):
                 outfile,
             ],
         )
-        result.stdout
+        print("STDERR", result.stdout)
         err = result.stderr
         self.assertEqual("", err)
         self.assertEqual(0, result.exit_code)
@@ -1530,7 +1529,7 @@ class TestCommandLineInterface(unittest.TestCase):
                 outfile,
             ],
         )
-        result.stdout
+        print("STDERR", result.stdout)
         err = result.stderr
         self.assertEqual("", err)
         self.assertEqual(0, result.exit_code)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -933,6 +933,10 @@ class TestCommandLineInterface(unittest.TestCase):
                     logging.error(f"INPUT: {input_arg} code = {result.exit_code}")
                     logging.error(f"OUTPUT={out}")
                     logging.error(f"ERR={err}")
+                if result.exit_code == 1:
+                    import pdb
+
+                    pdb.set_trace()
                 self.assertEqual(0, result.exit_code)
                 logging.info(f"OUTPUT={out}")
                 logging.info(f"ERR={err}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,6 @@ def _outpath(test: str, fmt: str = "tmp") -> str:
 
 
 class TestCommandLineInterface(unittest.TestCase):
-
     """
     Tests all command-line subcommands
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,6 @@ import yaml
 from click.testing import CliRunner
 from kgcl_schema.datamodel.kgcl import NodeChange
 from linkml_runtime.loaders import json_loader, yaml_loader
-from sssom.parsers import parse_sssom_table, to_mapping_set_document
-
 from oaklib import get_adapter
 from oaklib.cli import clear_cli_settings, main
 from oaklib.datamodels import fhir, obograph, taxon_constraints
@@ -24,6 +22,8 @@ from oaklib.datamodels.vocabulary import (
     SKOS_EXACT_MATCH,
 )
 from oaklib.utilities.kgcl_utilities import parse_kgcl_files
+from sssom.parsers import parse_sssom_table, to_mapping_set_document
+
 from tests import (
     ATOM,
     CATALYTIC_ACTIVITY,
@@ -69,6 +69,7 @@ def _outpath(test: str, fmt: str = "tmp") -> str:
 
 
 class TestCommandLineInterface(unittest.TestCase):
+
     """
     Tests all command-line subcommands
     """
@@ -463,7 +464,8 @@ class TestCommandLineInterface(unittest.TestCase):
                     self.assertNotIn(term, out)
 
     def test_obsoletes(self):
-        """Tests the obsoletes command using the obsoletion test ontology.
+        """
+        Tests the obsoletes command using the obsoletion test ontology.
 
         This should return
         """

--- a/tests/test_converters/test_logical_definition_flattener_converter.py
+++ b/tests/test_converters/test_logical_definition_flattener_converter.py
@@ -15,7 +15,6 @@ OUT = OUTPUT_DIR / "go-nucleus.ttl"
 
 
 class LogicalDefinitionFlattenerTest(unittest.TestCase):
-
     """Tests turning logical definition axioms into tuples."""
 
     def setUp(self):

--- a/tests/test_converters/test_logical_definition_flattener_converter.py
+++ b/tests/test_converters/test_logical_definition_flattener_converter.py
@@ -1,12 +1,12 @@
 import unittest
 
 from linkml_runtime.loaders import json_loader
-
 from oaklib import get_adapter
 from oaklib.converters.logical_definition_flattener import LogicalDefinitionFlattener
 from oaklib.datamodels import obograph
 from oaklib.datamodels.obograph import GraphDocument
 from oaklib.datamodels.vocabulary import HAS_PART, PART_OF
+
 from tests import INPUT_DIR, OUTPUT_DIR
 from tests.test_implementations import ComplianceTester
 
@@ -15,6 +15,7 @@ OUT = OUTPUT_DIR / "go-nucleus.ttl"
 
 
 class LogicalDefinitionFlattenerTest(unittest.TestCase):
+
     """Tests turning logical definition axioms into tuples."""
 
     def setUp(self):

--- a/tests/test_converters/test_obo_format.py
+++ b/tests/test_converters/test_obo_format.py
@@ -28,9 +28,9 @@ from typing import Optional
 
 import pytest
 import rdflib
+from oaklib import get_adapter
 from rdflib.compare import isomorphic
 
-from oaklib import get_adapter
 from tests import INPUT_DIR, OUTPUT_DIR
 
 logger = logging.getLogger(__name__)

--- a/tests/test_converters/test_obo_graph_to_cx.py
+++ b/tests/test_converters/test_obo_graph_to_cx.py
@@ -4,10 +4,10 @@ import unittest
 import curies
 from linkml_runtime.loaders import json_loader
 from ndex2 import create_nice_cx_from_file
-
 from oaklib.converters.obo_graph_to_cx_converter import OboGraphToCXConverter
 from oaklib.datamodels.obograph import GraphDocument
 from oaklib.interfaces.basic_ontology_interface import get_default_prefix_map
+
 from tests import INPUT_DIR, OUTPUT_DIR
 from tests.test_implementations import ComplianceTester
 
@@ -16,6 +16,7 @@ OUT = OUTPUT_DIR / "go-nucleus.cx"
 
 
 class OboGraphToCXTest(unittest.TestCase):
+
     """Tests OBO JSON -> RDF/OWL."""
 
     def setUp(self):

--- a/tests/test_converters/test_obo_graph_to_cx.py
+++ b/tests/test_converters/test_obo_graph_to_cx.py
@@ -16,7 +16,6 @@ OUT = OUTPUT_DIR / "go-nucleus.cx"
 
 
 class OboGraphToCXTest(unittest.TestCase):
-
     """Tests OBO JSON -> RDF/OWL."""
 
     def setUp(self):

--- a/tests/test_converters/test_obo_graph_to_fhir.py
+++ b/tests/test_converters/test_obo_graph_to_fhir.py
@@ -30,7 +30,7 @@ class OboGraphToFHIRTest(unittest.TestCase):
     def _load_ontology(url: str, download_path: str, use_cache: bool = True) -> GraphDocument:
         """Downloads ontology if needed, and loads it."""
         if not os.path.exists(download_path) and use_cache:
-            r = requests.get(url, timeout=10)
+            r = requests.get(url, timeout=30)
             with open(download_path, "wb") as f:
                 f.write(r.content)
             return json_loader.load(str(download_path), target_class=GraphDocument)

--- a/tests/test_converters/test_obo_graph_to_fhir.py
+++ b/tests/test_converters/test_obo_graph_to_fhir.py
@@ -7,6 +7,7 @@ from typing import List
 import curies
 import requests
 from linkml_runtime.loaders import json_loader
+from oaklib.constants import TIMEOUT_SECONDS
 from oaklib.converters.obo_graph_to_fhir_converter import OboGraphToFHIRConverter
 from oaklib.datamodels.fhir import CodeSystem
 from oaklib.datamodels.obograph import GraphDocument
@@ -19,7 +20,6 @@ DOWNLOAD_TESTS_ON = True
 
 
 class OboGraphToFHIRTest(unittest.TestCase):
-
     """
     Tests OBO JSON -> FHIR.
 
@@ -30,7 +30,7 @@ class OboGraphToFHIRTest(unittest.TestCase):
     def _load_ontology(url: str, download_path: str, use_cache: bool = True) -> GraphDocument:
         """Downloads ontology if needed, and loads it."""
         if not os.path.exists(download_path) and use_cache:
-            r = requests.get(url, timeout=30)
+            r = requests.get(url, timeout=TIMEOUT_SECONDS)
             with open(download_path, "wb") as f:
                 f.write(r.content)
             return json_loader.load(str(download_path), target_class=GraphDocument)

--- a/tests/test_converters/test_obo_graph_to_fhir.py
+++ b/tests/test_converters/test_obo_graph_to_fhir.py
@@ -7,11 +7,11 @@ from typing import List
 import curies
 import requests
 from linkml_runtime.loaders import json_loader
-
 from oaklib.converters.obo_graph_to_fhir_converter import OboGraphToFHIRConverter
 from oaklib.datamodels.fhir import CodeSystem
 from oaklib.datamodels.obograph import GraphDocument
 from oaklib.interfaces.basic_ontology_interface import get_default_prefix_map
+
 from tests import IMBO, INPUT_DIR, NUCLEUS, OUTPUT_DIR
 from tests.test_implementations import ComplianceTester
 
@@ -19,9 +19,12 @@ DOWNLOAD_TESTS_ON = True
 
 
 class OboGraphToFHIRTest(unittest.TestCase):
-    """Tests OBO JSON -> FHIR.
 
-    Different ontologies have unique structures, so test some specifics for those."""
+    """
+    Tests OBO JSON -> FHIR.
+
+    Different ontologies have unique structures, so test some specifics for those.
+    """
 
     @staticmethod
     def _load_ontology(url: str, download_path: str, use_cache: bool = True) -> GraphDocument:

--- a/tests/test_converters/test_obo_graph_to_fhir.py
+++ b/tests/test_converters/test_obo_graph_to_fhir.py
@@ -30,7 +30,7 @@ class OboGraphToFHIRTest(unittest.TestCase):
     def _load_ontology(url: str, download_path: str, use_cache: bool = True) -> GraphDocument:
         """Downloads ontology if needed, and loads it."""
         if not os.path.exists(download_path) and use_cache:
-            r = requests.get(url)
+            r = requests.get(url, timeout=10)
             with open(download_path, "wb") as f:
                 f.write(r.content)
             return json_loader.load(str(download_path), target_class=GraphDocument)

--- a/tests/test_converters/test_obo_graph_to_obo_format.py
+++ b/tests/test_converters/test_obo_graph_to_obo_format.py
@@ -2,7 +2,6 @@ import unittest
 
 import curies
 from linkml_runtime.loaders import json_loader
-
 from oaklib import OntologyResource
 from oaklib.converters.obo_graph_to_obo_format_converter import (
     OboGraphToOboFormatConverter,
@@ -10,6 +9,7 @@ from oaklib.converters.obo_graph_to_obo_format_converter import (
 from oaklib.datamodels.obograph import GraphDocument
 from oaklib.implementations import SimpleOboImplementation
 from oaklib.interfaces.basic_ontology_interface import get_default_prefix_map
+
 from tests import INPUT_DIR, OUTPUT_DIR
 from tests.test_implementations import ComplianceTester
 
@@ -18,6 +18,7 @@ OUT = OUTPUT_DIR / "go-nucleus-roundtrip.obo"
 
 
 class OboGraphToOboFormatTest(unittest.TestCase):
+
     """Tests OBO JSON -> RDF/OWL."""
 
     def setUp(self):

--- a/tests/test_converters/test_obo_graph_to_obo_format.py
+++ b/tests/test_converters/test_obo_graph_to_obo_format.py
@@ -18,7 +18,6 @@ OUT = OUTPUT_DIR / "go-nucleus-roundtrip.obo"
 
 
 class OboGraphToOboFormatTest(unittest.TestCase):
-
     """Tests OBO JSON -> RDF/OWL."""
 
     def setUp(self):

--- a/tests/test_converters/test_obo_graph_to_rdf_owl_converter.py
+++ b/tests/test_converters/test_obo_graph_to_rdf_owl_converter.py
@@ -16,7 +16,6 @@ OUT = OUTPUT_DIR / "go-nucleus.ttl"
 
 
 class OboGraphToRdfOwlConverterTest(unittest.TestCase):
-
     """Tests OBO JSON -> RDF/OWL."""
 
     def setUp(self):

--- a/tests/test_converters/test_obo_graph_to_rdf_owl_converter.py
+++ b/tests/test_converters/test_obo_graph_to_rdf_owl_converter.py
@@ -2,12 +2,12 @@ import unittest
 
 import curies
 from linkml_runtime.loaders import json_loader
-
 from oaklib import OntologyResource
 from oaklib.converters.obo_graph_to_rdf_owl_converter import OboGraphToRdfOwlConverter
 from oaklib.datamodels.obograph import GraphDocument
 from oaklib.implementations import SparqlImplementation
 from oaklib.interfaces.basic_ontology_interface import get_default_prefix_map
+
 from tests import INPUT_DIR, OUTPUT_DIR
 from tests.test_implementations import ComplianceTester
 
@@ -16,6 +16,7 @@ OUT = OUTPUT_DIR / "go-nucleus.ttl"
 
 
 class OboGraphToRdfOwlConverterTest(unittest.TestCase):
+
     """Tests OBO JSON -> RDF/OWL."""
 
     def setUp(self):

--- a/tests/test_datamodels/test_obograph_datamodel.py
+++ b/tests/test_datamodels/test_obograph_datamodel.py
@@ -1,8 +1,8 @@
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.utils.introspection import package_schemaview
-
 from oaklib.datamodels import obograph
 from oaklib.datamodels.vocabulary import IS_A
+
 from tests import output_path
 from tests.test_datamodels import AbstractDatamodelTestCase
 

--- a/tests/test_datamodels/test_ontology_metadata_datamodel.py
+++ b/tests/test_datamodels/test_ontology_metadata_datamodel.py
@@ -4,8 +4,8 @@ import unittest
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.loaders import yaml_loader
 from linkml_runtime.utils.introspection import package_schemaview
-
 from oaklib.datamodels import ontology_metadata
+
 from tests import output_path
 
 

--- a/tests/test_datamodels/test_search_datamodel.py
+++ b/tests/test_datamodels/test_search_datamodel.py
@@ -1,7 +1,6 @@
 import unittest
 
 from linkml_runtime.utils.introspection import package_schemaview
-
 from oaklib.datamodels import search_datamodel
 from oaklib.datamodels.search import create_search_configuration
 from oaklib.datamodels.search_datamodel import SearchProperty, SearchTermSyntax

--- a/tests/test_datamodels/test_text_annotator_datamodel.py
+++ b/tests/test_datamodels/test_text_annotator_datamodel.py
@@ -2,8 +2,8 @@ import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.utils.introspection import package_schemaview
-
 from oaklib.datamodels import text_annotator
+
 from tests import NUCLEUS, output_path
 
 

--- a/tests/test_datamodels/test_validation_datamodel.py
+++ b/tests/test_datamodels/test_validation_datamodel.py
@@ -1,10 +1,10 @@
 import logging
 import unittest
 
+import oaklib.datamodels.validation_datamodel as vdm
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.utils.introspection import package_schemaview
 
-import oaklib.datamodels.validation_datamodel as vdm
 from tests import output_path
 
 

--- a/tests/test_implementations/__init__.py
+++ b/tests/test_implementations/__init__.py
@@ -1,4 +1,5 @@
-"""Compliance tests for multiple interfaces.
+"""
+Compliance tests for multiple interfaces.
 
 See <https://github.com/INCATools/ontology-access-kit/issues/291>_
 """
@@ -16,7 +17,6 @@ from kgcl_schema.datamodel import kgcl
 from kgcl_schema.datamodel.kgcl import Change, NodeObsoletion
 from kgcl_schema.grammar.render_operations import render
 from linkml_runtime.dumpers import json_dumper
-
 from oaklib import BasicOntologyInterface, get_adapter
 from oaklib.datamodels import obograph
 from oaklib.datamodels.association import Association
@@ -78,6 +78,7 @@ from oaklib.interfaces.patcher_interface import PatcherInterface
 from oaklib.interfaces.semsim_interface import SemanticSimilarityInterface
 from oaklib.interfaces.summary_statistics_interface import SummaryStatisticsInterface
 from oaklib.utilities.kgcl_utilities import generate_change_id
+
 from tests import (
     ARCHAEA,
     BACTERIA,
@@ -141,6 +142,7 @@ def _as_json_dict_no_id(change: Change) -> dict:
 
 @dataclass
 class ComplianceTester:
+
     """
     Tests for compliance against expected behavior.
 

--- a/tests/test_implementations/__init__.py
+++ b/tests/test_implementations/__init__.py
@@ -142,7 +142,6 @@ def _as_json_dict_no_id(change: Change) -> dict:
 
 @dataclass
 class ComplianceTester:
-
     """
     Tests for compliance against expected behavior.
 

--- a/tests/test_implementations/test_aggregator.py
+++ b/tests/test_implementations/test_aggregator.py
@@ -2,7 +2,6 @@ import logging
 import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.aggregator.aggregator_implementation import (
     AggregatorImplementation,
@@ -10,6 +9,7 @@ from oaklib.implementations.aggregator.aggregator_implementation import (
 from oaklib.implementations.pronto.pronto_implementation import ProntoImplementation
 from oaklib.resource import OntologyResource
 from oaklib.utilities.obograph_utils import graph_as_dict
+
 from tests import (
     CELLULAR_COMPONENT,
     CYTOPLASM,
@@ -26,6 +26,7 @@ TEST_ONT2 = INPUT_DIR / "interneuron.obo"
 
 
 class TestAggregator(unittest.TestCase):
+
     """
     Tests the ability to wrap multiple implementations as if it were a single source
     """

--- a/tests/test_implementations/test_aggregator.py
+++ b/tests/test_implementations/test_aggregator.py
@@ -26,7 +26,6 @@ TEST_ONT2 = INPUT_DIR / "interneuron.obo"
 
 
 class TestAggregator(unittest.TestCase):
-
     """
     Tests the ability to wrap multiple implementations as if it were a single source
     """

--- a/tests/test_implementations/test_amigo.py
+++ b/tests/test_implementations/test_amigo.py
@@ -8,7 +8,6 @@ from oaklib.interfaces.association_provider_interface import (
 
 # TODO: use mock tests
 class TestAmiGO(unittest.TestCase):
-
     """
     Tests :ref:`AmiGOImplementation`
     """

--- a/tests/test_implementations/test_amigo.py
+++ b/tests/test_implementations/test_amigo.py
@@ -8,6 +8,7 @@ from oaklib.interfaces.association_provider_interface import (
 
 # TODO: use mock tests
 class TestAmiGO(unittest.TestCase):
+
     """
     Tests :ref:`AmiGOImplementation`
     """

--- a/tests/test_implementations/test_bioportal.py
+++ b/tests/test_implementations/test_bioportal.py
@@ -3,17 +3,18 @@ import logging
 import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib.implementations.ontoportal.bioportal_implementation import (
     BioPortalImplementation,
 )
 from oaklib.utilities.apikey_manager import get_apikey_value
+
 from tests import CELLULAR_COMPONENT, CYTOPLASM, DIGIT, HUMAN, NEURON, VACUOLE
 
 
 # TODO: use mock tests
 # @unittest.skip("Skipping bioportal tests")
 class TestBioportal(unittest.TestCase):
+
     """
     Tests :ref:`BioportalImplementation`
     """

--- a/tests/test_implementations/test_bioportal.py
+++ b/tests/test_implementations/test_bioportal.py
@@ -14,7 +14,6 @@ from tests import CELLULAR_COMPONENT, CYTOPLASM, DIGIT, HUMAN, NEURON, VACUOLE
 # TODO: use mock tests
 # @unittest.skip("Skipping bioportal tests")
 class TestBioportal(unittest.TestCase):
-
     """
     Tests :ref:`BioportalImplementation`
     """

--- a/tests/test_implementations/test_cx.py
+++ b/tests/test_implementations/test_cx.py
@@ -2,6 +2,7 @@ import unittest
 
 from oaklib.implementations.cx.cx_implementation import CXImplementation
 from oaklib.resource import OntologyResource
+
 from tests import INPUT_DIR
 from tests.test_implementations import ComplianceTester
 

--- a/tests/test_implementations/test_funowl.py
+++ b/tests/test_implementations/test_funowl.py
@@ -4,12 +4,12 @@ import unittest
 from funowl import EquivalentClasses, SubClassOf
 from funowl.writers.FunctionalWriter import FunctionalWriter
 from kgcl_schema.datamodel import kgcl
-
 from oaklib.implementations.funowl.funowl_implementation import FunOwlImplementation
 from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.interfaces.owl_interface import AxiomFilter
 from oaklib.resource import OntologyResource
 from oaklib.utilities.kgcl_utilities import generate_change_id
+
 from tests import CHEBI_NUCLEUS, HUMAN, INPUT_DIR, NUCLEUS, VACUOLE
 
 TEST_ONT = INPUT_DIR / "go-nucleus.ofn"

--- a/tests/test_implementations/test_gilda.py
+++ b/tests/test_implementations/test_gilda.py
@@ -4,6 +4,7 @@ import unittest
 
 from oaklib.datamodels.text_annotator import TextAnnotationConfiguration
 from oaklib.implementations import GildaImplementation
+
 from tests import CELL_CORTEX
 
 try:
@@ -16,6 +17,7 @@ except ImportError:
 
 @unittest.skipUnless(HAS_GILDA, "requires Gilda")
 class TestGilda(unittest.TestCase):
+
     """Tests for the Gilda annotator."""
 
     def setUp(self) -> None:

--- a/tests/test_implementations/test_gilda.py
+++ b/tests/test_implementations/test_gilda.py
@@ -17,7 +17,6 @@ except ImportError:
 
 @unittest.skipUnless(HAS_GILDA, "requires Gilda")
 class TestGilda(unittest.TestCase):
-
     """Tests for the Gilda annotator."""
 
     def setUp(self) -> None:

--- a/tests/test_implementations/test_ncbigene.py
+++ b/tests/test_implementations/test_ncbigene.py
@@ -6,6 +6,7 @@ from oaklib.implementations import NCBIGeneImplementation
 from oaklib.interfaces.association_provider_interface import (
     AssociationProviderInterface,
 )
+
 from tests import CYTOPLASM, INPUT_DIR
 
 GENE_PATH = INPUT_DIR / "ncbigene-1956.xml"
@@ -13,6 +14,7 @@ GENE_PATH = INPUT_DIR / "ncbigene-1956.xml"
 
 # TODO: use mock tests
 class TestNCBIGene(unittest.TestCase):
+
     """
     Tests :ref:`NCBIGeneImplementation`
     """

--- a/tests/test_implementations/test_ncbigene.py
+++ b/tests/test_implementations/test_ncbigene.py
@@ -14,7 +14,6 @@ GENE_PATH = INPUT_DIR / "ncbigene-1956.xml"
 
 # TODO: use mock tests
 class TestNCBIGene(unittest.TestCase):
-
     """
     Tests :ref:`NCBIGeneImplementation`
     """

--- a/tests/test_implementations/test_obograph.py
+++ b/tests/test_implementations/test_obograph.py
@@ -3,7 +3,6 @@ import unittest
 from copy import deepcopy
 
 from kgcl_schema.datamodel import kgcl
-
 from oaklib.datamodels import obograph
 from oaklib.datamodels.search import SearchConfiguration
 from oaklib.datamodels.search_datamodel import SearchProperty, SearchTermSyntax
@@ -23,6 +22,7 @@ from oaklib.utilities.obograph_utils import (
     index_graph_edges_by_subject,
     index_graph_nodes,
 )
+
 from tests import (
     CELL,
     CELLULAR_COMPONENT,

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -3,11 +3,11 @@ import logging
 import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib.datamodels.search import SearchConfiguration, SearchProperty
 from oaklib.datamodels.vocabulary import IS_A
 from oaklib.implementations.ols.ols_implementation import OlsImplementation
 from oaklib.resource import OntologyResource
+
 from tests import CELLULAR_COMPONENT, CYTOPLASM, DIGIT, VACUOLE
 
 

--- a/tests/test_implementations/test_ontobee.py
+++ b/tests/test_implementations/test_ontobee.py
@@ -6,6 +6,7 @@ from oaklib.datamodels.search_datamodel import SearchProperty, SearchTermSyntax
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.ontobee.ontobee_implementation import OntobeeImplementation
 from oaklib.resource import OntologyResource
+
 from tests import CELLULAR_COMPONENT, DIGIT, INPUT_DIR, OUTPUT_DIR, SHAPE, VACUOLE
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"

--- a/tests/test_implementations/test_pantherdb.py
+++ b/tests/test_implementations/test_pantherdb.py
@@ -11,7 +11,6 @@ from oaklib.utilities.iterator_utils import chunk
 # TODO: use mock tests
 @pytest.mark.skip(reason="Network dependency")
 class TestPantherDB(unittest.TestCase):
-
     """
     Tests :ref:`PantherDBImplementation`
     """

--- a/tests/test_implementations/test_pantherdb.py
+++ b/tests/test_implementations/test_pantherdb.py
@@ -1,7 +1,6 @@
 import unittest
 
 import pytest
-
 from oaklib import get_adapter
 from oaklib.interfaces.association_provider_interface import (
     AssociationProviderInterface,
@@ -12,6 +11,7 @@ from oaklib.utilities.iterator_utils import chunk
 # TODO: use mock tests
 @pytest.mark.skip(reason="Network dependency")
 class TestPantherDB(unittest.TestCase):
+
     """
     Tests :ref:`PantherDBImplementation`
     """

--- a/tests/test_implementations/test_pronto.py
+++ b/tests/test_implementations/test_pronto.py
@@ -3,7 +3,6 @@ import unittest
 
 import pronto
 from kgcl_schema.datamodel import kgcl
-
 from oaklib import get_adapter
 from oaklib.datamodels import obograph
 from oaklib.datamodels.search import SearchConfiguration
@@ -23,6 +22,7 @@ from oaklib.utilities.obograph_utils import (
 from oaklib.utilities.validation.definition_ontology_rule import (
     TextAndLogicalDefinitionMatchOntologyRule,
 )
+
 from tests import (
     CELL,
     CELLULAR_COMPONENT,

--- a/tests/test_implementations/test_pubmed.py
+++ b/tests/test_implementations/test_pubmed.py
@@ -7,6 +7,7 @@ TEST_PMID = "PMID:21873635"
 
 # TODO: use mock tests
 class TestPubMed(unittest.TestCase):
+
     """
     Tests :ref:`PubMedImplementation`
     """

--- a/tests/test_implementations/test_pubmed.py
+++ b/tests/test_implementations/test_pubmed.py
@@ -7,7 +7,6 @@ TEST_PMID = "PMID:21873635"
 
 # TODO: use mock tests
 class TestPubMed(unittest.TestCase):
-
     """
     Tests :ref:`PubMedImplementation`
     """

--- a/tests/test_implementations/test_semsimian_implementation.py
+++ b/tests/test_implementations/test_semsimian_implementation.py
@@ -30,7 +30,6 @@ EXPECTED_ICS = {
 
 @unittest.skipIf(os.name == "nt", "DB path loading inconsistent on Windows")
 class TestSemSimianImplementation(unittest.TestCase):
-
     """Implementation tests for Rust-based semantic similarity."""
 
     def setUp(self) -> None:

--- a/tests/test_implementations/test_semsimian_implementation.py
+++ b/tests/test_implementations/test_semsimian_implementation.py
@@ -3,11 +3,11 @@ import timeit
 import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib.datamodels.similarity import TermPairwiseSimilarity
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.interfaces.semsim_interface import SemanticSimilarityInterface
 from oaklib.selector import get_adapter
+
 from tests import (
     ENDOMEMBRANE_SYSTEM,
     FUNGI,
@@ -30,6 +30,7 @@ EXPECTED_ICS = {
 
 @unittest.skipIf(os.name == "nt", "DB path loading inconsistent on Windows")
 class TestSemSimianImplementation(unittest.TestCase):
+
     """Implementation tests for Rust-based semantic similarity."""
 
     def setUp(self) -> None:

--- a/tests/test_implementations/test_simple_obo.py
+++ b/tests/test_implementations/test_simple_obo.py
@@ -3,7 +3,6 @@ import unittest
 from copy import deepcopy
 
 from kgcl_schema.datamodel import kgcl
-
 from oaklib.cli import query_terms_iterator
 from oaklib.datamodels import obograph
 from oaklib.datamodels.search import SearchConfiguration
@@ -34,6 +33,7 @@ from oaklib.utilities.obograph_utils import (
     index_graph_edges_by_subject,
     index_graph_nodes,
 )
+
 from tests import (
     BIOLOGICAL_ENTITY,
     CELL,

--- a/tests/test_implementations/test_sparql.py
+++ b/tests/test_implementations/test_sparql.py
@@ -17,6 +17,7 @@ from oaklib.utilities.obograph_utils import (
     index_graph_edges_by_subject,
     index_graph_nodes,
 )
+
 from tests import (
     CATALYTIC_ACTIVITY,
     CELL_CORTEX,

--- a/tests/test_implementations/test_sqldb.py
+++ b/tests/test_implementations/test_sqldb.py
@@ -57,7 +57,6 @@ VALIDATION_REPORT_OUT = OUTPUT_DIR / "validation-results.tsv"
 
 
 class TestSqlDatabaseImplementation(unittest.TestCase):
-
     """Implementation tests for SqlDatabase adapter."""
 
     def setUp(self) -> None:

--- a/tests/test_implementations/test_sqldb.py
+++ b/tests/test_implementations/test_sqldb.py
@@ -5,9 +5,6 @@ import unittest
 from kgcl_schema.datamodel import kgcl
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.loaders import yaml_loader
-from semsql.sqla.semsql import Statements
-from sqlalchemy import delete
-
 from oaklib import BasicOntologyInterface, get_adapter
 from oaklib.conf import CONF_DIR_PATH
 from oaklib.datamodels import obograph
@@ -29,6 +26,9 @@ from oaklib.utilities.kgcl_utilities import generate_change_id
 from oaklib.utilities.lexical.lexical_indexer import add_labels_from_uris
 from oaklib.utilities.obograph_utils import graph_as_dict
 from oaklib.utilities.validation.rule_runner import RuleRunner
+from semsql.sqla.semsql import Statements
+from sqlalchemy import delete
+
 from tests import (
     CELLULAR_COMPONENT,
     CHEBI_NUCLEUS,
@@ -57,6 +57,7 @@ VALIDATION_REPORT_OUT = OUTPUT_DIR / "validation-results.tsv"
 
 
 class TestSqlDatabaseImplementation(unittest.TestCase):
+
     """Implementation tests for SqlDatabase adapter."""
 
     def setUp(self) -> None:

--- a/tests/test_implementations/test_translator.py
+++ b/tests/test_implementations/test_translator.py
@@ -8,7 +8,6 @@ from oaklib.implementations.translator.translator_implementation import (
 
 # TODO: use mock tests
 class TestTranslatorImplementation(unittest.TestCase):
-
     """
     Tests :ref:`TranslatorImplementation`
     """

--- a/tests/test_implementations/test_translator.py
+++ b/tests/test_implementations/test_translator.py
@@ -8,6 +8,7 @@ from oaklib.implementations.translator.translator_implementation import (
 
 # TODO: use mock tests
 class TestTranslatorImplementation(unittest.TestCase):
+
     """
     Tests :ref:`TranslatorImplementation`
     """

--- a/tests/test_implementations/test_ubergraph.py
+++ b/tests/test_implementations/test_ubergraph.py
@@ -24,7 +24,6 @@ from tests import (
 
 
 class TestUbergraphImplementation(unittest.TestCase):
-
     """
     Tests for the UbergraphImplementation class.
 

--- a/tests/test_implementations/test_ubergraph.py
+++ b/tests/test_implementations/test_ubergraph.py
@@ -4,6 +4,7 @@ import unittest
 from oaklib.datamodels.search import SearchConfiguration
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations import UbergraphImplementation
+
 from tests import (
     CELL,
     CELLULAR_ANATOMICAL_ENTITY,
@@ -23,6 +24,7 @@ from tests import (
 
 
 class TestUbergraphImplementation(unittest.TestCase):
+
     """
     Tests for the UbergraphImplementation class.
 

--- a/tests/test_implementations/test_uniprot.py
+++ b/tests/test_implementations/test_uniprot.py
@@ -14,7 +14,6 @@ PROTEIN_PATH = INPUT_DIR / "uniprot-P12345.json"
 
 # TODO: use mock tests
 class TestUniprot(unittest.TestCase):
-
     """
     Tests :ref:`UniprotImplementation`
     """

--- a/tests/test_implementations/test_uniprot.py
+++ b/tests/test_implementations/test_uniprot.py
@@ -6,6 +6,7 @@ from oaklib.implementations import UniprotImplementation
 from oaklib.interfaces.association_provider_interface import (
     AssociationProviderInterface,
 )
+
 from tests import INPUT_DIR
 
 PROTEIN_PATH = INPUT_DIR / "uniprot-P12345.json"
@@ -13,6 +14,7 @@ PROTEIN_PATH = INPUT_DIR / "uniprot-P12345.json"
 
 # TODO: use mock tests
 class TestUniprot(unittest.TestCase):
+
     """
     Tests :ref:`UniprotImplementation`
     """

--- a/tests/test_implementations/test_wikidata.py
+++ b/tests/test_implementations/test_wikidata.py
@@ -2,7 +2,6 @@ import logging
 import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib.datamodels.search import SearchConfiguration
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.wikidata.wikidata_implementation import (

--- a/tests/test_indexes/test_edge_index.py
+++ b/tests/test_indexes/test_edge_index.py
@@ -2,6 +2,7 @@ import unittest
 
 from oaklib.datamodels.vocabulary import HAS_PART, IS_A, PART_OF
 from oaklib.indexes.edge_index import EdgeIndex
+
 from tests import CELL, IMBO, NUCLEUS, VACUOLE
 
 RELS = [

--- a/tests/test_inference/test_relation_graph_reasoner.py
+++ b/tests/test_inference/test_relation_graph_reasoner.py
@@ -3,6 +3,7 @@ import unittest
 from oaklib import get_adapter
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.inference.relation_graph_reasoner import RelationGraphReasoner
+
 from tests import CELL, IMBO, INPUT_DIR, NUCLEAR_MEMBRANE, NUCLEUS, ORGANELLE, VACUOLE
 
 ONT = INPUT_DIR / "go-nucleus.obo"

--- a/tests/test_parsers/test_boomer_parser.py
+++ b/tests/test_parsers/test_boomer_parser.py
@@ -2,14 +2,15 @@ import logging
 import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib.parsers.boomer_parser import BoomerParser
+
 from tests import INPUT_DIR
 
 EXAMPLE = INPUT_DIR / "boomer-example.md"
 
 
 class BoomerParserTest(unittest.TestCase):
+
     """Tests parsing Boomer reports."""
 
     def setUp(self) -> None:

--- a/tests/test_parsers/test_boomer_parser.py
+++ b/tests/test_parsers/test_boomer_parser.py
@@ -10,7 +10,6 @@ EXAMPLE = INPUT_DIR / "boomer-example.md"
 
 
 class BoomerParserTest(unittest.TestCase):
-
     """Tests parsing Boomer reports."""
 
     def setUp(self) -> None:

--- a/tests/test_parsers/test_gaf_association_parser.py
+++ b/tests/test_parsers/test_gaf_association_parser.py
@@ -4,12 +4,14 @@ import unittest
 from oaklib.datamodels.association import Association
 from oaklib.parsers import GAF
 from oaklib.parsers.association_parser_factory import get_association_parser
+
 from tests import INPUT_DIR
 
 INPUT_GAF = INPUT_DIR / "test-uniprot.gaf"
 
 
 class GafAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of GAF and GAF-like formats."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_gaf_association_parser.py
+++ b/tests/test_parsers/test_gaf_association_parser.py
@@ -11,7 +11,6 @@ INPUT_GAF = INPUT_DIR / "test-uniprot.gaf"
 
 
 class GafAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of GAF and GAF-like formats."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_gencc_association_parser.py
+++ b/tests/test_parsers/test_gencc_association_parser.py
@@ -5,12 +5,14 @@ from oaklib import get_adapter
 from oaklib.conf import CONF_DIR_PATH
 from oaklib.parsers import GENCC
 from oaklib.parsers.association_parser_factory import get_association_parser
+
 from tests import INPUT_DIR
 
 G2D_INPUT = INPUT_DIR / "example-g2d.gencc.csv"
 
 
 class GenCCAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of gencc format."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_gencc_association_parser.py
+++ b/tests/test_parsers/test_gencc_association_parser.py
@@ -12,7 +12,6 @@ G2D_INPUT = INPUT_DIR / "example-g2d.gencc.csv"
 
 
 class GenCCAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of gencc format."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_hpoa_association_parser.py
+++ b/tests/test_parsers/test_hpoa_association_parser.py
@@ -4,12 +4,14 @@ import unittest
 from oaklib.datamodels.association import Association
 from oaklib.parsers import HPOA
 from oaklib.parsers.association_parser_factory import get_association_parser
+
 from tests import INPUT_DIR
 
 HPOA_INPUT = INPUT_DIR / "test.hpoa.tsv"
 
 
 class HpoaAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of hpoa formats."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_hpoa_association_parser.py
+++ b/tests/test_parsers/test_hpoa_association_parser.py
@@ -11,7 +11,6 @@ HPOA_INPUT = INPUT_DIR / "test.hpoa.tsv"
 
 
 class HpoaAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of hpoa formats."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_hpoa_g2d_association_parser.py
+++ b/tests/test_parsers/test_hpoa_g2d_association_parser.py
@@ -12,7 +12,6 @@ G2D_INPUT = INPUT_DIR / "example-hpoa-g2d.tsv"
 
 
 class HpoaG2DAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of hpoa g2d format."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_hpoa_g2d_association_parser.py
+++ b/tests/test_parsers/test_hpoa_g2d_association_parser.py
@@ -5,12 +5,14 @@ from oaklib import get_adapter
 from oaklib.conf import CONF_DIR_PATH
 from oaklib.parsers import HPOA_G2D
 from oaklib.parsers.association_parser_factory import get_association_parser
+
 from tests import INPUT_DIR
 
 G2D_INPUT = INPUT_DIR / "example-hpoa-g2d.tsv"
 
 
 class HpoaG2DAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of hpoa g2d format."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_hpoa_g2p_association_parser.py
+++ b/tests/test_parsers/test_hpoa_g2p_association_parser.py
@@ -11,7 +11,6 @@ G2P_INPUT = INPUT_DIR / "test.hpoa_g2p.tsv"
 
 
 class HpoaG2PAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of hpoa g2p format."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_hpoa_g2p_association_parser.py
+++ b/tests/test_parsers/test_hpoa_g2p_association_parser.py
@@ -4,12 +4,14 @@ import unittest
 from oaklib.datamodels.association import Association
 from oaklib.parsers import HPOA_G2P
 from oaklib.parsers.association_parser_factory import get_association_parser
+
 from tests import INPUT_DIR
 
 G2P_INPUT = INPUT_DIR / "test.hpoa_g2p.tsv"
 
 
 class HpoaG2PAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of hpoa g2p format."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_mim2gene_association_parser.py
+++ b/tests/test_parsers/test_mim2gene_association_parser.py
@@ -3,12 +3,14 @@ import unittest
 
 from oaklib.parsers import MEDGEN_MIM_G2D
 from oaklib.parsers.association_parser_factory import get_association_parser
+
 from tests import INPUT_DIR
 
 G2D_INPUT = INPUT_DIR / "example-g2d.mim2gene.tsv"
 
 
 class MIM2GeneAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of medgen file."""
 
     def test_g2d_parser(self):

--- a/tests/test_parsers/test_mim2gene_association_parser.py
+++ b/tests/test_parsers/test_mim2gene_association_parser.py
@@ -10,7 +10,6 @@ G2D_INPUT = INPUT_DIR / "example-g2d.mim2gene.tsv"
 
 
 class MIM2GeneAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of medgen file."""
 
     def test_g2d_parser(self):

--- a/tests/test_parsers/test_obojson_parser.py
+++ b/tests/test_parsers/test_obojson_parser.py
@@ -1,14 +1,15 @@
 import unittest
 
 from linkml_runtime.loaders import json_loader
-
 from oaklib.datamodels.obograph import GraphDocument
+
 from tests import INPUT_DIR
 
 ONT = INPUT_DIR / "go-nucleus.json"
 
 
 class OboJsonParserTest(unittest.TestCase):
+
     """Tests parsing OBO JSON directly."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_obojson_parser.py
+++ b/tests/test_parsers/test_obojson_parser.py
@@ -9,7 +9,6 @@ ONT = INPUT_DIR / "go-nucleus.json"
 
 
 class OboJsonParserTest(unittest.TestCase):
-
     """Tests parsing OBO JSON directly."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_pairwise_association_parser.py
+++ b/tests/test_parsers/test_pairwise_association_parser.py
@@ -4,12 +4,14 @@ import unittest
 from oaklib.datamodels.association import Association
 from oaklib.parsers import G2T
 from oaklib.parsers.association_parser_factory import get_association_parser
+
 from tests import INPUT_DIR
 
 INPUT_TSV = INPUT_DIR / "test-pairwise-associations.tsv"
 
 
 class PairwiseAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of simple pairwise TSVs."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_pairwise_association_parser.py
+++ b/tests/test_parsers/test_pairwise_association_parser.py
@@ -11,7 +11,6 @@ INPUT_TSV = INPUT_DIR / "test-pairwise-associations.tsv"
 
 
 class PairwiseAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of simple pairwise TSVs."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_phaf_association_parser.py
+++ b/tests/test_parsers/test_phaf_association_parser.py
@@ -11,7 +11,6 @@ PHAF_INPUT = INPUT_DIR / "test.phaf.tsv"
 
 
 class PhafAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of PHAF formats."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_phaf_association_parser.py
+++ b/tests/test_parsers/test_phaf_association_parser.py
@@ -4,12 +4,14 @@ import unittest
 from oaklib.datamodels.association import Association
 from oaklib.parsers import PHAF
 from oaklib.parsers.association_parser_factory import get_association_parser
+
 from tests import INPUT_DIR
 
 PHAF_INPUT = INPUT_DIR / "test.phaf.tsv"
 
 
 class PhafAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of PHAF formats."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_xaf_association_parser.py
+++ b/tests/test_parsers/test_xaf_association_parser.py
@@ -4,12 +4,14 @@ import unittest
 from oaklib.datamodels.association import Association
 from oaklib.parsers.parser_base import ColumnReference
 from oaklib.parsers.xaf_association_parser import XafAssociationParser
+
 from tests import INPUT_DIR
 
 GAF = INPUT_DIR / "test-uniprot.gaf"
 
 
 class XafAssociationParserTest(unittest.TestCase):
+
     """Tests parsing of GAF and GAF-like formats."""
 
     def test_parser(self):

--- a/tests/test_parsers/test_xaf_association_parser.py
+++ b/tests/test_parsers/test_xaf_association_parser.py
@@ -11,7 +11,6 @@ GAF = INPUT_DIR / "test-uniprot.gaf"
 
 
 class XafAssociationParserTest(unittest.TestCase):
-
     """Tests parsing of GAF and GAF-like formats."""
 
     def test_parser(self):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from gilda.grounder import Grounder
 from gilda.term import Term
-
 from oaklib.datamodels.text_annotator import TextAnnotationConfiguration
 from oaklib.implementations.gilda import GildaImplementation
 from oaklib.implementations.ontobee.ontobee_implementation import OntobeeImplementation
@@ -20,6 +19,7 @@ from oaklib.interfaces.association_provider_interface import (
     AssociationProviderInterface,
 )
 from oaklib.selector import get_adapter, get_resource_from_shorthand
+
 from tests import INPUT_DIR
 
 

--- a/tests/test_utilities/test_association_diffs.py
+++ b/tests/test_utilities/test_association_diffs.py
@@ -3,13 +3,13 @@ import unittest
 
 from kgcl_schema.datamodel import kgcl
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib import OntologyResource
 from oaklib.datamodels.association import Association
 from oaklib.datamodels.vocabulary import IS_A, LOCATED_IN, PART_OF
 from oaklib.implementations import ProntoImplementation
 from oaklib.utilities.associations.association_differ import AssociationDiffer
 from oaklib.utilities.basic_utils import powerset
+
 from tests import (
     IMBO,
     INPUT_DIR,
@@ -38,6 +38,7 @@ PREDS = [IS_A, PART_OF]
 
 
 class AssociationDiffsTest(unittest.TestCase):
+
     """Tests diffs."""
 
     def setUp(self) -> None:

--- a/tests/test_utilities/test_association_diffs.py
+++ b/tests/test_utilities/test_association_diffs.py
@@ -38,7 +38,6 @@ PREDS = [IS_A, PART_OF]
 
 
 class AssociationDiffsTest(unittest.TestCase):
-
     """Tests diffs."""
 
     def setUp(self) -> None:

--- a/tests/test_utilities/test_association_index.py
+++ b/tests/test_utilities/test_association_index.py
@@ -7,12 +7,14 @@ from oaklib.interfaces.association_provider_interface import (
 from oaklib.parsers.parser_base import ColumnReference
 from oaklib.parsers.xaf_association_parser import XafAssociationParser
 from oaklib.utilities.associations.association_index import AssociationIndex
+
 from tests import INPUT_DIR
 
 GAF = INPUT_DIR / "test-uniprot.gaf"
 
 
 class AssociationIndexTest(unittest.TestCase):
+
     """Tests indexing associations in-memory."""
 
     def test_index(self):

--- a/tests/test_utilities/test_association_index.py
+++ b/tests/test_utilities/test_association_index.py
@@ -14,7 +14,6 @@ GAF = INPUT_DIR / "test-uniprot.gaf"
 
 
 class AssociationIndexTest(unittest.TestCase):
-
     """Tests indexing associations in-memory."""
 
     def test_index(self):

--- a/tests/test_utilities/test_boomer_utils.py
+++ b/tests/test_utilities/test_boomer_utils.py
@@ -3,6 +3,7 @@ import unittest
 from oaklib import get_adapter
 from oaklib.interfaces import MappingProviderInterface
 from oaklib.utilities.mapping.boomer_utils import BoomerEngine, DiffType
+
 from tests import EXAMPLE_ONTOLOGY_DB, INPUT_DIR, NUCLEUS, VACUOLE
 
 EXAMPLE = INPUT_DIR / "boomer-example.md"

--- a/tests/test_utilities/test_cross_ontology_diff.py
+++ b/tests/test_utilities/test_cross_ontology_diff.py
@@ -3,7 +3,6 @@ import unittest
 import kgcl_schema.grammar.parser as kgcl_parser
 import yaml
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib import get_adapter
 from oaklib.datamodels.cross_ontology_diff import DiffCategory, RelationalDiff
 from oaklib.datamodels.vocabulary import HAS_PART, IS_A, PART_OF
@@ -15,6 +14,7 @@ from oaklib.resource import OntologyResource
 from oaklib.utilities.mapping.cross_ontology_diffs import (
     calculate_pairwise_relational_diff,
 )
+
 from tests import (
     CELLULAR_COMPONENT,
     EXAMPLE_ONTOLOGY_OBO,

--- a/tests/test_utilities/test_disjointness_analysis.py
+++ b/tests/test_utilities/test_disjointness_analysis.py
@@ -10,6 +10,7 @@ from oaklib.utilities.axioms.disjointness_axiom_analyzer import (
     generate_disjoint_class_expressions_axioms,
     subsumed_by,
 )
+
 from tests import (
     FUNGI,
     INPUT_DIR,

--- a/tests/test_utilities/test_kgcl_utilities.py
+++ b/tests/test_utilities/test_kgcl_utilities.py
@@ -1,6 +1,7 @@
 import unittest
 
 from oaklib.utilities.kgcl_utilities import parse_kgcl_files
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"

--- a/tests/test_utilities/test_lexical_index.py
+++ b/tests/test_utilities/test_lexical_index.py
@@ -16,6 +16,7 @@ from oaklib.utilities.lexical.lexical_indexer import (
     save_lexical_index,
 )
 from oaklib.utilities.ontology_builder import OntologyBuilder
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"

--- a/tests/test_utilities/test_logical_definition_summarizer.py
+++ b/tests/test_utilities/test_logical_definition_summarizer.py
@@ -6,6 +6,7 @@ from oaklib.utilities.axioms.logical_definition_summarizer import (
     logical_definitions_to_matrix,
     parse_axes_to_config,
 )
+
 from tests import INPUT_DIR
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"

--- a/tests/test_utilities/test_mapping_validation.py
+++ b/tests/test_utilities/test_mapping_validation.py
@@ -1,10 +1,10 @@
 import unittest
 
-from sssom_schema import Mapping
-
 from oaklib import get_adapter
 from oaklib.datamodels.vocabulary import IS_A, PART_OF, SEMAPV, SKOS_EXACT_MATCH
 from oaklib.utilities.mapping.mapping_validation import validate_mappings
+from sssom_schema import Mapping
+
 from tests import CYTOPLASM, FUNGI, INPUT_DIR, NUCLEUS, OUTPUT_DIR, VACUOLE
 
 DB = INPUT_DIR / "go-nucleus.db"

--- a/tests/test_utilities/test_networkx_bridge.py
+++ b/tests/test_utilities/test_networkx_bridge.py
@@ -2,7 +2,6 @@ import logging
 import unittest
 
 import networkx as nx
-
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.pronto.pronto_implementation import ProntoImplementation
 from oaklib.resource import OntologyResource
@@ -11,6 +10,7 @@ from oaklib.utilities.graph.networkx_bridge import (
     transitive_reduction,
     transitive_reduction_by_predicate,
 )
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"

--- a/tests/test_utilities/test_obograph_utils.py
+++ b/tests/test_utilities/test_obograph_utils.py
@@ -4,7 +4,6 @@ import unittest
 from copy import deepcopy
 
 from curies import Converter
-
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.pronto.pronto_implementation import ProntoImplementation
 from oaklib.interfaces.obograph_interface import OboGraphInterface
@@ -24,6 +23,7 @@ from oaklib.utilities.obograph_utils import (
     shortest_paths,
     trim_graph,
 )
+
 from tests import (
     CELLULAR_ANATOMICAL_ENTITY,
     CELLULAR_COMPONENT,

--- a/tests/test_utilities/test_patternizer.py
+++ b/tests/test_utilities/test_patternizer.py
@@ -1,7 +1,6 @@
 import unittest
 
 import yaml
-
 from oaklib.datamodels.vocabulary import (
     NEGATIVELY_REGULATES,
     PART_OF,
@@ -18,6 +17,7 @@ from oaklib.utilities.lexical.patternizer import (
     lexical_pattern_instances,
     load_pattern_collection,
 )
+
 from tests import INPUT_DIR, MEMBRANE, NUCLEAR_MEMBRANE, NUCLEUS, OUTPUT_DIR
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"

--- a/tests/test_utilities/test_relationship_walker.py
+++ b/tests/test_utilities/test_relationship_walker.py
@@ -5,6 +5,7 @@ from oaklib.datamodels.vocabulary import HAS_PART, IS_A
 from oaklib.implementations.pronto.pronto_implementation import ProntoImplementation
 from oaklib.resource import OntologyResource
 from oaklib.utilities.graph.relationship_walker import walk_down, walk_up
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 TEST_ONT = INPUT_DIR / "go-nucleus.obo"

--- a/tests/test_utilities/test_roll_up_to_subset.py
+++ b/tests/test_utilities/test_roll_up_to_subset.py
@@ -4,6 +4,7 @@ from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.sqldb.sql_implementation import SqlImplementation
 from oaklib.resource import OntologyResource
 from oaklib.utilities.subsets.slimmer_utils import roll_up_to_named_subset
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 DB = INPUT_DIR / "go-nucleus.db"

--- a/tests/test_utilities/test_sqlite_utils.py
+++ b/tests/test_utilities/test_sqlite_utils.py
@@ -7,6 +7,7 @@ from oaklib.implementations.sqldb.sqlite_utils import (
     sqlite_bulk_load,
     sqlite_bulk_load2,
 )
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 TSV = INPUT_DIR / "foo.tsv"

--- a/tests/test_utilities/test_sssom_matcher.py
+++ b/tests/test_utilities/test_sssom_matcher.py
@@ -2,10 +2,6 @@ import unittest
 from pathlib import Path
 
 import yaml
-from sssom.parsers import to_mapping_set_document
-from sssom.writers import write_table
-from sssom_schema import Mapping
-
 from oaklib import get_adapter
 from oaklib.datamodels.cross_ontology_diff import EntityReference
 from oaklib.datamodels.mapping_rules_datamodel import (
@@ -36,6 +32,10 @@ from oaklib.utilities.lexical.lexical_indexer import (
     precondition_holds,
     save_lexical_index,
 )
+from sssom.parsers import to_mapping_set_document
+from sssom.writers import write_table
+from sssom_schema import Mapping
+
 from tests import (
     CELL_CORTEX,
     CELL_PERIPHERY,

--- a/tests/test_utilities/test_subset_analysis.py
+++ b/tests/test_utilities/test_subset_analysis.py
@@ -9,6 +9,7 @@ from oaklib.utilities.subsets.subset_analysis import (
     compare_all_subsets,
     terms_by_subsets,
 )
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 DB = INPUT_DIR / "go-nucleus.db"

--- a/tests/test_utilities/test_table_filler.py
+++ b/tests/test_utilities/test_table_filler.py
@@ -137,7 +137,7 @@ EXPECTED = [
                     "label",
                     "label",
                     allow_missing_values=True,
-                    missing_value_token="not a label",
+                    missing_value_token="not a label", # noqa
                 )
             ]
         ),

--- a/tests/test_utilities/test_table_filler.py
+++ b/tests/test_utilities/test_table_filler.py
@@ -2,13 +2,12 @@ import logging
 import unittest
 from copy import deepcopy
 
+import oaklib.datamodels.ontology_metadata as om
 import yaml
 from linkml.utils.schema_builder import SchemaBuilder
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SlotDefinition
 from linkml_runtime.utils.introspection import package_schemaview
-
-import oaklib.datamodels.ontology_metadata as om
 from oaklib.datamodels.vocabulary import IS_A
 from oaklib.implementations import SqlImplementation
 from oaklib.implementations.sparql.sparql_implementation import SparqlImplementation
@@ -20,6 +19,7 @@ from oaklib.utilities.table_filler import (
     parse_table,
     write_table,
 )
+
 from tests import IMBO, INPUT_DIR, NUCLEAR_ENVELOPE, NUCLEUS, OUTPUT_DIR
 
 DB = INPUT_DIR / "go-nucleus.db"

--- a/tests/test_utilities/test_table_filler.py
+++ b/tests/test_utilities/test_table_filler.py
@@ -137,7 +137,7 @@ EXPECTED = [
                     "label",
                     "label",
                     allow_missing_values=True,
-                    missing_value_token="not a label", # noqa
+                    missing_value_token="not a label",  # noqa
                 )
             ]
         ),

--- a/tests/test_utilities/test_taxon_constraints.py
+++ b/tests/test_utilities/test_taxon_constraints.py
@@ -3,13 +3,13 @@ import unittest
 from typing import List
 
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib.datamodels.taxon_constraints import SubjectTerm, Taxon, TaxonConstraint
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.pronto.pronto_implementation import ProntoImplementation
 from oaklib.resource import OntologyResource
 from oaklib.types import TAXON_CURIE
 from oaklib.utilities.taxon.taxon_constraint_utils import parse_gain_loss_file
+
 from tests import (
     BACTERIA,
     CELLULAR_ORGANISMS,

--- a/tests/test_utilities/test_unreciprocated_mappings.py
+++ b/tests/test_utilities/test_unreciprocated_mappings.py
@@ -5,6 +5,7 @@ from oaklib.implementations.sparql.sparql_implementation import SparqlImplementa
 from oaklib.resource import OntologyResource
 from oaklib.utilities.mapping.mapping_validation import unreciprocated_mappings
 from oaklib.utilities.mapping.sssom_utils import mappings_to_pairs
+
 from tests import INPUT_DIR
 
 TEST_ONT = INPUT_DIR / "unreciprocated-mapping-test.obo"

--- a/tests/test_utilities/test_value_set_expander.py
+++ b/tests/test_utilities/test_value_set_expander.py
@@ -2,9 +2,9 @@ import unittest
 
 from linkml_runtime.linkml_model import EnumDefinition, SchemaDefinition
 from linkml_runtime.loaders import yaml_loader
-
 from oaklib.datamodels.value_set_configuration import ValueSetConfiguration
 from oaklib.utilities.subsets.value_set_expander import ValueSetExpander
+
 from tests import (
     BACTERIA,
     EXAMPLE_ONTOLOGY_DB,

--- a/tests/test_validation/test_definition_ontology_rules.py
+++ b/tests/test_validation/test_definition_ontology_rules.py
@@ -11,6 +11,7 @@ from oaklib.utilities.validation.definition_ontology_rule import (
     TextAndLogicalDefinitionMatchOntologyRule,
 )
 from oaklib.utilities.validation.rule_runner import RuleRunner
+
 from tests import INPUT_DIR, MEMBRANE, NUCLEAR_MEMBRANE, NUCLEUS, OUTPUT_DIR
 
 TEST_OUT = OUTPUT_DIR / "lint-test-output.obo"

--- a/tests/test_validation/test_disjointness_rule.py
+++ b/tests/test_validation/test_disjointness_rule.py
@@ -1,10 +1,10 @@
 import unittest
 
 from linkml_runtime.dumpers import yaml_dumper
-
 from oaklib import get_adapter
 from oaklib.utilities.validation.disjointness_rule import DisjointnessRule
 from oaklib.utilities.validation.rule_runner import RuleRunner
+
 from tests import INPUT_DIR, OUTPUT_DIR, SUBATOMIC_PARTICLE
 
 TEST_OUT = OUTPUT_DIR / "lint-test-output.obo"

--- a/tests/test_validation/test_lint_utils.py
+++ b/tests/test_validation/test_lint_utils.py
@@ -6,6 +6,7 @@ from oaklib.implementations.pronto.pronto_implementation import ProntoImplementa
 from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.resource import OntologyResource
 from oaklib.utilities.validation.lint_utils import lint_ontology
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 TEST_OUT = OUTPUT_DIR / "lint-test-output.obo"

--- a/tests/test_validation/test_rule_runner.py
+++ b/tests/test_validation/test_rule_runner.py
@@ -3,6 +3,7 @@ import unittest
 from oaklib.implementations.pronto.pronto_implementation import ProntoImplementation
 from oaklib.resource import OntologyResource
 from oaklib.utilities.validation.rule_runner import RuleRunner
+
 from tests import INPUT_DIR, OUTPUT_DIR
 
 TEST_OUT = OUTPUT_DIR / "lint-test-output.obo"

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,8 @@ deps =
     ruff
 skip_install = true
 commands =
-    ruff --fix kg_microbe/ tests/
+    black src/ tests/
+    ruff --fix src/ tests/
 description = Run linters.
 
 # This is used for QC checks.
@@ -50,5 +51,5 @@ deps =
     ruff
 skip_install = true
 commands =
-    ruff check kg_microbe/ tests/
+    ruff check src/ tests/
 description = Run linters.

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ description = Run linters.
 # This is used for QC checks.
 [testenv:lint]
 deps =
-    black
     ruff
 skip_install = true
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@
 [tox]
 isolated_build = true
 envlist =
+    format
     lint
-    flake8
     py
 
 [testenv]
@@ -34,63 +34,21 @@ commands = poetry lock
 deps = poetry
 description = Lock dependencies with poetry
 
+[testenv:format]
+deps =
+    black
+    ruff
+skip_install = true
+commands =
+    ruff --fix kg_microbe/ tests/
+description = Run linters.
+
+# This is used for QC checks.
 [testenv:lint]
 deps =
     black
-    isort
+    ruff
 skip_install = true
 commands =
-    black src/ tests/
-    isort src/ tests/
+    ruff check kg_microbe/ tests/
 description = Run linters.
-
-[testenv:flake8]
-skip_install = true
-deps =
-    flake8<5.0.0
-    flake8-bandit
-    flake8-black
-    flake8-bugbear
-    flake8-colors
-    flake8-isort
-    pep8-naming
-commands =
-    flake8 src/ tests/
-description = Run the flake8 tool with several plugins (bandit, docstrings, import order, pep8 naming).
-
-#########################
-# Flake8 Configuration  #
-# (.flake8)             #
-#########################
-[flake8]
-ignore =
-    E203
-    W503
-    C901 # needs code change so ignoring for now.
-    E731 # needs code change so ignoring for now.
-    S101 # asserts are fine
-    S106 # flags false positives with test_table_filler
-    N801 # mixed case is bad but there's a lot of auto-generated code
-    N815 # same ^
-    S404 # Consider possible security implications associated with the subprocess module.
-    S108 # Probable insecure usage of temp file/directory.
-    S307 # Use of possibly insecure function - consider using safer ast.literal_eval.
-    S603 # subprocess call - check for execution of untrusted input.
-    S607 # Starting a process with a partial executable path ["open" in both cases]
-    S608 # Possible SQL injection vector through string-based query construction.
-    B024 # StreamingWriter is an abstract base class, but it has no abstract methods. 
-         # Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
-    B027 # empty method in an abstract base class, but has no abstract decorator. Consider adding @abstractmethod
-    N803 # math-oriented classes can ignore this (e.g. hypergeometric.py)
-    N806 # math-oriented classes can ignore this (e.g. hypergeometric.py)
-    B019
-    S113 # new check - deal with this later
-    
-max-line-length = 120
-max-complexity = 13
-import-order-style = pycharm
-application-import-names =
-    oaklib
-    tests
-exclude =
-    datamodels   ## datamodels are auto-generated


### PR DESCRIPTION
- [x] Accommodate for `score_metric` for search and `termset_pairwise_similarity`
- [x] Replaced `flake8` by `ruff` 
  - Reason: We're moving away from `flake8` and embracing `ruff` in all our cookiecutters  and hence all projects.
  - `ruff` includes most rules `flake8` enforces and some more.