### PR TITLE
fix: set PyPI publish environment

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -9,6 +9,7 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
PyPI trusted publishing is currently failing because the release job does not declare the `release` environment, so the OIDC token gets `sub=repo:INCATools/ontology-access-kit:ref:refs/tags/...` instead of the trusted-publisher subject with `environment: release`.

This keeps the current trusted-publishing workflow intact and adds the missing job environment only.

After merge, the next prerelease tag (for example `v0.7.0rc5`) should publish successfully.