### PR TITLE
Fix test suite

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1522,7 +1522,7 @@ class TestCommandLineInterface(unittest.TestCase):
             ],
         )
         print("STDERR", result.stdout)
-        err = result.stderr
+        err = "\n".join([line for line in result.stderr.split("\n") if not line.startswith("WARNING")])
         self.assertEqual("", err)
         self.assertEqual(0, result.exit_code)
         with open(outfile) as stream:

--- a/tests/test_implementations/test_semsimian_implementation.py
+++ b/tests/test_implementations/test_semsimian_implementation.py
@@ -1,6 +1,7 @@
 import os
 import timeit
 import unittest
+from importlib.util import find_spec
 
 from linkml_runtime.dumpers import yaml_dumper
 
@@ -31,6 +32,7 @@ EXPECTED_ICS = {
 
 
 @unittest.skipIf(os.name == "nt", "DB path loading inconsistent on Windows")
+@unittest.skipIf(find_spec("semsimian") is None, "Semsimian not available")
 class TestSemSimianImplementation(unittest.TestCase):
     """Implementation tests for Rust-based semantic similarity."""
 

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -6,8 +6,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from gilda.grounder import Grounder
-from gilda.term import Term
+try:
+    from gilda.grounder import Grounder
+    from gilda.term import Term
+
+    have_gilda = True
+except ImportError:
+    have_gilda = False
 
 from oaklib.datamodels.text_annotator import TextAnnotationConfiguration
 from oaklib.implementations.gilda import GildaImplementation
@@ -23,6 +28,7 @@ from oaklib.selector import get_adapter, get_resource_from_shorthand
 from tests import INPUT_DIR
 
 
+@unittest.skipIf(not have_gilda, "Gilda not available")
 class TestResource(unittest.TestCase):
     def test_from_descriptor(self):
         # no scheme


### PR DESCRIPTION
This PR fixes two issues with the test suite.

The first (#794) is that the test suite fails if `gilda` and/or `semsimian` are not installed in the environment, even though those modules are _optional_ dependencies and as such not installed by a standard `poetry install` command. This PR fixes that by detecting the absence of those modules and skipping the corresponding tests, instead of letting them fail.

The second (#795) is that the `test_annotate_file` file may fail because of unexpected warnings emitted by the `annotate` command, even if the command runs normally and produces the expected output file. This PR fixes that by making the test ignore any `WARNING` line when checking the STDERR output of the command.

(That second fix  is based on the assumption that we don’t actually care about those warnings, as long as the command does what is expected of it. If that is not the case – if it is instead important to test that `annotate` does _not_ produce any warning, then obviously the proposed fix is wrong and we should instead figure out where those warnings are emitted to shut them off.)