### PR TITLE
[codex] Fix FunOwl closure traversal performance

### DIFF
--- a/src/oaklib/implementations/funowl/funowl_implementation.py
+++ b/src/oaklib/implementations/funowl/funowl_implementation.py
@@ -3,7 +3,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Set, cast
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Set, Tuple, Union, cast
 
 import pyhornedowl
 import rdflib
@@ -69,7 +69,7 @@ from oaklib.datamodels.vocabulary import (
 from oaklib.interfaces import SearchInterface
 from oaklib.interfaces.basic_ontology_interface import LANGUAGE_TAG, RELATIONSHIP
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
-from oaklib.interfaces.obograph_interface import OboGraphInterface
+from oaklib.interfaces.obograph_interface import GraphTraversalMethod, OboGraphInterface
 from oaklib.interfaces.owl_interface import OwlInterface, ReasonerConfiguration
 from oaklib.interfaces.patcher_interface import PatcherInterface
 from oaklib.types import CURIE, PRED_CURIE
@@ -140,6 +140,10 @@ class ProjectedRelationship:
         return self.subject, self.predicate, self.object
 
 
+AdjacencyMap = Dict[CURIE, Set[CURIE]]
+AdjacencyIndex = Dict[Optional[PRED_CURIE], AdjacencyMap]
+
+
 @dataclass
 class FunOwlImplementation(
     OwlInterface,
@@ -161,6 +165,18 @@ class FunOwlImplementation(
         default=None, init=False, repr=False
     )
     _entailed_relationship_cache: Optional[List[ProjectedRelationship]] = field(
+        default=None, init=False, repr=False
+    )
+    _direct_outgoing_adjacency_cache: Optional[AdjacencyIndex] = field(
+        default=None, init=False, repr=False
+    )
+    _direct_incoming_adjacency_cache: Optional[AdjacencyIndex] = field(
+        default=None, init=False, repr=False
+    )
+    _entailed_outgoing_adjacency_cache: Optional[AdjacencyIndex] = field(
+        default=None, init=False, repr=False
+    )
+    _entailed_incoming_adjacency_cache: Optional[AdjacencyIndex] = field(
         default=None, init=False, repr=False
     )
     _metadata_map_cache: Dict[CURIE, Dict[PRED_CURIE, List[str]]] = field(
@@ -274,6 +290,10 @@ class FunOwlImplementation(
         self._entailed_edge_index = None
         self._direct_relationship_cache = None
         self._entailed_relationship_cache = None
+        self._direct_outgoing_adjacency_cache = None
+        self._direct_incoming_adjacency_cache = None
+        self._entailed_outgoing_adjacency_cache = None
+        self._entailed_incoming_adjacency_cache = None
         self._metadata_map_cache.clear()
         self._owl_type_map_cache = None
 
@@ -373,9 +393,7 @@ class FunOwlImplementation(
                     if curie is not None:
                         type_map[curie].add(OWL_OBJECT_PROPERTY)
                         type_map[curie].add(OWL_TRANSITIVE_PROPERTY)
-            self._owl_type_map_cache = {
-                curie: set(types) for curie, types in type_map.items()
-            }
+            self._owl_type_map_cache = {curie: set(types) for curie, types in type_map.items()}
         return self._owl_type_map_cache
 
     def entities(self, filter_obsoletes=True, owl_type=None) -> Iterable[CURIE]:
@@ -455,7 +473,9 @@ class FunOwlImplementation(
     def get_sssom_mappings_by_curie(self, curie: CURIE) -> Iterable[sssom.Mapping]:
         seen = set()
 
-        def _mapping(subject_id: CURIE, predicate_id: PRED_CURIE, object_id: CURIE) -> sssom.Mapping:
+        def _mapping(
+            subject_id: CURIE, predicate_id: PRED_CURIE, object_id: CURIE
+        ) -> sssom.Mapping:
             mapping = sssom.Mapping(
                 subject_id=subject_id,
                 predicate_id=predicate_id,
@@ -516,7 +536,11 @@ class FunOwlImplementation(
         search_all = "ANYTHING" in property_names
         seen = set()
         for curie in self.entities(filter_obsoletes=not config.include_obsoletes_in_results):
-            if (search_all or "LABEL" in property_names) and (label := self.label(curie)) and matches(label):
+            if (
+                (search_all or "LABEL" in property_names)
+                and (label := self.label(curie))
+                and matches(label)
+            ):
                 if curie not in seen:
                     seen.add(curie)
                     yield curie
@@ -732,9 +756,7 @@ class FunOwlImplementation(
         return self._direct_relationship_cache
 
     @staticmethod
-    def _transitive_targets(
-        source: CURIE, adjacency_map: Mapping[CURIE, Set[CURIE]]
-    ) -> Set[CURIE]:
+    def _transitive_targets(source: CURIE, adjacency_map: Mapping[CURIE, Set[CURIE]]) -> Set[CURIE]:
         stack = list(adjacency_map.get(source, set()))
         targets = set()
         while stack:
@@ -744,6 +766,133 @@ class FunOwlImplementation(
             targets.add(target)
             stack.extend(adjacency_map.get(target, set()).difference(targets))
         return targets
+
+    @staticmethod
+    def _as_curie_list(start_curies: Union[CURIE, List[CURIE]]) -> List[CURIE]:
+        if isinstance(start_curies, str):
+            return [start_curies]
+        return list(start_curies)
+
+    @staticmethod
+    def _build_adjacency_indexes(
+        relationships: Iterable[ProjectedRelationship],
+    ) -> Tuple[AdjacencyIndex, AdjacencyIndex]:
+        outgoing: AdjacencyIndex = {None: defaultdict(set)}
+        incoming: AdjacencyIndex = {None: defaultdict(set)}
+        for relationship in relationships:
+            outgoing[None][relationship.subject].add(relationship.object)
+            incoming[None][relationship.object].add(relationship.subject)
+            outgoing.setdefault(relationship.predicate, defaultdict(set))[relationship.subject].add(
+                relationship.object
+            )
+            incoming.setdefault(relationship.predicate, defaultdict(set))[relationship.object].add(
+                relationship.subject
+            )
+        return outgoing, incoming
+
+    def _direct_adjacency_indexes(self) -> Tuple[AdjacencyIndex, AdjacencyIndex]:
+        if (
+            self._direct_outgoing_adjacency_cache is None
+            or self._direct_incoming_adjacency_cache is None
+        ):
+            (
+                self._direct_outgoing_adjacency_cache,
+                self._direct_incoming_adjacency_cache,
+            ) = self._build_adjacency_indexes(self._direct_relationships())
+        return self._direct_outgoing_adjacency_cache, self._direct_incoming_adjacency_cache
+
+    def _entailed_adjacency_indexes(self) -> Tuple[AdjacencyIndex, AdjacencyIndex]:
+        if (
+            self._entailed_outgoing_adjacency_cache is None
+            or self._entailed_incoming_adjacency_cache is None
+        ):
+            (
+                self._entailed_outgoing_adjacency_cache,
+                self._entailed_incoming_adjacency_cache,
+            ) = self._build_adjacency_indexes(self._entailed_relationships())
+        return self._entailed_outgoing_adjacency_cache, self._entailed_incoming_adjacency_cache
+
+    @staticmethod
+    def _select_adjacency_map(
+        index: AdjacencyIndex, predicates: Optional[List[PRED_CURIE]]
+    ) -> Mapping[CURIE, Set[CURIE]]:
+        if predicates is None:
+            return index.get(None, {})
+        if len(predicates) == 1:
+            return index.get(predicates[0], {})
+        adjacency_map: AdjacencyMap = defaultdict(set)
+        for predicate in predicates:
+            for source, targets in index.get(predicate, {}).items():
+                adjacency_map[source].update(targets)
+        return adjacency_map
+
+    def _closure_targets(
+        self,
+        start_curies: Union[CURIE, List[CURIE]],
+        predicates: Optional[List[PRED_CURIE]],
+        reflexive: bool,
+        *,
+        incoming: bool,
+        include_entailed: bool,
+    ) -> List[CURIE]:
+        start_curie_list = self._as_curie_list(start_curies)
+        outgoing_index, incoming_index = (
+            self._entailed_adjacency_indexes()
+            if include_entailed
+            else self._direct_adjacency_indexes()
+        )
+        index = incoming_index if incoming else outgoing_index
+        adjacency_map = self._select_adjacency_map(index, predicates)
+        targets: Set[CURIE] = set()
+        for curie in start_curie_list:
+            targets.update(self._transitive_targets(curie, adjacency_map))
+        if reflexive:
+            targets.update(start_curie_list)
+        else:
+            targets.difference_update(start_curie_list)
+        return list(targets)
+
+    def ancestors(
+        self,
+        start_curies: Union[CURIE, List[CURIE]],
+        predicates: Optional[List[PRED_CURIE]] = None,
+        reflexive: bool = True,
+        method: Optional[GraphTraversalMethod] = None,
+    ) -> Iterable[CURIE]:
+        """
+        Ancestors obtained from cached predicate adjacency maps.
+
+        This avoids repeatedly scanning the full projected relationship list during
+        graph walks over large OWL files.
+        """
+        return self._closure_targets(
+            start_curies,
+            predicates,
+            reflexive,
+            incoming=False,
+            include_entailed=method == GraphTraversalMethod.ENTAILMENT,
+        )
+
+    def descendants(
+        self,
+        start_curies: Union[CURIE, List[CURIE]],
+        predicates: Optional[List[PRED_CURIE]] = None,
+        reflexive: bool = True,
+        method: Optional[GraphTraversalMethod] = None,
+    ) -> Iterable[CURIE]:
+        """
+        Descendants obtained from cached predicate adjacency maps.
+
+        This avoids repeatedly scanning the full projected relationship list during
+        graph walks over large OWL files.
+        """
+        return self._closure_targets(
+            start_curies,
+            predicates,
+            reflexive,
+            incoming=True,
+            include_entailed=method == GraphTraversalMethod.ENTAILMENT,
+        )
 
     def _entailed_relationships(self) -> List[ProjectedRelationship]:
         if self._entailed_relationship_cache is None:

--- a/src/oaklib/implementations/funowl/funowl_implementation.py
+++ b/src/oaklib/implementations/funowl/funowl_implementation.py
@@ -845,7 +845,10 @@ class FunOwlImplementation(
         adjacency_map = self._select_adjacency_map(index, predicates)
         targets: Set[CURIE] = set()
         for curie in start_curie_list:
-            targets.update(self._transitive_targets(curie, adjacency_map))
+            if include_entailed:
+                targets.update(adjacency_map.get(curie, set()))
+            else:
+                targets.update(self._transitive_targets(curie, adjacency_map))
         if reflexive:
             targets.update(start_curie_list)
         else:

--- a/tests/test_implementations/test_funowl.py
+++ b/tests/test_implementations/test_funowl.py
@@ -9,7 +9,7 @@ from pyhornedowl.model import EquivalentClasses, SubClassOf
 from oaklib.datamodels.search import SearchConfiguration, SearchProperty, SearchTermSyntax
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.funowl.funowl_implementation import FunOwlImplementation
-from oaklib.interfaces.obograph_interface import OboGraphInterface
+from oaklib.interfaces.obograph_interface import GraphTraversalMethod, OboGraphInterface
 from oaklib.interfaces.owl_interface import AxiomFilter
 from oaklib.resource import OntologyResource
 from oaklib.utilities.kgcl_utilities import generate_change_id
@@ -177,6 +177,25 @@ class TestFunOwlImplementation(unittest.TestCase):
 
             oi.incoming_relationship_map = fail_incoming_relationship_map
             descendants = set(oi.descendants("EX:0001", predicates=[IS_A], reflexive=False))
+            self.assertEqual(descendants, {"EX:0002", "EX:0003"})
+
+    def test_entailed_closure_uses_precomputed_targets(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            oi = self._implementation_from_text(tmpdir, CLOSURE_OFN)
+            oi._entailed_adjacency_indexes()
+
+            def fail_transitive_targets(*args, **kwargs):
+                raise AssertionError("entailment traversal should use precomputed targets")
+
+            oi._transitive_targets = fail_transitive_targets
+            descendants = set(
+                oi.descendants(
+                    "EX:0001",
+                    predicates=[IS_A],
+                    reflexive=False,
+                    method=GraphTraversalMethod.ENTAILMENT,
+                )
+            )
             self.assertEqual(descendants, {"EX:0002", "EX:0003"})
 
     def test_cached_closure_cache_invalidates_after_edge_patch(self):

--- a/tests/test_implementations/test_funowl.py
+++ b/tests/test_implementations/test_funowl.py
@@ -7,6 +7,7 @@ from kgcl_schema.datamodel import kgcl
 from pyhornedowl.model import EquivalentClasses, SubClassOf
 
 from oaklib.datamodels.search import SearchConfiguration, SearchProperty, SearchTermSyntax
+from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.funowl.funowl_implementation import FunOwlImplementation
 from oaklib.interfaces.obograph_interface import OboGraphInterface
 from oaklib.interfaces.owl_interface import AxiomFilter
@@ -31,6 +32,23 @@ SubClassOf(CL:0000540 GO:0008150)
 SubClassOf(CL:0000540 ObjectSomeValuesFrom(BFO:0000050 GO:0008150))
 )
 """
+CLOSURE_OFN = """\
+Prefix(EX:=<http://example.org/EX_>)
+Prefix(BFO:=<http://purl.obolibrary.org/obo/BFO_>)
+Ontology(
+Declaration(Class(EX:0001))
+Declaration(Class(EX:0002))
+Declaration(Class(EX:0003))
+Declaration(Class(EX:0004))
+Declaration(Class(EX:0005))
+Declaration(Class(EX:0006))
+Declaration(ObjectProperty(BFO:0000050))
+SubClassOf(EX:0002 EX:0001)
+SubClassOf(EX:0003 EX:0002)
+SubClassOf(EX:0004 ObjectSomeValuesFrom(BFO:0000050 EX:0001))
+SubClassOf(EX:0005 EX:0004)
+)
+"""
 
 
 class TestFunOwlImplementation(unittest.TestCase):
@@ -38,6 +56,11 @@ class TestFunOwlImplementation(unittest.TestCase):
         resource = OntologyResource(str(TEST_ONT))
         self.oi = FunOwlImplementation(resource)
         self.compliance_tester = ComplianceTester(self)
+
+    def _implementation_from_text(self, tmpdir: str, text: str) -> FunOwlImplementation:
+        path = Path(tmpdir) / "test.ofn"
+        path.write_text(text, encoding="utf-8")
+        return FunOwlImplementation(OntologyResource(str(path)))
 
     def test_entities(self):
         curies = list(self.oi.entities())
@@ -106,6 +129,76 @@ class TestFunOwlImplementation(unittest.TestCase):
 
     def test_ancestors_descendants(self):
         self.compliance_tester.test_ancestors_descendants(self.oi)
+
+    def test_cached_closure_traversal_filters_predicates(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            oi = self._implementation_from_text(tmpdir, CLOSURE_OFN)
+
+            isa_descendants = set(oi.descendants("EX:0001", predicates=[IS_A], reflexive=False))
+            self.assertEqual(isa_descendants, {"EX:0002", "EX:0003"})
+
+            part_of_descendants = set(
+                oi.descendants("EX:0001", predicates=[PART_OF], reflexive=False)
+            )
+            self.assertEqual(part_of_descendants, {"EX:0004"})
+
+            hierarchical_descendants = set(
+                oi.descendants("EX:0001", predicates=[IS_A, PART_OF], reflexive=False)
+            )
+            self.assertEqual(
+                hierarchical_descendants,
+                {"EX:0002", "EX:0003", "EX:0004", "EX:0005"},
+            )
+
+            hierarchical_ancestors = set(
+                oi.ancestors("EX:0005", predicates=[IS_A, PART_OF], reflexive=False)
+            )
+            self.assertEqual(hierarchical_ancestors, {"EX:0001", "EX:0004"})
+            self.assertIn(
+                "EX:0005",
+                set(oi.ancestors("EX:0005", predicates=[IS_A, PART_OF])),
+            )
+
+    def test_cached_closure_traversal_handles_multi_start(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            oi = self._implementation_from_text(tmpdir, CLOSURE_OFN)
+
+            descendants = set(
+                oi.descendants(["EX:0001", "EX:0004"], predicates=[IS_A], reflexive=False)
+            )
+            self.assertEqual(descendants, {"EX:0002", "EX:0003", "EX:0005"})
+
+    def test_cached_closure_traversal_does_not_use_graph_walker(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            oi = self._implementation_from_text(tmpdir, CLOSURE_OFN)
+
+            def fail_incoming_relationship_map(*args, **kwargs):
+                raise AssertionError("descendants should use the cached adjacency index")
+
+            oi.incoming_relationship_map = fail_incoming_relationship_map
+            descendants = set(oi.descendants("EX:0001", predicates=[IS_A], reflexive=False))
+            self.assertEqual(descendants, {"EX:0002", "EX:0003"})
+
+    def test_cached_closure_cache_invalidates_after_edge_patch(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            oi = self._implementation_from_text(tmpdir, CLOSURE_OFN)
+
+            self.assertNotIn(
+                "EX:0006",
+                set(oi.descendants("EX:0001", predicates=[IS_A], reflexive=False)),
+            )
+            oi.apply_patch(
+                kgcl.EdgeCreation(
+                    id=generate_change_id(),
+                    subject="EX:0006",
+                    predicate=IS_A,
+                    object="EX:0001",
+                )
+            )
+            self.assertIn(
+                "EX:0006",
+                set(oi.descendants("EX:0001", predicates=[IS_A], reflexive=False)),
+            )
 
     def test_basic_search(self):
         self.assertIn(NUCLEUS, list(self.oi.basic_search("nucleus")))


### PR DESCRIPTION
## Summary

This updates `FunOwlImplementation` so `ancestors()` and `descendants()` use cached predicate adjacency maps instead of the inherited graph walker repeatedly filtering the full projected relationship list.

## Why

`linkml/linkml-term-validator#57` and `#58` identified `owl:`/FunOwl closure expansion as effectively O(V * E) on large ontologies such as GO, because each visited node caused another full relationship scan. This made reachable-from style closure validation unusably slow for local OWL inputs.

## Changes

- Add cached outgoing/incoming adjacency indexes for direct and entailed projected FunOwl relationships.
- Override `ancestors()` and `descendants()` to traverse those indexes with the existing `_transitive_targets()` helper.
- Invalidate the new adjacency caches through the existing FunOwl cache invalidation path.
- Add Functional OWL regression coverage for predicate filtering, multi-start traversal, avoiding the inherited graph walker, and cache invalidation after edge patches.

## Validation

- `poetry run pytest tests/test_implementations/test_funowl.py`
- `poetry run pytest tests/test_selector.py`
- `poetry run pytest tests/test_implementations/test_ols.py`
- `poetry run ruff check src/oaklib/implementations/funowl/funowl_implementation.py tests/test_implementations/test_funowl.py`
- `poetry run black --check src/oaklib/implementations/funowl/funowl_implementation.py tests/test_implementations/test_funowl.py`
- Synthetic sanity check: 2,999 descendants from a 3,000-node Functional OWL chain in 0.027s

Refs linkml/linkml-term-validator#57 and linkml/linkml-term-validator#58.
