### PR TITLE
[codex] fix owl input format detection

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -652,7 +652,7 @@ def main(
     if input:
         if wrap_adapter:
             input = wrap_adapter + ":" + input
-        settings.impl = get_adapter(input)
+        settings.impl = get_adapter(input, format=input_type)
         settings.impl.autosave = autosave
     if merge and not add:
         raise ValueError("Cannot use --merge without --add")

--- a/src/oaklib/implementations/funowl/funowl_implementation.py
+++ b/src/oaklib/implementations/funowl/funowl_implementation.py
@@ -70,6 +70,25 @@ from oaklib.types import CURIE, PRED_CURIE
 from oaklib.utilities.axioms.logical_definition_utilities import logical_definition_matches
 
 logger = logging.getLogger(__name__)
+SERIALIZATION_ALIASES = {
+    "functional": "ofn",
+    "functional-owl": "ofn",
+    "functional-syntax": "ofn",
+    "funowl": "ofn",
+    "manchester": "ofn",
+    "omn": "ofn",
+    "ofn": "ofn",
+    "owl": "owl",
+    "owl-xml": "owx",
+    "owl/xml": "owx",
+    "owlxml": "owx",
+    "owx": "owx",
+    "rdf": "rdf",
+    "rdf-xml": "rdf",
+    "rdf/xml": "rdf",
+    "rdfxml": "rdf",
+    "xml": "rdf",
+}
 DECLARATION_TYPES = (
     DeclareClass,
     DeclareObjectProperty,
@@ -152,13 +171,55 @@ class FunOwlImplementation(
             else:
                 local_path = Path(local_path)
                 logger.info("Loading %s into py-horned-owl", local_path)
-                doc = pyhornedowl.open_ontology_from_file(str(local_path))
-                if local_path.suffix in {".ofn", ".omn"}:
+                serialization = self._serialization_for_path(local_path)
+                if resource is not None and serialization is not None:
+                    resource.format = serialization
+                doc = pyhornedowl.open_ontology_from_file(
+                    str(local_path), serialization=serialization
+                )
+                if serialization == "ofn":
                     self.prefix_map().update(self._extract_prefix_declarations(local_path))
                 else:
                     self.prefix_map().update(self._extract_prefixes_from_rdf(local_path))
             self.ontology_document = doc
         self.functional_writer = self.ontology_document
+
+    def _serialization_for_path(self, path: Path) -> Optional[str]:
+        explicit_format = None if self.resource is None else self.resource.format
+        serialization = self._normalize_serialization(explicit_format)
+        if serialization is not None:
+            return serialization
+        return self._sniff_serialization(path)
+
+    @staticmethod
+    def _normalize_serialization(format_name: Optional[str]) -> Optional[str]:
+        if format_name is None:
+            return None
+        key = format_name.strip().lower().replace("_", "-").replace(" ", "-")
+        return SERIALIZATION_ALIASES.get(key, key)
+
+    @staticmethod
+    def _sniff_serialization(path: Path) -> Optional[str]:
+        suffix = path.suffix.lower()
+        if suffix in {".ofn", ".omn"}:
+            return "ofn"
+        if suffix == ".owx":
+            return "owx"
+        if suffix not in {".owl", ".rdf", ".xml"}:
+            return None
+        try:
+            head = path.read_text(encoding="utf-8", errors="ignore")[:4096]
+        except OSError:
+            logger.debug("Could not sniff OWL serialization for %s", path, exc_info=True)
+            return None
+        head = head.lstrip("\ufeff \t\r\n")
+        if head.startswith("Prefix(") or head.startswith("Ontology("):
+            return "ofn"
+        if re.match(r"<Ontology(?:\s|>)", head):
+            return "owx"
+        if head.startswith("<?xml") or head.startswith("<rdf:RDF") or "xmlns:rdf=" in head:
+            return "rdf"
+        return None
 
     @staticmethod
     def _extract_prefix_declarations(path: Path) -> Mapping[str, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,10 @@ import logging
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
+from pathlib import Path
+from shutil import copyfile
 from typing import Optional
 
 import rdflib
@@ -99,6 +102,18 @@ class TestCommandLineInterface(unittest.TestCase):
         self.assertIn("subset", out)
         self.assertIn("validate", out)
         self.assertEqual(0, result.exit_code)
+
+    def test_input_type_and_sniff_for_functional_owl_suffix(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            disguised_path = Path(tmpdir) / "go-nucleus-functional.owl"
+            copyfile(TEST_OWL_OFN, disguised_path)
+            for args in (
+                ["-I", "ofn", "-i", str(disguised_path), "labels", NUCLEUS],
+                ["-i", str(disguised_path), "labels", NUCLEUS],
+            ):
+                result = self.runner.invoke(main, args)
+                self.assertEqual(0, result.exit_code, result.output)
+                self.assertIn("nucleus", result.stdout)
 
     def test_multilingual(self):
         for input_arg in [INPUT_DIR / "hp-international-test.db"]:

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from shutil import copyfile
 
 try:
     from gilda.grounder import Grounder
@@ -73,6 +74,14 @@ class TestResource(unittest.TestCase):
             print(a)
             assocs.append((a.subject, a.object))
         self.assertCountEqual(expected, assocs)
+
+    def test_funowl_sniffs_functional_syntax_for_owl_suffix(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            disguised_path = Path(tmpdir) / "go-nucleus-functional.owl"
+            copyfile(INPUT_DIR / "go-nucleus.ofn", disguised_path)
+            adapter = get_adapter(str(disguised_path))
+            self.assertIsInstance(adapter, FunOwlImplementation)
+            self.assertEqual("nucleus", adapter.label("GO:0005634"))
 
     @unittest.skipIf(not have_gilda, "Gilda not available")
     @unittest.skipIf(sys.platform == "win32", "Skipping test_gilda_from_descriptor on Windows")


### PR DESCRIPTION
This fixes local OWL loading when the file suffix is `.owl` but the actual ontology serialization is not RDF/XML.

What changed:
- `runoak -I/--input-type` is now passed through to adapter creation.
- the horned-owl-backed adapter now normalizes explicit input-format aliases such as `ofn`, `rdfxml`, `owlxml`, and `xml`.
- local `.owl`, `.rdf`, and `.xml` files are sniffed before calling `pyhornedowl.open_ontology_from_file(...)` so Functional Syntax files with a `.owl` suffix do not get misparsed as OWL/XML.
- regression tests cover both the explicit `-I ofn` path and the sniffed `.owl` path.

Root cause:
- `py-horned-owl` guesses from file extension and treats `.owl` as OWL/XML by default.
- `runoak` already exposed `-I/--input-type`, but the CLI was not passing it into `get_adapter(...)`.
- for a file like `cl-edit.owl` that is actually Functional Syntax, the wrong parser path could fail before OAK had any chance to recover.

Validation:
- `uv run runoak -i ~/repos/cell-ontology/src/ontology/cl-edit.owl labels CL:0000000`
- `uv run runoak -I ofn -i ~/repos/cell-ontology/src/ontology/cl-edit.owl labels CL:0000000`
- `uv run pytest tests/test_selector.py tests/test_cli.py tests/test_implementations/test_funowl.py -q`
- `uv run pytest tests/ -x -q`
