### PR TITLE
Fix bare string CURIE handling and OLS4 API compatibility

### DIFF
--- a/src/oaklib/implementations/ols/ols_implementation.py
+++ b/src/oaklib/implementations/ols/ols_implementation.py
@@ -1,6 +1,7 @@
 from collections import ChainMap
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from urllib.parse import quote
 
 import requests
 from ols_client import Client, EBIClient, TIBClient
@@ -16,6 +17,7 @@ from oaklib.implementations.ols.constants import SEARCH_CONFIG
 from oaklib.implementations.ols.oxo_utils import load_oxo_payload
 from oaklib.interfaces.basic_ontology_interface import PREFIX_MAP
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
+from oaklib.interfaces.obograph_interface import GraphTraversalMethod
 from oaklib.interfaces.search_interface import SearchInterface
 from oaklib.interfaces.text_annotator_interface import TextAnnotatorInterface
 from oaklib.types import CURIE, LANGUAGE_TAG, PRED_CURIE
@@ -30,6 +32,50 @@ __all__ = [
 
 ANNOTATION = Dict[str, Any]
 SEARCH_ROWS = 50
+
+
+def _double_quote_iri(iri: str) -> str:
+    """Double-encode an IRI for use in OLS4 term path segments.
+
+    See: https://www.ebi.ac.uk/ols/docs/api
+    """
+    return quote(quote(iri, safe=""), safe="")
+
+
+def _first_term(response: Any) -> Optional[Dict[str, Any]]:
+    """Normalise an OLS ``get_term`` response down to a single term record.
+
+    The OLS4 API (as returned by ``ols_client``) wraps term lookups in a
+    paged/search-style payload of the form ``{"_embedded": {"terms": [...]}}``.
+    Older/flat payloads that already look like a single term (i.e. contain a
+    ``label`` key directly) are returned unchanged so this helper works across
+    client versions.
+
+    :param response: the raw response from ``client.get_term``
+    :return: the first term record, or None if there are none
+    """
+    if not response:
+        return None
+    if isinstance(response, dict) and "_embedded" in response:
+        terms = (response.get("_embedded") or {}).get("terms") or []
+        return terms[0] if terms else None
+    return response
+
+
+def _scalar(value: Any) -> Optional[str]:
+    """Coerce an OLS field to a scalar string.
+
+    Some OLS4 fields (e.g. ``description``) are returned as lists; take the
+    first non-empty element in that case.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            if item:
+                return item
+        return None
+    return value
 
 oxo_pred_mappings = {
     ScopeEnum.EXACT.text: "skos:exactMatch",
@@ -80,10 +126,12 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
 
         ontology = self.focus_ontology
         iri = self.curie_to_uri(curie)
-        term = self.client.get_term(ontology=ontology, iri=iri)
-        if term and "label" in term:
-            self.label_cache[curie] = term["label"]
-            return term["label"]
+        term = _first_term(self.client.get_term(ontology=ontology, iri=iri))
+        if term:
+            label = _scalar(term.get("label"))
+            if label is not None:
+                self.label_cache[curie] = label
+                return label
         return None
 
     def labels(
@@ -116,10 +164,12 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
 
         ontology = self.focus_ontology
         iri = self.curie_to_uri(curie)
-        term = self.client.get_term(ontology=ontology, iri=iri)
-        if term and "description" in term and term["description"]:
-            self.definition_cache[curie] = term["description"]
-            return term["description"]
+        term = _first_term(self.client.get_term(ontology=ontology, iri=iri))
+        if term:
+            definition = _scalar(term.get("description"))
+            if definition:
+                self.definition_cache[curie] = definition
+                return definition
         return None
 
     def definitions(
@@ -154,23 +204,89 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     def ancestors(
-        self, start_curies: Union[CURIE, List[CURIE]], predicates: List[PRED_CURIE] = None
+        self,
+        start_curies: Union[CURIE, List[CURIE]],
+        predicates: List[PRED_CURIE] = None,
+        reflexive: bool = True,
+        method: Optional[GraphTraversalMethod] = None,
     ) -> Iterable[CURIE]:
+        """
+        Ancestors of the given term(s), as computed by the OLS hierarchy endpoints.
+
+        The ``reflexive`` and ``method`` keywords are accepted for compatibility with
+        the other graph adapters (see :class:`OboGraphInterface`).
+
+        :param start_curies: curie or curies to start the walk from
+        :param predicates: only traverse over these (traverses over all if this is not set)
+        :param reflexive: include the start curie(s) in the result
+        :param method: only the default (ENTAILMENT-style) traversal is supported
+        :return: all ancestor CURIEs
+        """
+        if method is not None and method == GraphTraversalMethod.HOP:
+            raise NotImplementedError("HOP traversal is not implemented for OLS")
         func = self.client.iter_hierarchical_ancestors
         if predicates:
             if predicates == [IS_A]:
                 func = self.client.iter_ancestors
             elif IS_A not in predicates:
                 raise NotImplementedError(f"OLS always include {IS_A}, you selected: {predicates}")
-        if not isinstance(start_curies, list):
-            start_curies = [start_curies]
+        start_curies = self._as_curie_list(start_curies)
         ancs = set()
         ontology = self.focus_ontology
         for curie in start_curies:
             iri = self.curie_to_uri(curie)
             records = func(ontology=ontology, iri=iri)
-            ancs.update(record["obo_id"] for record in records)
+            ancs.update(record["obo_id"] for record in records if record.get("obo_id"))
+        if reflexive:
+            ancs.update(start_curies)
         return list(ancs)
+
+    def descendants(
+        self,
+        start_curies: Union[CURIE, List[CURIE]],
+        predicates: List[PRED_CURIE] = None,
+        reflexive: bool = True,
+        method: Optional[GraphTraversalMethod] = None,
+    ) -> Iterable[CURIE]:
+        """
+        Descendants of the given term(s), backed by the OLS4 descendant endpoints.
+
+        As with :meth:`ancestors`, OLS traversal always includes the ``is_a`` (subClassOf)
+        relation, so ``predicates`` may either be omitted or must include ``rdfs:subClassOf``.
+
+        :param start_curies: curie or curies to start the walk from
+        :param predicates: only traverse over these (traverses over all if this is not set)
+        :param reflexive: include the start curie(s) in the result
+        :param method: only the default (ENTAILMENT-style) traversal is supported
+        :return: all descendant CURIEs
+        """
+        if method is not None and method == GraphTraversalMethod.HOP:
+            raise NotImplementedError("HOP traversal is not implemented for OLS")
+        path_key = "hierarchicalDescendants"
+        if predicates:
+            if predicates == [IS_A]:
+                path_key = "descendants"
+            elif IS_A not in predicates:
+                raise NotImplementedError(f"OLS always include {IS_A}, you selected: {predicates}")
+        start_curies = self._as_curie_list(start_curies)
+        descs = set()
+        ontology = self.focus_ontology
+        for curie in start_curies:
+            iri = self.curie_to_uri(curie)
+            path = f"ontologies/{ontology}/terms/{_double_quote_iri(iri)}/{path_key}"
+            for record in self.client.get_paged(path, key="terms"):
+                obo_id = record.get("obo_id")
+                if obo_id:
+                    descs.add(obo_id)
+        if reflexive:
+            descs.update(start_curies)
+        return list(descs)
+
+    @staticmethod
+    def _as_curie_list(start_curies: Union[CURIE, List[CURIE]]) -> List[CURIE]:
+        if isinstance(start_curies, str):
+            return [start_curies]
+        return list(start_curies)
 
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     # Implements: SearchInterface

--- a/src/oaklib/implementations/sparql/abstract_sparql_implementation.py
+++ b/src/oaklib/implementations/sparql/abstract_sparql_implementation.py
@@ -897,6 +897,8 @@ class AbstractSparqlImplementation(RdfInterface, DumperInterface, ABC):
         return node
 
     def hierarchical_descendants(self, start_curies: Union[CURIE, List[CURIE]]) -> Iterable[CURIE]:
+        if not isinstance(start_curies, list):
+            start_curies = [start_curies]
         query_uris = [self.curie_to_sparql(curie) for curie in start_curies]
         where = ["?s rdfs:subClassOf* ?o", _sparql_values("o", query_uris)]
         query = SparqlQuery(select=["?s"], distinct=True, where=where)

--- a/src/oaklib/implementations/ubergraph/ubergraph_implementation.py
+++ b/src/oaklib/implementations/ubergraph/ubergraph_implementation.py
@@ -334,6 +334,8 @@ class UbergraphImplementation(
         if method and method == GraphTraversalMethod.HOP:
             raise NotImplementedError("HOP not implemented for ubergraph")
         # TODO: DRY
+        if not isinstance(start_curies, list):
+            start_curies = [start_curies]
         query_uris = [self.curie_to_sparql(curie) for curie in start_curies]
         where = ["?s ?p ?o", "?s a owl:Class", f'VALUES ?o {{ {" ".join(query_uris)} }}']
         if predicates:

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -156,6 +156,47 @@ class TestOlsImplementation(unittest.TestCase):
         #     logging.info(yaml_dumper.dumps(m))
         # assert any(m for m in mappings if m.object_id == "EMAPA:32725")
 
+    def test_label_from_ols4_payload(self):
+        """label() should parse the paged OLS4 ``_embedded.terms`` payload."""
+        self.mock_client.get_term.return_value = {
+            "_embedded": {
+                "terms": [
+                    {
+                        "iri": "http://purl.obolibrary.org/obo/GO_0008150",
+                        "label": "biological_process",
+                        "description": ["A biological process ..."],
+                    }
+                ]
+            }
+        }
+        oi = self.oi
+        oi.focus_ontology = "go"
+        self.assertEqual(oi.label("GO:0008150"), "biological_process")
+
+    def test_definition_from_ols4_payload(self):
+        """definition() should parse OLS4 payloads where description is a list."""
+        self.mock_client.get_term.return_value = {
+            "_embedded": {
+                "terms": [
+                    {
+                        "iri": "http://purl.obolibrary.org/obo/GO_0008150",
+                        "label": "biological_process",
+                        "description": ["A biological process represents ..."],
+                    }
+                ]
+            }
+        }
+        oi = self.oi
+        oi.focus_ontology = "go"
+        self.assertEqual(oi.definition("GO:0008150"), "A biological process represents ...")
+
+    def test_label_missing_term(self):
+        """label() should return None when OLS returns no terms."""
+        self.mock_client.get_term.return_value = {"_embedded": {"terms": []}}
+        oi = self.oi
+        oi.focus_ontology = "go"
+        self.assertIsNone(oi.label("GO:9999999"))
+
     def test_ancestors(self):
         oi = self.oi
         self.mock_client.iter_hierarchical_ancestors.return_value = [
@@ -163,15 +204,46 @@ class TestOlsImplementation(unittest.TestCase):
             {"obo_id": CELLULAR_COMPONENT},
         ]
 
+        # reflexive is True by default, so the start term is included
         ancs = list(oi.ancestors([VACUOLE]))
+        assert VACUOLE in ancs
+        assert CYTOPLASM in ancs
+        assert CELLULAR_COMPONENT in ancs
+
+        # reflexive=False excludes the start term
+        ancs = list(oi.ancestors([VACUOLE], reflexive=False))
+        assert VACUOLE not in ancs
+        assert CYTOPLASM in ancs
+        assert CELLULAR_COMPONENT in ancs
+
+        # a bare string CURIE should behave like a single-element list
+        ancs = list(oi.ancestors(VACUOLE, reflexive=False))
         assert CYTOPLASM in ancs
         assert CELLULAR_COMPONENT in ancs
 
         self.mock_client.iter_ancestors.return_value = [{"obo_id": CELLULAR_COMPONENT}]
 
-        ancs = list(oi.ancestors([VACUOLE], predicates=[IS_A]))
+        ancs = list(oi.ancestors([VACUOLE], predicates=[IS_A], reflexive=False))
         assert CYTOPLASM not in ancs
         assert CELLULAR_COMPONENT in ancs
+
+    def test_descendants(self):
+        oi = self.oi
+        self.mock_client.get_paged.return_value = [
+            {"obo_id": CYTOPLASM},
+            {"obo_id": CELLULAR_COMPONENT},
+        ]
+
+        # bare string CURIE should not be treated as an iterable of characters
+        descs = list(oi.descendants(CELLULAR_COMPONENT, reflexive=False))
+        assert CYTOPLASM in descs
+        assert CELLULAR_COMPONENT in descs  # returned by the mocked endpoint
+
+        # reflexive includes the start term
+        self.mock_client.get_paged.return_value = [{"obo_id": CYTOPLASM}]
+        descs = list(oi.descendants(CELLULAR_COMPONENT, reflexive=True))
+        assert CELLULAR_COMPONENT in descs
+        assert CYTOPLASM in descs
 
     def test_basic_search(self):
         self.oi.focus_ontology = None

--- a/tests/test_implementations/test_ubergraph.py
+++ b/tests/test_implementations/test_ubergraph.py
@@ -170,6 +170,18 @@ class TestUbergraphImplementation(unittest.TestCase):
         self.assertNotIn(VACUOLE, descs)
 
     @skip_on_remote_error
+    def test_descendants_bare_string(self):
+        """A bare string CURIE must not be treated as an iterable of characters.
+
+        See https://github.com/INCATools/ontology-access-kit/issues/883
+        """
+        oi = self.oi
+        from_list = set(oi.descendants([CYTOPLASM], predicates=[IS_A]))
+        from_string = set(oi.descendants(CYTOPLASM, predicates=[IS_A]))
+        self.assertEqual(from_list, from_string)
+        self.assertIn(CYTOPLASM, from_string)
+
+    @skip_on_remote_error
     def test_ancestor_graph(self):
         oi = self.oi
         for preds in [None, [IS_A], [IS_A, PART_OF]]:


### PR DESCRIPTION
## Summary
This PR fixes several issues with CURIE handling and OLS4 API compatibility across multiple ontology implementations. The main changes ensure that bare string CURIEs are properly handled as single-element lists rather than being iterated character-by-character, and add support for parsing OLS4's paged response format.

## Key Changes

- **OLS Implementation (`ols_implementation.py`)**:
  - Added `_double_quote_iri()` helper to properly encode IRIs for OLS4 API path segments
  - Added `_first_term()` helper to normalize OLS4's paged `_embedded.terms` response format alongside older flat payloads
  - Added `_scalar()` helper to coerce OLS fields (like `description`) from lists to scalar strings
  - Updated `label()` and `definition()` methods to use the new helpers for OLS4 compatibility
  - Enhanced `ancestors()` method with `reflexive` and `method` parameters for interface compatibility
  - Implemented new `descendants()` method backed by OLS4 descendant endpoints
  - Added `_as_curie_list()` static helper to consistently convert bare string CURIEs to lists
  - Fixed `ancestors()` to include reflexive results and handle missing `obo_id` fields gracefully

- **SPARQL Implementation (`abstract_sparql_implementation.py`)**:
  - Fixed `hierarchical_descendants()` to convert bare string CURIEs to lists before processing

- **Ubergraph Implementation (`ubergraph_implementation.py`)**:
  - Fixed `descendants()` to convert bare string CURIEs to lists before processing

- **Tests (`test_ols.py`, `test_ubergraph.py`)**:
  - Added comprehensive tests for OLS4 payload parsing (`test_label_from_ols4_payload`, `test_definition_from_ols4_payload`)
  - Added test for missing terms handling (`test_label_missing_term`)
  - Enhanced `test_ancestors()` to verify reflexive behavior and bare string CURIE handling
  - Added `test_descendants()` for the new descendants method
  - Added `test_descendants_bare_string()` to Ubergraph tests to prevent regression of bare string CURIE issues

## Notable Implementation Details

- The OLS4 API requires double-URL-encoding of IRIs in path segments, handled by the new `_double_quote_iri()` function
- OLS4 wraps term responses in `_embedded.terms` arrays while older versions return flat objects; the `_first_term()` helper handles both formats transparently
- The `reflexive` parameter defaults to `True` to match expected graph traversal semantics
- All implementations now consistently handle bare string CURIEs by converting them to single-element lists, preventing unintended character-by-character iteration

https://claude.ai/code/session_01Sa7PaJD845aSmfsmhkvD6e