### PR TITLE
[codex] fix release build versioning

### DIFF
--- a/.github/workflows/pypi-publish-dry-run.yaml
+++ b/.github/workflows/pypi-publish-dry-run.yaml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6.0.2
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v6.2.0
@@ -29,6 +31,11 @@ jobs:
     - name: Build source and wheel archives
       run: |
         make build-whl
+
+    - name: Verify release artifact version
+      run: |
+        ls -1 dist
+        ! ls dist/oaklib-0.0.0* 1>/dev/null 2>&1
 
 #    - name: Publish package to TestPyPI
 #      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6.0.2
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v6.2.0
@@ -18,8 +20,15 @@ jobs:
         python-version: 3.12
 
     - name: Build source and wheel archives
+      env:
+        OAK_BUILD_TAG: ${{ github.event.release.tag_name }}
       run: |
         make build-whl
+
+    - name: Verify release artifact version
+      run: |
+        ls -1 dist
+        ! ls dist/oaklib-0.0.0* 1>/dev/null 2>&1
 
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@v1.2.2

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,22 @@ tests:
 
 .PHONY: build-whl
 build-whl:
-	#Set the version of oaklib and build the python whl.
-	$(INSTALL)
-	uv version $(git describe --tags --abbrev=0)
-	uv build 
+	# Set the version from the release tag before building the wheel.
+	# uv-dynamic-versioning does not currently derive the version for `uv build`.
+	@build_tag="$${OAK_BUILD_TAG:-$$(git describe --tags --abbrev=0)}"; \
+	build_version="$$(printf '%s\n' "$$build_tag" | sed -E 's/^v//; s/-rc([0-9]+)$$/rc\1/')"; \
+	case "$$build_tag" in \
+		v[0-9]*.[0-9]*.[0-9]*|v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*) ;; \
+		*) echo "Unsupported release tag: $$build_tag"; exit 1 ;; \
+	esac; \
+	tmpdir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	echo "Building oaklib $$build_version from $$build_tag"; \
+	git archive --format=tar HEAD | tar -xf - -C "$$tmpdir"; \
+	python3 -c 'import re, sys; from pathlib import Path; path = Path(sys.argv[1]); version = sys.argv[2]; text = path.read_text(); text, n = re.subn(r"(?m)^version = \"[^\"]+\"$$", f"version = \"{version}\"", text, count=1); assert n == 1, "Could not update version in pyproject.toml"; path.write_text(text)' "$$tmpdir/pyproject.toml" "$$build_version" \
+	&& (cd "$$tmpdir" && uv build) \
+	&& mkdir -p dist \
+	&& cp "$$tmpdir"/dist/* dist/
 
 # not yet deployed
 doctest:
@@ -169,4 +181,3 @@ phenio-benchmarks:
 phenio-profiles:
 	python $(PROFILER_SCRIPT) $(SEMSIMIAN_PHENIO_PROFILE)
 	python $(PROFILER_SCRIPT) $(NON_SEMSIMIAN_PHENIO_PROFILE)
-


### PR DESCRIPTION
This fixes the release build path before cutting the next release candidate.

What changed:
- `Makefile` `build-whl` now derives the package version from the release tag, converts `vX.Y.Z-rcN` to the PEP 440 form `X.Y.ZrcN`, and builds from a temporary archive of `HEAD` so the working tree is not mutated.
- `pypi-publish.yaml` now passes the release tag explicitly into the build and verifies that the artifacts are not `0.0.0`.
- `pypi-publish-dry-run.yaml` now fetches tags and runs the same artifact-version guard so CI catches this regression.

Root cause:
- the existing target called `uv version $(git describe --tags --abbrev=0)`, but `uv version` in this environment only prints the current version and the Makefile expression was not valid shell substitution for setting the package version. As a result, release builds were producing `oaklib-0.0.0`.

Validation:
- `OAK_BUILD_TAG=v0.6.24-rc1 make build-whl`
- produced `oaklib-0.6.24rc1.tar.gz` and `oaklib-0.6.24rc1-py3-none-any.whl`
