### PR TITLE
Fix broken links to notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For more examples, see
 See:
 
  - [CLI docs](https://incatools.github.io/ontology-access-kit/cli.html)
- - [Example notebooks](https://github.com/INCATools/ontology-access-kit/tree/main/notebooks/Commands)
+ - [Example notebooks](https://github.com/INCATools/ontology-access-kit/tree/main/docs/examples/Commands)
 
 ## Search
 

--- a/docs/faq/commandline.rst
+++ b/docs/faq/commandline.rst
@@ -28,7 +28,7 @@ Each command typically comes with some examples of use
 How do I get more examples of command line usage?
 -------------------------------------------------
 
-See the ``Commands <https://github.com/INCATools/ontology-access-kit/tree/main/notebooks/Commands>`_ folder
+See the ``Commands <https://github.com/INCATools/ontology-access-kit/tree/main/docs/examples/Commands>`_ folder
 of the Jupyter notebooks directory in GitHub. Our aim is to eventually have one notebook per command.
 
 I want to query an ontology, what do I pass for the ``--input`` option?

--- a/docs/guide/mappings.rst
+++ b/docs/guide/mappings.rst
@@ -30,7 +30,7 @@ Mappings in OAK
 
 To see all mappings for a concept or concept, you can use the mappings command.
 
-See the `Notebook example on mappings <https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Mappings.ipynb>`_.
+See the `Notebook example on mappings <https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/Mappings.ipynb>`_.
 
 .. code-block:: bash
 

--- a/docs/guide/similarity.rst
+++ b/docs/guide/similarity.rst
@@ -358,7 +358,7 @@ See the `Similarity data model <https://w3id.org/oak/similarity/>`_ for details 
 Companion Notebooks
 -------------------
 
-See the notebook for the `termset-similarity Command <https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/TermsetSimilarity.ipynb`_
+See the notebook for the `termset-similarity Command <https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/TermsetSimilarity.ipynb`_
 
 Further reading
 ---------------

--- a/docs/howtos/use-oak-expression-language.rst
+++ b/docs/howtos/use-oak-expression-language.rst
@@ -15,7 +15,7 @@ Some experience in using the CLI is recommended.
 For the full list of OAK command line commands, see:
 
 - :ref:`_command_line_interface`
-- `Commands notebook <https://github.com/INCATools/ontology-access-kit/tree/main/notebooks/Commands>`_
+- `Commands notebook <https://github.com/INCATools/ontology-access-kit/tree/main/docs/examples/Commands>`_
 
 Basics
 ------

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -855,7 +855,7 @@ def obsoletes(
 
     More examples:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Obsoletes.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/Obsoletes.ipynb
 
     Python API:
 
@@ -1953,7 +1953,7 @@ def paths(
 
     More examples:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Paths.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/Paths.ipynb
 
     """
     impl = settings.impl
@@ -3231,7 +3231,7 @@ def relationships(
 
     More examples:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Relationships.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/Relationships.ipynb
 
     Python API:
 
@@ -3405,7 +3405,7 @@ def logical_definitions(
 
     More examples:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/LogicalDefinitions.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/LogicalDefinitions.ipynb
 
     Python API:
 
@@ -3988,7 +3988,7 @@ def mappings(terms, maps_to_source, autolabel: bool, output, output_type, mapper
 
     More examples:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Mappings.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/Mappings.ipynb
 
     """
     impl = settings.impl
@@ -4339,7 +4339,7 @@ def taxon_constraints(
 
     More examples:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/TaxonConstraints.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/TaxonConstraints.ipynb
 
     This command is a wrapper onto taxon_constraints_utils:
 
@@ -4413,7 +4413,7 @@ def apply_taxon_constraints(
 
     More examples:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Apply.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/Apply.ipynb
 
     """
     impl = settings.impl
@@ -4632,7 +4632,7 @@ def associations(
 
     More examples:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Associations.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/Associations.ipynb
 
     """
     impl = settings.impl
@@ -5325,7 +5325,7 @@ def enrichment(
 
     For a full example, see:
 
-       https://github.com/INCATools/ontology-access-kit/blob/main/notebooks/Commands/Enrichment.ipynb
+       https://github.com/INCATools/ontology-access-kit/blob/main/docs/examples/Commands/Enrichment.ipynb
 
     Note that it is possible to run "pseudo-enrichments" on term lists only by passing
     no associations and using --ontology-only. This creates a fake association set that is simply


### PR DESCRIPTION
to fix #836 

Updated all links pointing to /notebooks/Commands/ to now point to /docs/examples/Commands/ following repository reorganization. This includes links in:
- README.md
- src/oaklib/cli.py
- docs/faq/commandline.rst
- docs/guide/mappings.rst
- docs/guide/similarity.rst
- docs/howtos/use-oak-expression-language.rst

🤖 Generated with CBorg Code
Co-Authored-By: Claude <noreply@anthropic.com>