### PR TITLE
Fix silent truncation of OLS descendant/ancestor closures to the first page

### DIFF
--- a/src/oaklib/implementations/ols/ols_implementation.py
+++ b/src/oaklib/implementations/ols/ols_implementation.py
@@ -224,10 +224,10 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
         """
         if method is not None and method == GraphTraversalMethod.HOP:
             raise NotImplementedError("HOP traversal is not implemented for OLS")
-        func = self.client.iter_hierarchical_ancestors
+        path_key = "hierarchicalAncestors"
         if predicates:
             if predicates == [IS_A]:
-                func = self.client.iter_ancestors
+                path_key = "ancestors"
             elif IS_A not in predicates:
                 raise NotImplementedError(f"OLS always include {IS_A}, you selected: {predicates}")
         start_curies = self._as_curie_list(start_curies)
@@ -235,8 +235,11 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
         ontology = self.focus_ontology
         for curie in start_curies:
             iri = self.curie_to_uri(curie)
-            records = func(ontology=ontology, iri=iri)
-            ancs.update(record["obo_id"] for record in records if record.get("obo_id"))
+            path = f"ontologies/{ontology}/terms/{_double_quote_iri(iri)}/{path_key}"
+            for record in self._iter_paged(path):
+                obo_id = record.get("obo_id")
+                if obo_id:
+                    ancs.add(obo_id)
         if reflexive:
             ancs.update(start_curies)
         return list(ancs)
@@ -274,13 +277,48 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
         for curie in start_curies:
             iri = self.curie_to_uri(curie)
             path = f"ontologies/{ontology}/terms/{_double_quote_iri(iri)}/{path_key}"
-            for record in self.client.get_paged(path, key="terms"):
+            for record in self._iter_paged(path):
                 obo_id = record.get("obo_id")
                 if obo_id:
                     descs.add(obo_id)
         if reflexive:
             descs.update(start_curies)
         return list(descs)
+
+    def _iter_paged(
+        self, path: str, key: str = "terms", size: int = 500
+    ) -> Iterator[Dict[str, Any]]:
+        """Iterate over every record of a paged OLS4 collection endpoint.
+
+        This walks the pages explicitly using the ``page``/``size`` query
+        parameters and the ``page.totalPages`` field of the HAL response,
+        rather than relying on ``ols_client.Client.get_paged``. That client
+        helper looks for the *next* page under ``_links.href``, but OLS4 (like
+        any HAL API) exposes it under ``_links.next.href``; the top-level key is
+        never present, so the loop terminates after the first page and every
+        result set is silently truncated to ``size`` (500) records. High-level
+        terms such as ``GO:0005575`` (cellular_component) have thousands of
+        descendants, so that truncation turns closure queries into silent false
+        negatives. See https://github.com/ai4curation/ai-gene-review/issues/1653.
+
+        :param path: the collection endpoint, relative to the API base URL
+        :param key: the ``_embedded`` key to slice each page from
+        :param size: the page size (OLS4 caps this at 500)
+        :yields: every record across all pages
+        """
+        page = 0
+        while True:
+            response = self.client.get_json(path, params={"size": size, "page": page})
+            embedded = (response or {}).get("_embedded") or {}
+            records = embedded.get(key) or []
+            yield from records
+            page_info = (response or {}).get("page") or {}
+            total_pages = page_info.get("totalPages")
+            page += 1
+            if not records:
+                break
+            if total_pages is not None and page >= total_pages:
+                break
 
     @staticmethod
     def _as_curie_list(start_curies: Union[CURIE, List[CURIE]]) -> List[CURIE]:

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -197,12 +197,29 @@ class TestOlsImplementation(unittest.TestCase):
         oi.focus_ontology = "go"
         self.assertIsNone(oi.label("GO:9999999"))
 
+    @staticmethod
+    def _hal_page(obo_ids, number, total_pages, key="terms"):
+        """Build one page of an OLS4 HAL collection response.
+
+        Mirrors the real payload shape: records live under ``_embedded[key]``,
+        paging metadata under ``page``, and (crucially) the link to the next
+        page is nested under ``_links.next.href`` -- never at ``_links.href``.
+        """
+        links = {"self": {"href": "https://ols.example/self"}}
+        if number + 1 < total_pages:
+            links["next"] = {"href": f"https://ols.example/next?page={number + 1}"}
+        return {
+            "_embedded": {key: [{"obo_id": obo_id} for obo_id in obo_ids]},
+            "_links": links,
+            "page": {"size": 500, "totalPages": total_pages, "number": number},
+        }
+
     def test_ancestors(self):
         oi = self.oi
-        self.mock_client.iter_hierarchical_ancestors.return_value = [
-            {"obo_id": CYTOPLASM},
-            {"obo_id": CELLULAR_COMPONENT},
-        ]
+        # hierarchicalAncestors endpoint (default, is_a + part_of)
+        self.mock_client.get_json.return_value = self._hal_page(
+            [CYTOPLASM, CELLULAR_COMPONENT], number=0, total_pages=1
+        )
 
         # reflexive is True by default, so the start term is included
         ancs = list(oi.ancestors([VACUOLE]))
@@ -221,18 +238,18 @@ class TestOlsImplementation(unittest.TestCase):
         assert CYTOPLASM in ancs
         assert CELLULAR_COMPONENT in ancs
 
-        self.mock_client.iter_ancestors.return_value = [{"obo_id": CELLULAR_COMPONENT}]
-
+        # ancestors endpoint (is_a only)
+        self.mock_client.get_json.return_value = self._hal_page(
+            [CELLULAR_COMPONENT], number=0, total_pages=1
+        )
         ancs = list(oi.ancestors([VACUOLE], predicates=[IS_A], reflexive=False))
-        assert CYTOPLASM not in ancs
         assert CELLULAR_COMPONENT in ancs
 
     def test_descendants(self):
         oi = self.oi
-        self.mock_client.get_paged.return_value = [
-            {"obo_id": CYTOPLASM},
-            {"obo_id": CELLULAR_COMPONENT},
-        ]
+        self.mock_client.get_json.return_value = self._hal_page(
+            [CYTOPLASM, CELLULAR_COMPONENT], number=0, total_pages=1
+        )
 
         # bare string CURIE should not be treated as an iterable of characters
         descs = list(oi.descendants(CELLULAR_COMPONENT, reflexive=False))
@@ -240,10 +257,53 @@ class TestOlsImplementation(unittest.TestCase):
         assert CELLULAR_COMPONENT in descs  # returned by the mocked endpoint
 
         # reflexive includes the start term
-        self.mock_client.get_paged.return_value = [{"obo_id": CYTOPLASM}]
+        self.mock_client.get_json.return_value = self._hal_page(
+            [CYTOPLASM], number=0, total_pages=1
+        )
         descs = list(oi.descendants(CELLULAR_COMPONENT, reflexive=True))
         assert CELLULAR_COMPONENT in descs
         assert CYTOPLASM in descs
+
+    def test_descendants_are_not_truncated_to_first_page(self):
+        """Descendants must span every page, not just the first.
+
+        Regression test for the OLS adapter silently truncating closure
+        queries to the first page (~500 terms). Querying descendants of a
+        high-level term such as GO:0005575 (cellular_component) returned only
+        491 GO terms via ``ols:go`` versus 4076 via ``sqlite:obo:go``, causing
+        silent false negatives in downstream ``reachable_from`` validation.
+        See https://github.com/ai4curation/ai-gene-review/issues/1653.
+
+        Here we simulate a three-page response (1200 descendants). A paginator
+        that stops after the first page would return only 500; a correct one
+        returns all 1200.
+        """
+        oi = self.oi
+        total_pages = 3
+        page_terms = [
+            [f"GO:{n:07d}" for n in range(0, 500)],
+            [f"GO:{n:07d}" for n in range(500, 1000)],
+            [f"GO:{n:07d}" for n in range(1000, 1200)],
+        ]
+        pages = [
+            self._hal_page(terms, number=i, total_pages=total_pages)
+            for i, terms in enumerate(page_terms)
+        ]
+        self.mock_client.get_json.side_effect = pages
+
+        descs = {d for d in oi.descendants(CELLULAR_COMPONENT, reflexive=False)}
+
+        expected = {curie for terms in page_terms for curie in terms}
+        # All pages collected, not just the first 500.
+        self.assertEqual(len(descs), 1200)
+        self.assertEqual(descs, expected)
+        # And every page was actually fetched (page=0, page=1, page=2).
+        self.assertEqual(self.mock_client.get_json.call_count, total_pages)
+        requested_pages = [
+            call.kwargs.get("params", {}).get("page")
+            for call in self.mock_client.get_json.call_args_list
+        ]
+        self.assertEqual(requested_pages, [0, 1, 2])
 
     def test_basic_search(self):
         self.oi.focus_ontology = None

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from oaklib.datamodels.search import SearchConfiguration, SearchProperty
-from oaklib.datamodels.vocabulary import IS_A
+from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.ols.ols_implementation import OlsImplementation
 from oaklib.resource import OntologyResource
 from tests import CELLULAR_COMPONENT, CYTOPLASM, VACUOLE
@@ -304,6 +304,66 @@ class TestOlsImplementation(unittest.TestCase):
             for call in self.mock_client.get_json.call_args_list
         ]
         self.assertEqual(requested_pages, [0, 1, 2])
+
+    def _descendants_endpoint(self, predicates):
+        """Return the OLS endpoint hit by ``descendants`` for the given predicates.
+
+        Drives a single-page ``descendants`` call and reads back the path that
+        was passed to ``get_json`` (its trailing segment names the endpoint).
+        """
+        self.mock_client.get_json.reset_mock(side_effect=True)
+        self.mock_client.get_json.return_value = self._hal_page(
+            [CYTOPLASM], number=0, total_pages=1
+        )
+        list(self.oi.descendants(CELLULAR_COMPONENT, predicates=predicates))
+        path = self.mock_client.get_json.call_args_list[0].args[0]
+        return path.rsplit("/", 1)[-1]
+
+    def test_descendants_isa_and_partof_use_hierarchical_endpoint(self):
+        """``predicates=[IS_A, PART_OF]`` must query the hierarchical endpoint.
+
+        OLS closes over is_a + part_of via ``hierarchicalDescendants`` (e.g.
+        GO:0005634 nucleus has 24 is_a-only descendants but 473 hierarchical
+        descendants). OAK selects the endpoint from ``predicates``:
+
+        * ``[IS_A]``            -> ``descendants``              (is_a only)
+        * ``[IS_A, PART_OF]``   -> ``hierarchicalDescendants``  (is_a + part_of)
+        * ``None`` / unset      -> ``hierarchicalDescendants``  (all relations)
+
+        Note: OLS has no endpoint for an arbitrary predicate subset -- the
+        hierarchical endpoint returns the ontology's full hierarchical relation
+        set (is_a + part_of for GO), so ``[IS_A, PART_OF]`` is served by it.
+        """
+        self.assertEqual(self._descendants_endpoint([IS_A]), "descendants")
+        self.assertEqual(
+            self._descendants_endpoint([IS_A, PART_OF]), "hierarchicalDescendants"
+        )
+        # order-independent
+        self.assertEqual(
+            self._descendants_endpoint([PART_OF, IS_A]), "hierarchicalDescendants"
+        )
+        # default (no predicates) also traverses is_a + part_of
+        self.assertEqual(self._descendants_endpoint(None), "hierarchicalDescendants")
+
+    def test_descendants_isa_and_partof_paginate_fully(self):
+        """The is_a + part_of closure is paged the same way as the is_a one."""
+        oi = self.oi
+        page_terms = [
+            [f"GO:{n:07d}" for n in range(0, 500)],
+            [f"GO:{n:07d}" for n in range(500, 730)],
+        ]
+        pages = [
+            self._hal_page(terms, number=i, total_pages=len(page_terms))
+            for i, terms in enumerate(page_terms)
+        ]
+        self.mock_client.get_json.reset_mock(side_effect=True)
+        self.mock_client.get_json.side_effect = pages
+
+        descs = set(oi.descendants(CELLULAR_COMPONENT, predicates=[IS_A, PART_OF], reflexive=False))
+
+        self.assertEqual(descs, {curie for terms in page_terms for curie in terms})
+        self.assertEqual(len(descs), 730)
+        self.assertEqual(self.mock_client.get_json.call_count, 2)
 
     def test_basic_search(self):
         self.oi.focus_ontology = None


### PR DESCRIPTION
Fixes #892

## Problem

The OLS adapter silently truncated `descendants()` and `ancestors()` closures to the first page of results (default 500 records). No error was raised — callers just got an incomplete set, producing silent false negatives in downstream `reachable_from` / closure validation.

Reported downstream in ai4curation/ai-gene-review#1653: descendants of `GO:0005575` (cellular_component) returned **491** GO terms via `ols:go` vs **4076** via `sqlite:obo:go`.

## Root cause

The adapter delegated paging to `ols_client.Client.get_paged`, which follows the next-page link at `_links.href`. OLS4 is a HAL API — the next page is at `_links.next.href`, and there is no top-level `href`. So the paging loop exits after page 0 and every result is capped at `size` (500).

Verified against the live EBI API:

```
GET .../GO:0005575/descendants?size=500
  page:   {size: 500, totalElements: 4086, totalPages: 9, number: 0}
  _links: ['first', 'self', 'next', 'last']   # no top-level 'href'
```

First page = 500 records; after `startswith("GO:")` filtering → 491, exactly matching the downstream report. Both the `descendants`/`hierarchicalDescendants` and `ancestors`/`hierarchicalAncestors` endpoints were affected.

## Fix

- Add a local `_iter_paged()` helper on `BaseOlsImplementation` that walks pages explicitly via the `page`/`size` params and `page.totalPages`, instead of relying on the buggy `get_paged`. Also more robust to responses lacking `_embedded` (terms with no descendants no longer `KeyError`).
- Route both `descendants()` and `ancestors()` through it.

## Tests

- `test_descendants_are_not_truncated_to_first_page` — simulates a 3-page / 1200-term response and asserts every page is collected and fetched (fails under the old first-page-only behavior).
- `test_descendants_isa_and_partof_use_hierarchical_endpoint` — pins endpoint selection: `[IS_A]` → `descendants` (is_a only); `[IS_A, PART_OF]` (any order) and default → `hierarchicalDescendants` (is_a + part_of).
- `test_descendants_isa_and_partof_paginate_fully` — verifies the is_a + part_of closure pages fully too.
- Reworked `test_ancestors` / `test_descendants` to mock at the `get_json` level so they genuinely exercise pagination rather than mocking it away.

All OLS adapter tests pass (14 passed, 1 pre-existing skip).

## Upstream note

The underlying bug is in `ols-client` (`get_paged` reads `_links.href` instead of `_links.next.href`); a report is being filed there. OAK no longer depends on `get_paged` for these calls, but the dependency floor is still `ols-client>=0.1.1`. Once a fixed `ols-client` ships, we can optionally simplify back to the client helper and bump the floor.

Closes #892
Ref: ai4curation/ai-gene-review#1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014JsGr7QSAaKGZKhhFSnpTb)_