### PR TITLE
Add cache management features

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -91,6 +91,55 @@ and tracing upwards through is_a and part_of relationships:
 
     uberon viz -p i,p hand foot
 
+Cache Control
+-------------
+
+OAK may download data from remote sources as part of its normal operations. For
+example, using the :code:`sqlite:obo:...` input selector will cause OAK to
+fetch the requested Semantic-SQL database from a centralised repository.
+Whenever that happens, the downloaded data will be cached in a local directory
+so that subsequent commands using the same input selector do not have to
+download the file again.
+
+By default, OAK will refresh (download again) a previously downloaded file if
+it was last downloaded more than 7 days ago.
+
+The global option :code:`--caching` gives the user some control on how the
+cache works.
+
+To change the default cache expiry lifetime of 7 days, the :code:`--caching`
+option accepts a value of the form :code:`ND`, where *N* is a positive integer
+and *D* can be either :code:`s`, :code:`d`, :code:`w`, :code:`m`, or :code:`y`
+to indicate that *N* is a number of seconds, days, weeks, months, or years,
+respectively. If the *D* part is omitted, it defaults to :code:`d`.
+
+For example, :code:`--caching=3w` instructs OAK to refresh a cached file if it
+was last refreshed 21 days ago.
+
+The :code:`--caching` option also accepts the following special values:
+
+- :code:`refresh` to force OAK to always refresh a file regardless of its age;
+- :code:`no-refresh` to do the opposite, that is, preventing OAK from
+  refreshing a file regardless of its age;
+- :code:`clear` to forcefully clear the cache (which will trigger a refresh as
+  a consequence);
+- :code:`reset` is a synonym of :code:`clear`.
+
+Note the difference between :code:`refresh` and :code:`clear`. The former will
+only cause the requested file to be refreshed, leaving any other file that may
+exist in the cache untouched. The latter will delete all cached files, so that
+not only the requested file will be downloaded again, but any other
+previously cached file will also have to be downloaded again the next time they
+are requested.
+
+In both case, refreshing and clearing will only happen if the OAK command in
+which the :code:`--caching` option is used attempts to look up a cached file.
+Otherwise the option will have no effect.
+
+To forcefully clear the cache independently of any command, the
+:ref:`cache-clear` command may be used. The contents of the cache may be
+explored at any time with the :ref:`cache-ls` command.
+
 Commands
 -----------
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -104,6 +104,12 @@ download the file again.
 By default, OAK will refresh (download again) a previously downloaded file if
 it was last downloaded more than 7 days ago.
 
+The behavior of the cache can be controlled in two ways: with an option on the
+command line and with a configuration.
+
+Controlling the cache on the command line
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The global option :code:`--caching` gives the user some control on how the
 cache works.
 
@@ -139,6 +145,55 @@ Otherwise the option will have no effect.
 To forcefully clear the cache independently of any command, the
 :ref:`cache-clear` command may be used. The contents of the cache may be
 explored at any time with the :ref:`cache-ls` command.
+
+Controlling the cache with a configuration file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Finer control of how the cache works is possible through a configuration file
+that OAK will look up for at the following locations:
+
+- under GNU/Linux: in ``$XDG_CONFIG_HOME/ontology-access-kit/cache.conf``;
+- under macOS: in ``$HOME/Library/Preferences/ontology-access-kit/cache.conf``;
+- under Windows: in ``%LOCALAPPDATA%\ontology-access-kit\ontology-access-kit\cache.conf``,
+  or ``%APPDATA%\ontology-access-kit\ontology-access-kit\cache.conf`` if the
+  user is using a roaming profile.
+
+The file should contain lines of the form :code:`pattern = policy`, where:
+
+- *pattern* is a shell-type globbing pattern indicating the files that will be
+  concerned by the policy set forth on the line;
+- *policy* is the same type of value as expected by the :code:`--caching`
+  option as explained in the previous section.
+
+Blank lines and lines starting with :code:`#` are ignored.
+
+If the *pattern* is :code:`default` (or :code:`*`), the corresponding policy
+will be used for any cached file that does not have a matching policy.
+
+Here is a sample configuration file:
+
+.. code-block::
+
+    # Uberon will be refreshed if older than 1 month
+    uberon.db = 1m
+    # FBbt will be refreshed if older than 2 weeks
+    fbbt.db = 2w
+    # Other FlyBase ontologies will be refreshed if older than 2 months
+    fb*.db = 2m
+    # All other files will be refreshed if older than 3 weeks
+    default = 3w
+
+Note that when looking up the policy to apply to a given file, patterns are
+tried in the order they appear in the file. This is why the :code:`fbbt.db`
+pattern in the example above must be listed *before* the less specific
+:code:`fb*.db` pattern, otherwise it would be ignored. (This does not apply to
+the default pattern -- whether it is specified as :code:`default` or as
+:code:`*` -- which is always tried after all the other patterns.)
+
+The :code:`--caching` option described in the previous section always takes
+precedence over the configuration file. That is, all rules set forth in the
+configuration will be ignored if the :code:`--caching` option is specified on
+the command line.
 
 Commands
 -----------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -105,7 +105,7 @@ By default, OAK will refresh (download again) a previously downloaded file if
 it was last downloaded more than 7 days ago.
 
 The behavior of the cache can be controlled in two ways: with an option on the
