### PR TITLE
Update sql_implementation.py to include sqlachemy output in debug logging.

### DIFF
--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -364,8 +364,8 @@ class SqlImplementation(
                 locator = f"sqlite:///{path}"
             logging.info(f"Locator, post-processed: {locator}")
             self.engine = create_engine(locator)
-            
-            if(logging.root.level <= logging.DEBUG): 
+
+            if(logging.root.level <= logging.DEBUG):
                 #If oaklib is running at DEBUG level logging; record all queries from sqlachemy on execution.
                 #This line is equivalent to create_engine(locator,echo=True)
                 logging.getLogger('sqlalchemy.engine.Engine').setLevel(logging.INFO)

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -364,6 +364,11 @@ class SqlImplementation(
                 locator = f"sqlite:///{path}"
             logging.info(f"Locator, post-processed: {locator}")
             self.engine = create_engine(locator)
+            
+            if(logging.root.level <= logging.DEBUG): 
+                #If oaklib is running at DEBUG level logging; record all queries from sqlachemy on execution.
+                #This line is equivalent to create_engine(locator,echo=True)
+                logging.getLogger('sqlalchemy.engine.Engine').setLevel(logging.INFO)
 
     @property
     def session(self):


### PR DESCRIPTION
The current logging scheme for sql_queries directly outputs the sqlachemy query as rendered by what is the following:
```
q = session.query(...)
logging.info(str(q))
```
The following is the output from [logging.info(f"ECA query: {q}")](https://github.com/INCATools/ontology-access-kit/blob/7774d909e7231ac94347cc77cda4fe5e05b54922/src/oaklib/implementations/sqldb/sql_implementation.py#L1083) in function[ _equivalent_class_relationships](https://github.com/INCATools/ontology-access-kit/blob/7774d909e7231ac94347cc77cda4fe5e05b54922/src/oaklib/implementations/sqldb/sql_implementation.py#L1067).

```
INFO:root:ECA query: SELECT statements.subject AS statements_subject, statements.predicate AS statements_predicate, statements.object AS statements_object FROM statements
WHERE statements.predicate = ? AND statements.object IN (__[POSTCOMPILE_object_1]) AND statements.object IN (SELECT class_node.id FROM class_node)
```

With this change, when running at logging level DEBUG, anytime a query is executed sqlachemy will also writes it's logging output, which is the following: 
```
INFO:sqlalchemy.engine.Engine:SELECT statements.subject AS statements_subject, statements.predicate AS statements_predicate, statements.object AS statements_object FROM statements
WHERE statements.predicate = ? AND statements.object IN (?) AND statements.object IN (SELECT class_node.id FROM class_node)
INFO:sqlalchemy.engine.Engine:[generated in 0.00023s] ('owl:equivalentClass', 'MONDO:0000550')
```

In the Sqlalchemy logging, the ambiguous term _"(__[POSTCOMPILE_object_1])"_ isn't stated and instead replaced with a query parameter, and the query parameters are outputted on a second line.