### PR TITLE
Align PyPI publish workflow with existing trusted publisher

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -10,6 +10,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
 
     steps:

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -9,7 +9,6 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       id-token: write
 


### PR DESCRIPTION
Summary

- remove the GitHub Actions `environment` binding from the release publish job
- keep trusted publishing enabled via `id-token: write` and `pypa/gh-action-pypi-publish@release/v1`

Why

The prerelease publish failure is currently:

- `invalid-publisher: valid token, but no corresponding publisher`
- failing claim: `sub=repo:INCATools/ontology-access-kit:environment:release`

That indicates the workflow is emitting an environment-bound OIDC subject that does not match the existing PyPI trusted publisher for this project. The minimal fix is to stop binding the job to the `release` environment so the workflow claims line up with the already-configured publisher.

Validation

- parsed `.github/workflows/pypi-publish.yaml` successfully
- confirmed the publish job no longer declares `environment`
- `OAK_BUILD_TAG=v0.7.0rc3 make build-whl`

Scope

- only `.github/workflows/pypi-publish.yaml` changed
- done in a fresh worktree off `origin/main` to avoid unrelated local changes
