### PR TITLE
Solves ClassCreation duplication & formats Mappings md table properly

### DIFF
--- a/src/oaklib/utilities/writers/change_handler.py
+++ b/src/oaklib/utilities/writers/change_handler.py
@@ -313,7 +313,7 @@ class ChangeHandler:
                 for change in value
             }
         )
-        
+
         header = "| Subject | Predicate | Object |"
         self.write_markdown_table(f"Mappings added: {len(rows)}", header, rows)
 
@@ -344,7 +344,7 @@ class ChangeHandler:
                 for change in value
             }
         )
-        
+
         header = "| Subject | Predicate | Object |"
         self.write_markdown_table(f"Mappings removed: {len(rows)}", header, rows)
 

--- a/src/oaklib/utilities/writers/change_handler.py
+++ b/src/oaklib/utilities/writers/change_handler.py
@@ -307,11 +307,13 @@ class ChangeHandler:
     def handle_mapping_creation(self, value):
         rows = list(
             {
-                f"""| {self._format_entity_labels(change.subject)}
-                | {change.predicate} | {self._format_entity_labels(change.object)} |"""
+                f"""| {self._format_entity_labels(change.subject)} | """
+                f"""{change.predicate} | """
+                f"""{self._format_entity_labels(change.object)} |"""
                 for change in value
             }
         )
+        
         header = "| Subject | Predicate | Object |"
         self.write_markdown_table(f"Mappings added: {len(rows)}", header, rows)
 
@@ -336,11 +338,13 @@ class ChangeHandler:
     def handle_remove_mapping(self, value):
         rows = list(
             {
-                f"""| {self._format_entity_labels(change.about_node)}
-                | {change.predicate} | {self._format_entity_labels(change.object)} |"""
+                f"""| {self._format_entity_labels(change.about_node)} | """
+                f"""{change.predicate} | """
+                f"""{self._format_entity_labels(change.object)} |"""
                 for change in value
             }
         )
+        
         header = "| Subject | Predicate | Object |"
         self.write_markdown_table(f"Mappings removed: {len(rows)}", header, rows)
 

--- a/tests/test_implementations/__init__.py
+++ b/tests/test_implementations/__init__.py
@@ -1081,7 +1081,6 @@ class ComplianceTester:
                 old_value="enzyme activity",
                 new_value="catalytic activity",
             ),
-            kgcl.ClassCreation(id=FIXED_ID, about_node="GO:0033673"),
             kgcl.MappingCreation(
                 id=FIXED_ID,
                 subject=CELLULAR_COMPONENT,


### PR DESCRIPTION
- Fixes #778
- Fixes #779 
- Fixes #732 

Resolves multiple issues:

 - `ClassCreeation` was being duplicated in all output formats when the `simpleobo:` adapter was used.
 - `Mappings created/removed` table in markdown format was not properly formatted.

This PR fixes both.