### PR TITLE
increase default cache ttl

### DIFF
--- a/src/oaklib/utilities/caching.py
+++ b/src/oaklib/utilities/caching.py
@@ -235,7 +235,7 @@ class FileCache(object):
         """
 
         self._module = module
-        self._default_policy = CachePolicy.from_string("1w")
+        self._default_policy = CachePolicy.from_string("1m")
         self._forced_policy = None
         self._policies = []
         self._config_file = os.path.join(user_config_dir(APP_NAME), "cache.conf")

--- a/tests/test_utilities/test_caching.py
+++ b/tests/test_utilities/test_caching.py
@@ -148,7 +148,7 @@ class TestFileCache(unittest.TestCase):
         self.assertEqual(cache._get_policy("fbbt.db")._max_age, 86400 * 7 * 3)
         self.assertEqual(cache._get_policy("fbdv.db")._max_age, 86400 * 30)
         self.assertEqual(cache._get_policy("fbcv.db")._max_age, 86400 * 30)
-        self.assertEqual(cache._get_policy("other.db")._max_age, 86400 * 7)
+        self.assertEqual(cache._get_policy("other.db")._max_age, 86400 * 30)
 
         # Check that "forced policy" takes precedence
         cache.force_policy(CachePolicy.from_string("2d"))


### PR DESCRIPTION
- **Increase default cache TTL from 1 week to 1 month to reduce S3 egress**
- **Update test to expect 1-month default cache TTL**