-command line and with a configuration.
+command line and with a configuration file.
 
 Controlling the cache on the command line
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,10 +153,8 @@ Finer control of how the cache works is possible through a configuration file
 that OAK will look up for at the following locations:
 
 - under GNU/Linux: in ``$XDG_CONFIG_HOME/ontology-access-kit/cache.conf``;
-- under macOS: in ``$HOME/Library/Preferences/ontology-access-kit/cache.conf``;
-- under Windows: in ``%LOCALAPPDATA%\ontology-access-kit\ontology-access-kit\cache.conf``,
-  or ``%APPDATA%\ontology-access-kit\ontology-access-kit\cache.conf`` if the
-  user is using a roaming profile.
+- under macOS: in ``$HOME/Library/Application Support/ontology-access-kit/cache.conf``;
+- under Windows: in ``%LOCALAPPDATA%\ontology-access-kit\ontology-access-kit\cache.conf``.
 
 The file should contain lines of the form :code:`pattern = policy`, where:
 

--- a/docs/intro/tutorial07.rst
+++ b/docs/intro/tutorial07.rst
@@ -64,6 +64,25 @@ This will download the pato.db sqlite file once, and cache it.
 
 PyStow is used to cache the file, and the default location is ``~/.data/oaklib``.
 
+By default, a cached SQLite file will be automatically refreshed (downloaded
+again) if it is older than 7 days. That behavior can be controlled with the
+global ``--caching`` option. For example, to force OAK to always download the
+file regardless of its age:
+
+.. code-block::
+
+    runoak --caching=refresh -i sqlite:obo:pato search t~shape
+
+Other possible values for the ``--caching`` option include:
+
+- ``no-refresh`` to prevent OAK from re-downloading the file even it is older
+  than 7 days;
+- ``Xd`` to refresh a cached file older than _X_ days;
+- ``Xw`` to refresh a cached file older than _X_ weeks.
+
+You may also use the ``cache-clear`` command to force clearing any cached
+SQLite file at anytime.
+
 Building your own SQLite files
 -------------------
 

--- a/docs/intro/tutorial07.rst
+++ b/docs/intro/tutorial07.rst
@@ -65,23 +65,8 @@ This will download the pato.db sqlite file once, and cache it.
 PyStow is used to cache the file, and the default location is ``~/.data/oaklib``.
 
 By default, a cached SQLite file will be automatically refreshed (downloaded
-again) if it is older than 7 days. That behavior can be controlled with the
-global ``--caching`` option. For example, to force OAK to always download the
-file regardless of its age:
-
-.. code-block::
-
-    runoak --caching=refresh -i sqlite:obo:pato search t~shape
-
-Other possible values for the ``--caching`` option include:
-
-- ``no-refresh`` to prevent OAK from re-downloading the file even it is older
-  than 7 days;
-- ``Xd`` to refresh a cached file older than _X_ days;
-- ``Xw`` to refresh a cached file older than _X_ weeks.
-
-You may also use the ``cache-clear`` command to force clearing any cached
-SQLite file at anytime.
+again) if it is older than 7 days. For details on how to alter the behavior of
+the cache, see the :ref:`Cache Control` section in the CLI documentation.
 
 Building your own SQLite files
 -------------------

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -42,6 +42,7 @@ from sssom.parsers import parse_sssom_table, to_mapping_set_document
 
 import oaklib.datamodels.taxon_constraints as tcdm
 from oaklib import datamodels
+from oaklib.constants import FILE_CACHE
 from oaklib.converters.logical_definition_flattener import LogicalDefinitionFlattener
 from oaklib.datamodels import synonymizer_datamodel
 from oaklib.datamodels.association import RollupGroup
