### PR TITLE
Enable parallel test execution and improve CI efficiency

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,18 +10,23 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancel superseded runs on pull requests (e.g. when new commits are pushed),
+# but never cancel runs on main so pushed commits are always fully validated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
+    # ruff lint results do not depend on the runner's Python version, so a
+    # single version is sufficient (target version is pinned in pyproject.toml).
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4.3.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           pip install tox
@@ -44,6 +49,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: setup python environment
         uses: actions/setup-python@v6

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@ INSTALL = uv sync
 RUN = uv run
 
 .PHONY: tests
+# Run the test suite in parallel with pytest-xdist. Override PYTEST_ARGS to
+# customise, e.g. `make tests PYTEST_ARGS=-n0` to run serially when debugging.
+PYTEST_ARGS ?= -n auto
 tests:
 	$(INSTALL)
-	$(RUN) pytest tests
+	$(RUN) pytest tests $(PYTEST_ARGS)
 
 .PHONY: build-whl
 build-whl:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 
 dev = [
     "pytest>=7.1.3,<8",
+    "pytest-xdist>=3.0.0,<4",
     "Sphinx>=6.1.3",
     "pandas>=1.5.1",
     "jupyter>=1.0.0",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 import difflib
 import math
+import os
 from pathlib import Path
 from typing import List
 
@@ -8,6 +9,17 @@ from linkml_runtime.utils.yamlutils import YAMLRoot
 ROOT = Path(__file__).resolve().parent
 INPUT_DIR = ROOT / "input"
 OUTPUT_DIR = ROOT / "output"
+
+# When the test suite is parallelised with pytest-xdist, every worker imports
+# this module in its own subprocess. Many tests write to shared, mutable output
+# files (e.g. ``output/go-nucleus.db``), so without isolation concurrent workers
+# would clobber each other's files and produce flaky failures. Give each xdist
+# worker its own output subdirectory. When running serially (no xdist) the
+# behaviour is unchanged.
+_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER")
+if _XDIST_WORKER:
+    OUTPUT_DIR = OUTPUT_DIR / _XDIST_WORKER
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 SCHEMA_DIR = Path(ROOT) / "../src/linkml"
 EXTERNAL_DB_DIR = Path(ROOT) / "../db"  # for integration tests: optional
 EXAMPLE_ONTOLOGY_OBO = Path(INPUT_DIR) / "go-nucleus.obo"

--- a/uv.lock
+++ b/uv.lock
@@ -1017,6 +1017,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708 },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3124,6 +3133,7 @@ dev = [
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pip" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "seaborn" },
     { name = "sphinx" },
     { name = "sphinx-click" },
@@ -3201,6 +3211,7 @@ dev = [
     { name = "pandas", specifier = ">=1.5.1" },
     { name = "pip", specifier = ">=24.0,<25" },
     { name = "pytest", specifier = ">=7.1.3,<8" },
+    { name = "pytest-xdist", specifier = ">=3.0.0,<4" },
     { name = "seaborn", specifier = ">=0.12.2,<1" },
     { name = "sphinx", specifier = ">=6.1.3" },
     { name = "sphinx-click", specifier = ">=4.4.0" },
@@ -4030,6 +4041,19 @@ dependencies = [
     { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/1e/fb11174c9eaebcec27d36e9e994b90ffa168bc3226925900b9dbbf16c9da/pytest-logging-2015.11.4.tar.gz", hash = "sha256:cec5c85ecf18aab7b2ead5498a31b9f758680ef5a902b9054ab3f2bdbb77c896", size = 3916 }
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396 },
+]
 
 [[package]]
 name = "python-dateutil"


### PR DESCRIPTION
## Summary
This PR enables parallel test execution using pytest-xdist and optimizes CI workflows to reduce build times and improve resource utilization.

## Key Changes

- **Parallel test execution**: Added pytest-xdist dependency and configured the test suite to run in parallel by default (`-n auto`), with an option to override via `PYTEST_ARGS` make variable
- **Test isolation for parallel workers**: Modified `tests/__init__.py` to give each pytest-xdist worker its own output subdirectory, preventing file contention and flaky failures when tests run concurrently
- **CI workflow optimization**:
  - Added concurrency configuration to cancel superseded pull request runs while preserving main branch validation
  - Removed Python version matrix from lint job (single version sufficient since ruff results don't depend on Python version)
  - Pinned lint job to Python 3.12 for consistency
  - Added uv cache configuration to speed up dependency resolution
- **Makefile improvements**: Updated test target to support parallel execution with customizable pytest arguments

## Implementation Details

The test isolation mechanism detects when pytest-xdist is active via the `PYTEST_XDIST_WORKER` environment variable and creates worker-specific output directories. When running tests serially (without xdist), behavior remains unchanged. The output directory is created with `parents=True, exist_ok=True` to handle both parallel and serial execution gracefully.

https://claude.ai/code/session_01Dd6vEPosgAyUuLnqc4JQMP