### PR TITLE
Increase default cache TTL from 1 week to 1 month

### DIFF
--- a/src/oaklib/utilities/caching.py
+++ b/src/oaklib/utilities/caching.py
@@ -235,7 +235,7 @@ class FileCache(object):
         """
 
         self._module = module
-        self._default_policy = CachePolicy.from_string("1w")
+        self._default_policy = CachePolicy.from_string("1m")
         self._forced_policy = None
         self._policies = []
         self._config_file = os.path.join(user_config_dir(APP_NAME), "cache.conf")

--- a/tests/test_utilities/test_caching.py
+++ b/tests/test_utilities/test_caching.py
@@ -148,7 +148,7 @@ class TestFileCache(unittest.TestCase):
         self.assertEqual(cache._get_policy("fbbt.db")._max_age, 86400 * 7 * 3)
         self.assertEqual(cache._get_policy("fbdv.db")._max_age, 86400 * 30)
         self.assertEqual(cache._get_policy("fbcv.db")._max_age, 86400 * 30)
-        self.assertEqual(cache._get_policy("other.db")._max_age, 86400 * 7)
+        self.assertEqual(cache._get_policy("other.db")._max_age, 86400 * 30)
 
         # Check that "forced policy" takes precedence
         cache.force_policy(CachePolicy.from_string("2d"))


### PR DESCRIPTION
## Summary
- Changes the default cache policy from `1w` to `1m` in `FileCache.__init__`
- Reduces S3 egress costs since most bbop-sqlite ontology databases don't change weekly
- Users can still override via `--caching` CLI flag or `~/.config/ontology-access-kit/cache.conf`

## Test plan
- [ ] Verify `FileCache` initializes with `1m` default policy
- [ ] Verify `--caching` CLI flag still overrides the default
- [ ] Verify config file policies still take precedence over default

🤖 Generated with [Claude Code](https://claude.com/claude-code)