@@ -149,6 +150,7 @@ from oaklib.utilities.axioms.disjointness_axiom_analyzer import (
     generate_disjoint_class_expressions_axioms,
 )
 from oaklib.utilities.basic_utils import pairs_as_dict
+from oaklib.utilities.caching import CachePolicy
 from oaklib.utilities.iterator_utils import chunk
 from oaklib.utilities.kgcl_utilities import (
     generate_change_id,
@@ -568,6 +570,13 @@ def _apply_changes(impl, changes: List[kgcl.Change]):
     show_default=True,
     help="If set, will profile the command",
 )
+@click.option(
+    "--caching",
+    type=CachePolicy.ClickType,
+    default="1w",
+    show_default=True,
+    help="Set the cache management policy",
+)
 def main(
     verbose: int,
     quiet: bool,
@@ -587,6 +596,7 @@ def main(
     prefix,
     profile: bool,
     import_depth: Optional[int],
+    caching: CachePolicy,
     **kwargs,
 ):
     """
@@ -635,6 +645,7 @@ def main(
         import requests_cache
 
         requests_cache.install_cache(requests_cache_db)
+    FILE_CACHE.policy = caching
     resource = OntologyResource()
     resource.slug = input
     settings.autosave = autosave

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -570,7 +570,6 @@ def _apply_changes(impl, changes: List[kgcl.Change]):
 @click.option(
     "--caching",
     type=CachePolicy.ClickType,
-    default="1w",
     show_default=True,
     help="Set the cache management policy",
 )
@@ -593,7 +592,7 @@ def main(
     prefix,
     profile: bool,
     import_depth: Optional[int],
-    caching: CachePolicy,
+    caching: Optional[CachePolicy],
     **kwargs,
 ):
     """
@@ -642,7 +641,7 @@ def main(
         import requests_cache
 
         requests_cache.install_cache(requests_cache_db)
-    FILE_CACHE.policy = caching
+    FILE_CACHE.force_policy(caching)
     resource = OntologyResource()
     resource.slug = input
     settings.autosave = autosave

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -570,7 +570,6 @@ def _apply_changes(impl, changes: List[kgcl.Change]):
 @click.option(
     "--caching",
     type=CachePolicy.ClickType,
-    show_default=True,
     help="Set the cache management policy",
 )
 def main(

--- a/src/oaklib/constants.py
+++ b/src/oaklib/constants.py
@@ -10,5 +10,5 @@ __all__ = [
 ]
 
 OAKLIB_MODULE = pystow.module("oaklib")
-FILE_CACHE = FileCache(OAKLIB_MODULE, '1w')
+FILE_CACHE = FileCache(OAKLIB_MODULE)
 TIMEOUT_SECONDS = 30

--- a/src/oaklib/constants.py
+++ b/src/oaklib/constants.py
@@ -2,9 +2,13 @@
 
 import pystow
 
+from oaklib.utilities.caching import FileCache
+
 __all__ = [
     "OAKLIB_MODULE",
+    "FILE_CACHE",
 ]
 
 OAKLIB_MODULE = pystow.module("oaklib")
+FILE_CACHE = FileCache(OAKLIB_MODULE, '1w')
 TIMEOUT_SECONDS = 30

--- a/src/oaklib/implementations/llm_implementation.py
+++ b/src/oaklib/implementations/llm_implementation.py
@@ -8,7 +8,6 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Tuple
 
-import pystow
 from linkml_runtime.dumpers import yaml_dumper
 from sssom_schema import Mapping
 from tenacity import (
@@ -19,6 +18,7 @@ from tenacity import (
 )
 
 from oaklib import BasicOntologyInterface
+from oaklib.constants import FILE_CACHE
 from oaklib.datamodels.class_enrichment import ClassEnrichmentResult
 from oaklib.datamodels.item_list import ItemList
 from oaklib.datamodels.obograph import DefinitionPropertyValue
@@ -148,7 +148,7 @@ def config_to_prompt(configuration: Optional[ValidationConfiguration]) -> Option
 
             for obj in configuration.documentation_objects:
                 if obj.startswith("http:") or obj.startswith("https:"):
-                    path = pystow.ensure("oaklib", "documents", url=obj)
+                    path = FILE_CACHE.ensure("documents", url=obj)
                 else:
                     path = obj
                 with open(path) as f:

--- a/src/oaklib/implementations/sqldb/sql_implementation.py
+++ b/src/oaklib/implementations/sqldb/sql_implementation.py
@@ -63,7 +63,7 @@ from sssom_schema import Mapping
 
 import oaklib.datamodels.ontology_metadata as om
 import oaklib.datamodels.validation_datamodel as vdm
-from oaklib.constants import OAKLIB_MODULE
+from oaklib.constants import FILE_CACHE
 from oaklib.datamodels import obograph, ontology_metadata
 from oaklib.datamodels.association import Association
 from oaklib.datamodels.obograph import (
@@ -342,7 +342,7 @@ class SqlImplementation(
                 # Option 1 uses direct URL construction:
                 url = f"https://s3.amazonaws.com/bbop-sqlite/{prefix}.db.gz"
                 logging.info(f"Ensuring gunzipped for {url}")
-                db_path = OAKLIB_MODULE.ensure_gunzip(url=url, autoclean=False)
+                db_path = FILE_CACHE.ensure_gunzip(url=url, autoclean=False)
                 # Option 2 uses botocore to interface with the S3 API directly:
                 # db_path = OAKLIB_MODULE.ensure_from_s3(s3_bucket="bbop-sqlite", s3_key=f"{prefix}.db")
                 locator = f"sqlite:///{db_path}"

--- a/src/oaklib/utilities/caching.py
+++ b/src/oaklib/utilities/caching.py
@@ -257,6 +257,9 @@ class FileCache(object):
         to the current caching policy.
         """
 
+        if self._policy == CachePolicy.RESET:
+            self.clear(pattern="*.db*")
+
         if not name:
             name = name_from_url(url)
 
@@ -269,6 +272,9 @@ class FileCache(object):
 
     def ensure(self, *subkeys, url, name=None):
         """Looks up and maybe downloads a file."""
+
+        if self._policy == CachePolicy.RESET:
+            self.clear(pattern="*.db*")
 
         if not name:
             name = name_from_url(url)

--- a/src/oaklib/utilities/caching.py
+++ b/src/oaklib/utilities/caching.py
@@ -60,6 +60,9 @@ class CachePolicy(object):
         :return: True if the data should be refreshed, otherwise False
         """
 
+        if self._max_age <= 0:
+            # Forceful refresh/reset, even if "then" is somehow in the future
+            return True
         return time.time() - then > self._max_age
 
     def refresh_file(self, pathname):

--- a/tests/input/cache.conf
+++ b/tests/input/cache.conf
@@ -1,0 +1,16 @@
+# Test file for the file cache configuration
+
+# Default policy: refresh after 1 week
+default = 1w
+
+# Refresh Uberon after 2 weeks
+uberon.db = 2w
+
+# Refresh FlyBase ontologies after 1 month
+fb*.db = 1m
+
+# Warning: pattern without associated policy
+missing_policy.db
+
+# Warning: invalid policy
+invalid_policy.db = invalid

--- a/tests/test_utilities/test_caching.py
+++ b/tests/test_utilities/test_caching.py
@@ -1,0 +1,95 @@
+import os
+import time
+import unittest
+
+from oaklib.utilities.caching import CachePolicy
+
+
+class TestCachePolicy(unittest.TestCase):
+
+    def test_refresh_policy(self):
+        policy = CachePolicy.from_string("refresh")
+
+        self.assertTrue(policy.always_refresh)
+        self.assertFalse(policy.never_refresh)
+        self.assertFalse(policy.reset)
+
+        self.assertEqual(CachePolicy.REFRESH, policy)
+
+        now = time.time()
+        self.assertTrue(policy.refresh(now))
+        self.assertTrue(policy.refresh(now + 86400)) # 1 day in the future
+        self.assertTrue(policy.refresh(now - 86400)) # 1 day in the past
+
+    def test_never_refresh_policy(self):
+        policy = CachePolicy.from_string("no-refresh")
+
+        self.assertTrue(policy.never_refresh)
+        self.assertFalse(policy.always_refresh)
+        self.assertFalse(policy.reset)
+
+        self.assertEqual(CachePolicy.NO_REFRESH, policy)
+
+        now = time.time()
+        self.assertFalse(policy.refresh(now))
+        self.assertFalse(policy.refresh(now + 86400))
+        self.assertFalse(policy.refresh(now - 86400))
+
+        # inexistent file is always refreshed even under "no-refresh"
+        self.assertTrue(policy.refresh_file("inexistent-file"))
+
+    def test_reset_policy(self):
+        policy = CachePolicy.from_string("reset")
+        self.assertEqual(policy, CachePolicy.from_string("clear"))
+
+        self.assertTrue(policy.reset)
+        self.assertFalse(policy.always_refresh)
+        self.assertFalse(policy.never_refresh)
+
+        self.assertEqual(CachePolicy.RESET, policy)
+
+        now = time.time()
+        self.assertTrue(policy.refresh(now))
+        self.assertTrue(policy.refresh(now + 86400))
+        self.assertTrue(policy.refresh(now - 86400))
+
+    def test_refresh_after_1day_policy(self):
+        policy = CachePolicy.from_string('1d')
+
+        self.assertFalse(policy.always_refresh)
+        self.assertFalse(policy.never_refresh)
+        self.assertFalse(policy.reset)
+
+        now = time.time()
+        self.assertTrue(policy.refresh(now - 90000)) # 25 hours in the past
+        self.assertFalse(policy.refresh(now - 82800)) # 23 hours in the past
+
+    def test_refresh_file(self):
+        now = time.time()
+
+        # Create dummy file with known mtime 3 days in the past
+        path = "tests/output/dummy-cache"
+        with open(path, "w"):
+            pass
+        os.utime(path, (now - 259200, now - 259200))
+
+        self.assertTrue(CachePolicy.REFRESH.refresh_file(path))
+        self.assertTrue(CachePolicy.RESET.refresh_file(path))
+        self.assertFalse(CachePolicy.NO_REFRESH.refresh_file(path))
+        self.assertTrue(CachePolicy.from_string('2d').refresh_file(path))
+        self.assertFalse(CachePolicy.from_string('4d').refresh_file(path))
+
+        os.unlink(path)
+
+        # Inexistent file gets refreshed even under no-refresh
+        self.assertTrue(CachePolicy.NO_REFRESH.refresh_file(path))
+
+    def test_parsing_durations(self):
+        self.assertEqual(CachePolicy.from_string("1")._max_age, 86400)
+        self.assertEqual(CachePolicy.from_string("1d")._max_age, 86400)
+        self.assertEqual(CachePolicy.from_string("86400s")._max_age, 86400)
+        self.assertEqual(CachePolicy.from_string("1w")._max_age, 86400 * 7)
+        self.assertEqual(CachePolicy.from_string("1m")._max_age, 86400 * 30)
+        self.assertEqual(CachePolicy.from_string("1y")._max_age, 86400 * 365)
+
+        self.assertIsNone(CachePolicy.from_string("bogus"))


### PR DESCRIPTION
This PR implements roughly what was proposed in [this comment](https://github.com/INCATools/ontology-access-kit/issues/792#issuecomment-2292350550).

From a user’s perspective:

By default, whenever an attempt is made to access a SQLite DB through the `sqlite:obo:...` descriptor, and the requested DB is already present in the Pystow cache, OAK will check whether the SQLite file is older than 7 days, and if it is, will forcefully re-download that file again.

A new command-line global option `--caching` is available to alter that default behaviour. That option allows to:

* Change the duration after which a cached DB is considered “stale” and in need of refreshing; for example, with `--caching=3w`, a cached DB will be refreshed upon access if is older than 3 weeks (the general syntax is `ND`, where _N_ is a number and `D` can be `s`, `d`, `w`, `m`, or `y` to indicate that _N_ is a number of seconds, days, weeks, months, or years, respectively).
* Prevent OAK from refreshing a cached DB regardless of how old it is, with `--caching=no-refresh`.
* Force OAK to refresh a cached DB regardless of how old it is, with `--caching=refresh`.
* Force OAK to completely clear the cache (which will obviously trigger a refresh), with `--caching=clear` or `--caching=reset`.

Implementation details:

Most of the new code is in the new module `oaklib.utilities.caching` and split in two classes:

* `CachePolicy` represents the logic to determine whether a given file is in need of refreshing.
* `FileCache` represents the file cache itself and is the main interface that the rest of OAK should interact with whenever they need to access the cache (instead of using Pystow directly). It is merely a thin layer on top of Pystow, that tries¹ to present the same interface (same methods) than a Pystow module, so that it can be used as a drop-in replacement.

(¹ I say “tries to” because it only implements the Pystow methods that were actually used somewhere in OAK code, and only with the parameters used in those case.)

A new `FILE_CACHE` object (an instance of `FileCache`) is added to the globals in `oaklib.constants` (same place containing the `PYSTOW_MODULE`), where it can be used by any part of OAK that needs to interact with the cache. The `llm_implementation` and `sqldb_implementation` modules are amended to use that new global instead of `PYSTOW_MODULE`.

Finally, in the main entry point module:

* the `--caching` option is added;
* the `cache-ls` and `cache-clear` commands are re-written to use methods from the `FileCache` class.

closes #792