### PR TITLE
[codex] fix FunOWL search syntax and stub node regressions

### DIFF
--- a/src/oaklib/implementations/funowl/funowl_implementation.py
+++ b/src/oaklib/implementations/funowl/funowl_implementation.py
@@ -503,9 +503,9 @@ class FunOwlImplementation(
         def _normalize(value: str) -> str:
             return value.lower() if config.force_case_insensitive else value
 
-        if config.syntax == SearchTermSyntax.STARTS_WITH:
+        if config.syntax == SearchTermSyntax(SearchTermSyntax.STARTS_WITH):
             matches = lambda value: _normalize(value).startswith(normalized_search_term)
-        elif config.syntax == SearchTermSyntax.REGULAR_EXPRESSION:
+        elif config.syntax == SearchTermSyntax(SearchTermSyntax.REGULAR_EXPRESSION):
             prog = re.compile(search_term, flags=flags)
             matches = lambda value: prog.search(value) is not None
         elif config.is_partial:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,6 +153,28 @@ class TestCommandLineInterface(unittest.TestCase):
             self.assertIn("CL:0000540", result.stdout)
             self.assertIn("CL:0000000", result.stdout)
 
+            viz_out = Path(tmpdir) / "viz.json"
+            result = self.runner.invoke(
+                main,
+                [
+                    "-I",
+                    "ofn",
+                    "-i",
+                    str(disguised_path),
+                    "viz",
+                    "CL:0000540",
+                    "-O",
+                    "json",
+                    "-o",
+                    str(viz_out),
+                ],
+            )
+            self.assertEqual(0, result.exit_code, result.output)
+            obj = json.loads(viz_out.read_text(encoding="utf-8"))
+            node_ids = {node["id"] for node in obj["nodes"]}
+            self.assertIn("CL:0000540", node_ids)
+            self.assertIn("CL:0000000", node_ids)
+
     def test_functional_owl_mappings(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             disguised_path = self._write_minimal_cl_funowl(Path(tmpdir) / "cl-edit.owl")

--- a/tests/test_implementations/test_funowl.py
+++ b/tests/test_implementations/test_funowl.py
@@ -1,21 +1,36 @@
 import logging
+import tempfile
 import unittest
+from pathlib import Path
 
 from kgcl_schema.datamodel import kgcl
 from pyhornedowl.model import EquivalentClasses, SubClassOf
 
+from oaklib.datamodels.search import SearchConfiguration, SearchProperty, SearchTermSyntax
 from oaklib.implementations.funowl.funowl_implementation import FunOwlImplementation
 from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.interfaces.owl_interface import AxiomFilter
 from oaklib.resource import OntologyResource
 from oaklib.utilities.kgcl_utilities import generate_change_id
-from tests import CHEBI_NUCLEUS, HUMAN, INPUT_DIR, NUCLEUS, VACUOLE
+from tests import BIOLOGICAL_PROCESS, CHEBI_NUCLEUS, HUMAN, INPUT_DIR, NUCLEUS, VACUOLE
 from tests.test_implementations import ComplianceTester
 
 TEST_ONT = INPUT_DIR / "go-nucleus.ofn"
 TEST_GRAPH_PROJECTION_ONT = INPUT_DIR / "graph_projection.owl"
 TEST_INST_ONT = INPUT_DIR / "inst.ofn"
 NEW_NAME = "new name"
+EXTERNAL_REFERENCE_OFN = """\
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+Prefix(CL:=<http://purl.obolibrary.org/obo/CL_>)
+Prefix(BFO:=<http://purl.obolibrary.org/obo/BFO_>)
+Prefix(GO:=<http://purl.obolibrary.org/obo/GO_>)
+Ontology(
+Declaration(Class(CL:0000540))
+AnnotationAssertion(rdfs:label CL:0000540 "neuron")
+SubClassOf(CL:0000540 GO:0008150)
+SubClassOf(CL:0000540 ObjectSomeValuesFrom(BFO:0000050 GO:0008150))
+)
+"""
 
 
 class TestFunOwlImplementation(unittest.TestCase):
@@ -91,6 +106,71 @@ class TestFunOwlImplementation(unittest.TestCase):
 
     def test_ancestors_descendants(self):
         self.compliance_tester.test_ancestors_descendants(self.oi)
+
+    def test_basic_search(self):
+        self.assertIn(NUCLEUS, list(self.oi.basic_search("nucleus")))
+        self.assertIn(
+            NUCLEUS,
+            list(self.oi.basic_search("nucl", config=SearchConfiguration(is_partial=True))),
+        )
+        self.assertIn(
+            NUCLEUS,
+            list(
+                self.oi.basic_search(
+                    "GO:00056",
+                    config=SearchConfiguration(
+                        properties=[SearchProperty.IDENTIFIER],
+                        syntax=SearchTermSyntax.STARTS_WITH,
+                    ),
+                )
+            ),
+        )
+        self.assertIn(
+            NUCLEUS,
+            list(
+                self.oi.basic_search(
+                    "nuc.*us",
+                    config=SearchConfiguration(
+                        properties=[SearchProperty.LABEL],
+                        syntax=SearchTermSyntax.REGULAR_EXPRESSION,
+                    ),
+                )
+            ),
+        )
+        self.assertIn(
+            NUCLEUS,
+            list(
+                self.oi.basic_search(
+                    "cell nucleus",
+                    config=SearchConfiguration(properties=[SearchProperty.ALIAS]),
+                )
+            ),
+        )
+        self.assertIn(
+            NUCLEUS,
+            list(
+                self.oi.basic_search(
+                    "Wikipedia:Cell_nucleus",
+                    config=SearchConfiguration(properties=[SearchProperty.MAPPED_IDENTIFIER]),
+                )
+            ),
+        )
+
+    def test_stub_nodes_for_unresolved_external_references(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "external-ref.ofn"
+            path.write_text(EXTERNAL_REFERENCE_OFN, encoding="utf-8")
+            oi = FunOwlImplementation(OntologyResource(str(path)))
+
+            self.assertIsNone(oi.label(BIOLOGICAL_PROCESS))
+            self.assertEqual(BIOLOGICAL_PROCESS, oi.node(BIOLOGICAL_PROCESS).id)
+            with self.assertRaises(ValueError):
+                oi.node(BIOLOGICAL_PROCESS, strict=True)
+
+            graph = oi.direct_graph("CL:0000540")
+            node_ids = {node.id for node in graph.nodes}
+            self.assertIn("CL:0000540", node_ids)
+            self.assertIn(BIOLOGICAL_PROCESS, node_ids)
 
     def test_patcher(self):
         oi = self.oi


### PR DESCRIPTION
## Summary

This supersedes #878 with the smaller patch needed on current `main`.

- Fix `FunOwlImplementation.basic_search()` so `STARTS_WITH` and `REGULAR_EXPRESSION` configs compare against LinkML enum instances correctly.
- Add FunOWL regression coverage for exact, partial, starts-with, regex, alias, and mapped identifier search.
- Add regression coverage for unresolved external references returning stub nodes and for CLI `viz` output on Functional OWL input.

## Root cause

Current `main` already contains the larger FunOWL `basic_search()` and stub-node implementation from later work, but the syntax checks compared a `SearchTermSyntax` object to raw permissible values. That made starts-with and regex searches fall through to exact matching.

## Validation

- `tox -e lint`
- `poetry run pytest tests/test_implementations/test_funowl.py tests/test_cli.py::TestCommandLineInterface::test_input_type_and_sniff_for_functional_owl_suffix tests/test_cli.py::TestCommandLineInterface::test_functional_owl_info_and_tree_with_search_and_undeclared_ancestors tests/test_cli.py::TestCommandLineInterface::test_functional_owl_mappings -q`
- GitHub Actions are passing on #891.
