### PR TITLE
`EdgeCreation` object has `about_edge` == None

### DIFF
--- a/src/oaklib/interfaces/differ_interface.py
+++ b/src/oaklib/interfaces/differ_interface.py
@@ -392,7 +392,7 @@ class DifferInterface(BasicOntologyInterface, ABC):
                 if isinstance(change, kgcl.EdgeDeletion):
                     about = change.subject
                 else:
-                    about = change.about_edge.subject
+                    about = change.subject
             else:
                 about = None
             partition = RESIDUAL_KEY


### PR DESCRIPTION
In KGCL when an `EdgeChange` is recorded, the `subject`, `predicate` and `object` attributes of the class are set. The `about_edge` attribute is `None`. This came to light while solving https://github.com/monarch-initiative/rppr_stats/issues/1 .

This PR refactors 1 line of code