### PR TITLE
Adding has-part glyph to config.

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -1875,6 +1875,12 @@ def viz(
     if stylemap is None:
         stylemap = default_stylemap_path()
     actual_predicates = _process_predicates_arg(predicates)
+    curies_hightlight = None
+    if "@" in terms:
+        ix = terms.index("@")
+        terms_highlight = terms[0:ix]
+        terms = terms[ix + 1 :]
+        curies_hightlight = list(query_terms_iterator(terms_highlight, impl))
     curies = list(query_terms_iterator(terms, impl))
     if add_mrcas:
         if isinstance(impl, SemanticSimilarityInterface):
@@ -1910,11 +1916,13 @@ def viz(
         impl.add_metadata(graph)
     if not graph.nodes:
         raise ValueError(f"No nodes in graph for {curies}")
+    if curies_hightlight is None:
+        curies_hightlight = curies
     # TODO: abstract this out
     if not output_type or output_type in ["png", "svg", "dot"]:
         graph_to_image(
             graph,
-            seeds=curies,
+            seeds=curies_hightlight,
             stylemap=stylemap,
             configure=configure,
             imgfile=output,

--- a/src/oaklib/conf/obograph-style.json
+++ b/src/oaklib/conf/obograph-style.json
@@ -64,6 +64,12 @@
             "penwidth": 3,            
             "label": "ⓟ"
         },
+        "BFO:0000051": {
+            "arrowhead": "box",
+            "color": "teal",
+            "penwidth": 2,            
+            "label": "ⓗ"
+        },
         "RO:0004009": {
             "arrowhead": "box",
             "color": "green",
@@ -170,7 +176,7 @@
             "fillcolor": "cyan"
         },
         "CHEBI": {
-            "fillcolor": "cyan"
+            "fillcolor": "mediumturquoise"
         },
         "NCBITaxon": {
             "fillcolor": "burlywood1"


### PR DESCRIPTION
Allowing '@' in input options for viz, allowing separation
of highlighted terms and query terms
