### PR TITLE
[codex] fix: restore token-based PyPI publishing

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -9,10 +9,8 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: read
-      id-token: write
 
     steps:
     - uses: actions/checkout@v6.0.2
@@ -41,4 +39,6 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}
         verbose: true


### PR DESCRIPTION
## Summary

Revert the PyPI upload step from GitHub trusted publishing back to the existing `PYPI_PASSWORD` token secret while keeping the current `uv`-based build and tag-driven version stamping.

## Why

Recent prerelease history shows two separate problems:

- `v0.6.24-rc1` and `v0.7.0rc1` failed before upload because the release workflow did not install `uv`.
- After that was fixed, every trusted-publishing attempt still failed at the PyPI exchange step with `invalid-publisher`.

The repo has already tried both OIDC claim shapes that were under discussion:

- no environment bound job: `sub=repo:INCATools/ontology-access-kit:ref:refs/tags/...`
- environment bound job: `sub=repo:INCATools/ontology-access-kit:environment:release`

PyPI rejected both, which means trusted publishing is still externally blocked. Since the repo already has a working `PYPI_PASSWORD` secret and the last successful oaklib PyPI release (`0.6.23`) used token-based upload, the smallest fix to restore seamless RC publishing is to switch only the upload auth back to the token flow.

## Validation

- inspected recent Actions release runs for `v0.6.24-rc1`, `v0.7.0rc1`, `v0.7.0rc3`, `v0.7.0rc4`, and `v0.7.0rc5`
- confirmed trusted publishing failed for both `ref` and `environment` OIDC subject variants
- confirmed the repository still has a `PYPI_PASSWORD` Actions secret
- ran `OAK_BUILD_TAG=v0.7.0rc5 make build-whl`
- verified build outputs:
  - `oaklib-0.7.0rc5.tar.gz`
  - `oaklib-0.7.0rc5-py3-none-any.whl`

## Scope

- `.github/workflows/pypi-publish.yaml` only
