### PR TITLE
Remove outdated warning, fix minor typos

### DIFF
--- a/docs/guide/mappings.rst
+++ b/docs/guide/mappings.rst
@@ -145,10 +145,10 @@ If we query for the ZFA ID we see the complete set of ZFA mappings for that term
 
 So ZFA bundles mappings to TAO.
 
-At the time of writing ZFA, does bundle mappings to CL.
+At the time of writing, ZFA does bundle mappings to CL.
 
-In future OAK may have easier ways to query a union of ontologies, and in the future OBO ontologies
-may redistribute reciprocal mappings, but for now it helps to know how each ontology handles mappings to
+In the future, OAK may have easier ways to query a union of ontologies, and OBO ontologies may
+redistribute reciprocal mappings, but for now it helps to know how each ontology handles mappings to
 use these effectively.
 
 Support for SSSOM
@@ -166,7 +166,7 @@ Generating Mappings
 
 OAK also includes a functionality for *generating* mappings, via the `lexmatch` command.
 
-See the `Lexmatch tutorial <https://oboacademy.github.io/obook/tutorial/lexmatch-tutorial/>`_. on OBO Academy.
+See the `Lexmatch tutorial <https://oboacademy.github.io/obook/tutorial/lexmatch-tutorial/>`_ on OBO Academy.
 
 Further reading
 ---------------

--- a/docs/guide/relationships-and-graphs.rst
+++ b/docs/guide/relationships-and-graphs.rst
@@ -6,7 +6,7 @@ Relationships and Graphs
 One of the main uses of an ontology is to precisely state the :term:`Relationships<Relationship>` between different entities or concepts.
 
 In OAK, classes in ontologies can be related to one another via different *relationship types*, also known as :term:`Predicates<Predicate>`. These
-may come from a relationship type ontology such as :term:`RO`, or they may be a "builtin" construct in :term:`RDF` or :term:`OWL`
+may come from a relationship type ontology such as :term:`RO`, or they may be a "built-in" construct in :term:`RDF` or :term:`OWL`
 such as ``rdfs:subClassOf``.
 
 These can be thought of as a :term:`Graph` of concepts and relationships. This is a common idiom

--- a/docs/intro/tutorial06.rst
+++ b/docs/intro/tutorial06.rst
@@ -1,11 +1,6 @@
 Part 6: Working With OWL
 =====================
 
-.. warning ::
-
-   this functionality is not available until v0.3.0
-   we are waiting for one rdflib PR (https://github.com/RDFLib/rdflib/pull/1686) to be merged...
-
 OAK comes bundled with the `funowl <https://github.com/hsolbrig/funowl/>`_ library
 
 

--- a/docs/intro/tutorial08.rst
+++ b/docs/intro/tutorial08.rst
@@ -6,7 +6,7 @@ Part 8: Applying Changes to Ontologies
 .. warning::
 
     Apply changes is an experimental feature. This documentation is provided for alpha testers
-    to try out existing functionality. Currently on a fraction of the KGCL specification is
+    to try out existing functionality. Currently only a fraction of the KGCL specification is
     implemented.
 
 OAK allows various kinds of changes to be applied to ontologies, including:
@@ -94,5 +94,3 @@ To make edits and export to a new file:
     runoak  -i go-edit.obo set-obsolete nucleus -o go-edit-out.obo -O obo
 
 This will apply the obsoletion changes in memory and then save results to a separate obo file.
-
-

--- a/docs/packages/interfaces/index.rst
+++ b/docs/packages/interfaces/index.rst
@@ -50,6 +50,6 @@ The most common operations are found in the :ref:`basic_ontology_interface`
 
 .. note::
 
-    Some interfaces may not be "pure" interfaces is that they may provide
+    Some interfaces may not be "pure" interfaces, in that they may provide
     a default implementation, which may or may not be overridden by an
     implementation


### PR DESCRIPTION
The owl tutorial has an outdated warning about a PR that needed merging in one of the dependencies:

https://github.com/INCATools/ontology-access-kit/blob/main/docs/intro/tutorial06.rst?plain=1#L4

The warning mentions v0.3.0 of OAK so I'm guessing it's safe to assume that changes have been made and only this documentation artefact remains.

This PR removes that warning and fixes a few minor typos that I noticed whilst going through the tutorial.