### PR TITLE
[codex] Fix OLS CLI hierarchy relationships

### DIFF
--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -1816,8 +1816,10 @@ def ancestors(
     # writer.display_options = display.split(',')
     writer.file = output
     if callable(getattr(impl, "ancestors", None)) and isinstance(impl, SearchInterface):
+        traversal_kwargs = {}
         if graph_traversal_method:
             graph_traversal_method = GraphTraversalMethod[graph_traversal_method]
+            traversal_kwargs["method"] = graph_traversal_method
             if graph_traversal_method == GraphTraversalMethod.HOP and isinstance(
                 impl, OboGraphInterface
             ):
@@ -1843,7 +1845,7 @@ def ancestors(
                 raise NotImplementedError
         else:
             logging.info(f"Getting ancestors of {curies} over {actual_predicates}")
-            ancs = list(impl.ancestors(curies, actual_predicates, method=graph_traversal_method))
+            ancs = list(impl.ancestors(curies, actual_predicates, **traversal_kwargs))
             for a_curie, a_label in impl.labels(ancs):
                 writer.emit(dict(id=a_curie, label=a_label))
     else:
@@ -2243,15 +2245,15 @@ def descendants(
     writer = _get_writer(output_type, impl, StreamingInfoWriter)
     writer.display_options = display.split(",")
     writer.file = output
+    traversal_kwargs = {}
     if graph_traversal_method:
         graph_traversal_method = GraphTraversalMethod[graph_traversal_method]
+        traversal_kwargs["method"] = graph_traversal_method
     if not callable(getattr(impl, "descendants", None)) or not isinstance(impl, SearchInterface):
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")
     actual_predicates = process_predicates_arg(predicates)
     curies = list(query_terms_iterator(terms, impl))
-    result_it = impl.descendants(
-        curies, predicates=actual_predicates, method=graph_traversal_method
-    )
+    result_it = impl.descendants(curies, predicates=actual_predicates, **traversal_kwargs)
     writer.emit_multiple(result_it)
     writer.finish()
 

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -1815,10 +1815,12 @@ def ancestors(
     writer = _get_writer(output_type, impl, StreamingCsvWriter)
     # writer.display_options = display.split(',')
     writer.file = output
-    if isinstance(impl, OboGraphInterface) and isinstance(impl, SearchInterface):
+    if callable(getattr(impl, "ancestors", None)) and isinstance(impl, SearchInterface):
         if graph_traversal_method:
             graph_traversal_method = GraphTraversalMethod[graph_traversal_method]
-            if graph_traversal_method == GraphTraversalMethod.HOP:
+            if graph_traversal_method == GraphTraversalMethod.HOP and isinstance(
+                impl, OboGraphInterface
+            ):
                 impl.precompute_lookups()
         actual_predicates = process_predicates_arg(predicates)
         curies = list(query_terms_iterator(terms, impl))
@@ -1840,15 +1842,10 @@ def ancestors(
             else:
                 raise NotImplementedError
         else:
-            if isinstance(impl, OboGraphInterface):
-                logging.info(f"Getting ancestors of {curies} over {actual_predicates}")
-                ancs = list(
-                    impl.ancestors(curies, actual_predicates, method=graph_traversal_method)
-                )
-                for a_curie, a_label in impl.labels(ancs):
-                    writer.emit(dict(id=a_curie, label=a_label))
-            else:
-                raise NotImplementedError
+            logging.info(f"Getting ancestors of {curies} over {actual_predicates}")
+            ancs = list(impl.ancestors(curies, actual_predicates, method=graph_traversal_method))
+            for a_curie, a_label in impl.labels(ancs):
+                writer.emit(dict(id=a_curie, label=a_label))
     else:
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")
     writer.finish()

--- a/src/oaklib/cli.py
+++ b/src/oaklib/cli.py
@@ -2245,7 +2245,7 @@ def descendants(
     writer.file = output
     if graph_traversal_method:
         graph_traversal_method = GraphTraversalMethod[graph_traversal_method]
-    if not isinstance(impl, OboGraphInterface):
+    if not callable(getattr(impl, "descendants", None)) or not isinstance(impl, SearchInterface):
         raise NotImplementedError(f"Cannot execute this using {impl} of type {type(impl)}")
     actual_predicates = process_predicates_arg(predicates)
     curies = list(query_terms_iterator(terms, impl))

--- a/src/oaklib/implementations/ols/ols_implementation.py
+++ b/src/oaklib/implementations/ols/ols_implementation.py
@@ -12,10 +12,10 @@ from oaklib.datamodels import oxo
 from oaklib.datamodels.oxo import ScopeEnum
 from oaklib.datamodels.search import SearchConfiguration, SearchProperty
 from oaklib.datamodels.text_annotator import TextAnnotation
-from oaklib.datamodels.vocabulary import IS_A, SEMAPV
+from oaklib.datamodels.vocabulary import IS_A, PART_OF, SEMAPV
 from oaklib.implementations.ols.constants import SEARCH_CONFIG
 from oaklib.implementations.ols.oxo_utils import load_oxo_payload
-from oaklib.interfaces.basic_ontology_interface import PREFIX_MAP
+from oaklib.interfaces.basic_ontology_interface import PREFIX_MAP, RELATIONSHIP
 from oaklib.interfaces.mapping_provider_interface import MappingProviderInterface
 from oaklib.interfaces.obograph_interface import GraphTraversalMethod
 from oaklib.interfaces.search_interface import SearchInterface
@@ -77,6 +77,7 @@ def _scalar(value: Any) -> Optional[str]:
         return None
     return value
 
+
 oxo_pred_mappings = {
     ScopeEnum.EXACT.text: "skos:exactMatch",
     ScopeEnum.BROADER.text: "skos:broadMatch",
@@ -126,7 +127,10 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
 
         ontology = self.focus_ontology
         iri = self.curie_to_uri(curie)
-        term = _first_term(self.client.get_term(ontology=ontology, iri=iri))
+        try:
+            term = _first_term(self.client.get_term(ontology=ontology, iri=iri))
+        except requests.HTTPError:
+            return None
         if term:
             label = _scalar(term.get("label"))
             if label is not None:
@@ -164,7 +168,10 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
 
         ontology = self.focus_ontology
         iri = self.curie_to_uri(curie)
-        term = _first_term(self.client.get_term(ontology=ontology, iri=iri))
+        try:
+            term = _first_term(self.client.get_term(ontology=ontology, iri=iri))
+        except requests.HTTPError:
+            return None
         if term:
             definition = _scalar(term.get("description"))
             if definition:
@@ -284,6 +291,183 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
         if reflexive:
             descs.update(start_curies)
         return list(descs)
+
+    def relationships(
+        self,
+        subjects: Iterable[CURIE] = None,
+        predicates: Iterable[PRED_CURIE] = None,
+        objects: Iterable[CURIE] = None,
+        include_tbox: bool = True,
+        include_abox: bool = True,
+        include_entailed: bool = False,
+        exclude_blank: bool = True,
+        invert: bool = False,
+    ) -> Iterator[RELATIONSHIP]:
+        """
+        Yield relationships from OLS term graph and hierarchy endpoints.
+
+        Direct relationships are read from the OLS ``graph`` endpoint. Entailed
+        hierarchy relationships are approximated from OLS closure endpoints:
+        ``ancestors``/``descendants`` for ``is_a`` and the extra nodes from
+        ``hierarchicalAncestors``/``hierarchicalDescendants`` for ``part_of``.
+
+        :param subjects: constrain search to these subjects
+        :param predicates: constrain search to these predicates
+        :param objects: constrain search to these objects
+        :param include_tbox: accepted for interface compatibility
+        :param include_abox: accepted for interface compatibility
+        :param include_entailed: include hierarchy closure edges
+        :param exclude_blank: accepted for interface compatibility
+        :param invert: invert subject/object constraints and returned triples
+        :return: relationship triples
+        """
+        if invert:
+            for s, p, o in self.relationships(
+                subjects=objects,
+                predicates=predicates,
+                objects=subjects,
+                include_tbox=include_tbox,
+                include_abox=include_abox,
+                include_entailed=include_entailed,
+                exclude_blank=exclude_blank,
+            ):
+                yield o, p, s
+            return
+
+        subject_list = list(subjects) if subjects else None
+        object_list = list(objects) if objects else None
+        predicate_list = list(predicates) if predicates else None
+
+        if not subject_list and not object_list:
+            raise NotImplementedError(
+                "OLS relationships must be constrained by subjects or objects"
+            )
+
+        if include_entailed:
+            yield from self._entailed_hierarchy_relationships(
+                subjects=subject_list,
+                predicates=predicate_list,
+                objects=object_list,
+            )
+            return
+
+        yielded = set()
+        if subject_list:
+            object_set = set(object_list) if object_list else None
+            for subject in subject_list:
+                for rel in self._graph_relationships(
+                    subject,
+                    predicates=predicate_list,
+                    subjects={subject},
+                    objects=object_set,
+                ):
+                    if rel not in yielded:
+                        yielded.add(rel)
+                        yield rel
+        else:
+            for obj in object_list:
+                for rel in self._graph_relationships(
+                    obj,
+                    predicates=predicate_list,
+                    objects={obj},
+                ):
+                    if rel not in yielded:
+                        yielded.add(rel)
+                        yield rel
+
+    def _graph_relationships(
+        self,
+        focus_curie: CURIE,
+        predicates: List[PRED_CURIE] = None,
+        subjects: set = None,
+        objects: set = None,
+    ) -> Iterator[RELATIONSHIP]:
+        """Return direct graph relationships from the OLS term graph endpoint."""
+        ontology = self.focus_ontology
+        iri = self.curie_to_uri(focus_curie)
+        path = f"ontologies/{ontology}/terms/{_double_quote_iri(iri)}/graph"
+        response = self.client.get_json(path)
+        for edge in (response or {}).get("edges") or []:
+            source = edge.get("source")
+            predicate = edge.get("uri")
+            target = edge.get("target")
+            if not (source and predicate and target):
+                continue
+            subject_curie = self.uri_to_curie(source, strict=False)
+            predicate_curie = self.uri_to_curie(predicate, strict=False)
+            object_curie = self.uri_to_curie(target, strict=False)
+            if subjects and subject_curie not in subjects:
+                continue
+            if objects and object_curie not in objects:
+                continue
+            if predicates and predicate_curie not in predicates:
+                continue
+            yield subject_curie, predicate_curie, object_curie
+
+    def _entailed_hierarchy_relationships(
+        self,
+        subjects: List[CURIE] = None,
+        predicates: List[PRED_CURIE] = None,
+        objects: List[CURIE] = None,
+    ) -> Iterator[RELATIONSHIP]:
+        """Return entailed hierarchy relationships supported by OLS closures."""
+        supported_predicates = {IS_A, PART_OF}
+        predicate_set = set(predicates) if predicates else supported_predicates
+        unsupported_predicates = predicate_set - supported_predicates
+        if unsupported_predicates:
+            raise NotImplementedError(
+                "OLS entailed relationships support only "
+                f"{sorted(supported_predicates)}; got {sorted(predicate_set)}"
+            )
+
+        yielded = set()
+        if subjects:
+            object_set = set(objects) if objects else None
+            for subject in subjects:
+                for rel in self._entailed_hierarchy_relationships_from_subject(
+                    subject, predicate_set, object_set
+                ):
+                    if rel not in yielded:
+                        yielded.add(rel)
+                        yield rel
+        elif objects:
+            for obj in objects:
+                for rel in self._entailed_hierarchy_relationships_to_object(obj, predicate_set):
+                    if rel not in yielded:
+                        yielded.add(rel)
+                        yield rel
+
+    def _entailed_hierarchy_relationships_from_subject(
+        self, subject: CURIE, predicate_set: set, objects: set = None
+    ) -> Iterator[RELATIONSHIP]:
+        isa_ancestors = set(self.ancestors(subject, predicates=[IS_A], reflexive=True))
+        if IS_A in predicate_set:
+            for obj in isa_ancestors:
+                if objects and obj not in objects:
+                    continue
+                yield subject, IS_A, obj
+        if PART_OF in predicate_set:
+            hierarchy_ancestors = set(
+                self.ancestors(subject, predicates=[IS_A, PART_OF], reflexive=True)
+            )
+            for obj in hierarchy_ancestors - isa_ancestors:
+                if objects and obj not in objects:
+                    continue
+                yield subject, PART_OF, obj
+
+    def _entailed_hierarchy_relationships_to_object(
+        self, obj: CURIE, predicate_set: set
+    ) -> Iterator[RELATIONSHIP]:
+        isa_descendants = set(self.descendants(obj, predicates=[IS_A], reflexive=True))
+        if IS_A in predicate_set:
+            for subject in isa_descendants:
+                yield subject, IS_A, obj
+        if PART_OF in predicate_set:
+            hierarchy_descendants = set(
+                self.descendants(obj, predicates=[IS_A, PART_OF], reflexive=True)
+            )
+            for subject in hierarchy_descendants - isa_descendants:
+                yield subject, PART_OF, obj
 
     def _iter_paged(
         self, path: str, key: str = "terms", size: int = 500

--- a/src/oaklib/implementations/ols/ols_implementation.py
+++ b/src/oaklib/implementations/ols/ols_implementation.py
@@ -391,21 +391,26 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
         path = f"ontologies/{ontology}/terms/{_double_quote_iri(iri)}/graph"
         response = self.client.get_json(path)
         for edge in (response or {}).get("edges") or []:
+            if not isinstance(edge, dict):
+                continue
             source = edge.get("source")
             predicate = edge.get("uri")
             target = edge.get("target")
-            if not (source and predicate and target):
+            if not all(isinstance(value, str) and value for value in (source, predicate, target)):
                 continue
-            subject_curie = self.uri_to_curie(source, strict=False)
-            predicate_curie = self.uri_to_curie(predicate, strict=False)
-            object_curie = self.uri_to_curie(target, strict=False)
+            subject_curie = self.uri_to_curie(source, strict=False, use_uri_fallback=True)
+            predicate_curie = self.uri_to_curie(predicate, strict=False, use_uri_fallback=True)
+            object_curie = self.uri_to_curie(target, strict=False, use_uri_fallback=True)
+            relationship = (subject_curie, predicate_curie, object_curie)
+            if not all(isinstance(value, str) and value for value in relationship):
+                continue
             if subjects and subject_curie not in subjects:
                 continue
             if objects and object_curie not in objects:
                 continue
             if predicates and predicate_curie not in predicates:
                 continue
-            yield subject_curie, predicate_curie, object_curie
+            yield relationship
 
     def _entailed_hierarchy_relationships(
         self,

--- a/src/oaklib/implementations/ols/ols_implementation.py
+++ b/src/oaklib/implementations/ols/ols_implementation.py
@@ -93,8 +93,8 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
     """
 
     ols_client_class: ClassVar[type[Client]]
-    label_cache: Dict[CURIE, str] = field(default_factory=lambda: {})
-    definition_cache: Dict[CURIE, str] = field(default_factory=lambda: {})
+    label_cache: Dict[CURIE, Optional[str]] = field(default_factory=lambda: {})
+    definition_cache: Dict[CURIE, Optional[str]] = field(default_factory=lambda: {})
     base_url = "https://www.ebi.ac.uk/spot/oxo/api/mappings"
     _prefix_map: Dict[str, str] = field(default_factory=lambda: {})
     focus_ontology: str = None
@@ -129,14 +129,14 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
         iri = self.curie_to_uri(curie)
         try:
             term = _first_term(self.client.get_term(ontology=ontology, iri=iri))
-        except requests.HTTPError:
-            return None
-        if term:
-            label = _scalar(term.get("label"))
-            if label is not None:
-                self.label_cache[curie] = label
-                return label
-        return None
+        except requests.HTTPError as error:
+            if error.response is None or error.response.status_code != requests.codes.not_found:
+                raise
+            label = None
+        else:
+            label = _scalar(term.get("label")) if term else None
+        self.label_cache[curie] = label
+        return label
 
     def labels(
         self, curies: Iterable[CURIE], allow_none=True, lang: LANGUAGE_TAG = None
@@ -170,14 +170,16 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
         iri = self.curie_to_uri(curie)
         try:
             term = _first_term(self.client.get_term(ontology=ontology, iri=iri))
-        except requests.HTTPError:
-            return None
-        if term:
-            definition = _scalar(term.get("description"))
-            if definition:
-                self.definition_cache[curie] = definition
-                return definition
-        return None
+        except requests.HTTPError as error:
+            if error.response is None or error.response.status_code != requests.codes.not_found:
+                raise
+            definition = None
+        else:
+            definition = _scalar(term.get("description")) if term else None
+            if not definition:
+                definition = None
+        self.definition_cache[curie] = definition
+        return definition
 
     def definitions(
         self,
@@ -307,8 +309,9 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
         Yield relationships from OLS term graph and hierarchy endpoints.
 
         Direct relationships are read from the OLS ``graph`` endpoint. Entailed
-        hierarchy relationships are approximated from OLS closure endpoints:
-        ``ancestors``/``descendants`` for ``is_a`` and the extra nodes from
+        hierarchy relationships are read from OLS closure endpoints:
+        ``ancestors``/``descendants`` for ``is_a`` and, when the ontology has no
+        other configured hierarchy predicates, the extra nodes from
         ``hierarchicalAncestors``/``hierarchicalDescendants`` for ``part_of``.
 
         :param subjects: constrain search to these subjects
@@ -419,6 +422,16 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
                 "OLS entailed relationships support only "
                 f"{sorted(supported_predicates)}; got {sorted(predicate_set)}"
             )
+        if PART_OF in predicate_set:
+            additional_hierarchical_predicates = (
+                self._ols_hierarchical_predicates() - supported_predicates
+            )
+            if additional_hierarchical_predicates:
+                raise NotImplementedError(
+                    "OLS cannot distinguish entailed part_of relationships from "
+                    "the ontology's additional hierarchical predicates: "
+                    f"{sorted(additional_hierarchical_predicates)}"
+                )
 
         yielded = set()
         if subjects:
@@ -454,6 +467,30 @@ class BaseOlsImplementation(MappingProviderInterface, TextAnnotatorInterface, Se
                 if objects and obj not in objects:
                     continue
                 yield subject, PART_OF, obj
+
+    def _ols_hierarchical_predicates(self) -> set[PRED_CURIE]:
+        """Return the predicates included in the OLS hierarchical closure.
+
+        OLS always includes ``rdfs:subClassOf``. Its ontology metadata reports
+        additional predicates in ``config.hierarchicalProperties``; when that
+        setting is empty or absent, OLS defaults to ``part_of``.
+        """
+        metadata = self.client.get_ontology(self.focus_ontology)
+        config = metadata.get("config") if isinstance(metadata, dict) else None
+        if not isinstance(config, dict):
+            raise NotImplementedError(
+                "OLS ontology metadata does not expose configured hierarchical predicates"
+            )
+        configured_properties = config.get("hierarchicalProperties") or [self.curie_to_uri(PART_OF)]
+        if isinstance(configured_properties, str):
+            configured_properties = [configured_properties]
+
+        predicates = {IS_A}
+        for property_iri in configured_properties:
+            predicate = self.uri_to_curie(property_iri, strict=False, use_uri_fallback=True)
+            if predicate:
+                predicates.add(predicate)
+        return predicates
 
     def _entailed_hierarchy_relationships_to_object(
         self, obj: CURIE, predicate_set: set

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import unittest
 from pathlib import Path
 from shutil import copyfile
 from typing import Optional
+from unittest.mock import MagicMock, patch
 
 import rdflib
 import yaml
@@ -430,6 +431,91 @@ class TestCommandLineInterface(unittest.TestCase):
             self.assertIn("GO:0031965", out)
             self.assertNotIn("subClassOf", out)
             self.assertNotIn("BFO", out)
+
+    def test_ols_ancestors_cli(self):
+        mock_client = MagicMock()
+        mock_client.get_json.return_value = {
+            "_embedded": {
+                "terms": [
+                    {"obo_id": CYTOPLASM},
+                    {"obo_id": CELLULAR_COMPONENT},
+                ]
+            },
+            "page": {"size": 500, "totalPages": 1, "number": 0},
+        }
+        mock_client.get_term.return_value = {"_embedded": {"terms": []}}
+
+        with patch(
+            "oaklib.implementations.ols.ols_implementation.OlsImplementation.ols_client_class",
+            return_value=mock_client,
+        ):
+            result = self.runner.invoke(
+                main,
+                [
+                    "-i",
+                    "ols:go",
+                    "ancestors",
+                    "-p",
+                    "i,p",
+                    NUCLEUS,
+                ],
+            )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertIn(NUCLEUS, result.stdout)
+        self.assertIn(CYTOPLASM, result.stdout)
+        self.assertIn(CELLULAR_COMPONENT, result.stdout)
+
+        path = mock_client.get_json.call_args.args[0]
+        self.assertIn("hierarchicalAncestors", path)
+
+    def test_ols_relationships_include_entailed_cli(self):
+        mock_client = MagicMock()
+
+        def mock_get_json(path, **kwargs):
+            if path.endswith("/ancestors"):
+                return {
+                    "_embedded": {"terms": [{"obo_id": CELLULAR_COMPONENT}]},
+                    "page": {"size": 500, "totalPages": 1, "number": 0},
+                }
+            if path.endswith("/hierarchicalAncestors"):
+                return {
+                    "_embedded": {
+                        "terms": [
+                            {"obo_id": CELLULAR_COMPONENT},
+                            {"obo_id": CYTOPLASM},
+                        ]
+                    },
+                    "page": {"size": 500, "totalPages": 1, "number": 0},
+                }
+            raise AssertionError(f"Unexpected path: {path}")
+
+        mock_client.get_json.side_effect = mock_get_json
+        mock_client.get_term.return_value = {"_embedded": {"terms": []}}
+
+        with patch(
+            "oaklib.implementations.ols.ols_implementation.OlsImplementation.ols_client_class",
+            return_value=mock_client,
+        ):
+            result = self.runner.invoke(
+                main,
+                [
+                    "-i",
+                    "ols:go",
+                    "relationships",
+                    "-p",
+                    "i,p",
+                    NUCLEUS,
+                    "--include-entailed",
+                ],
+            )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertIn(NUCLEUS, result.stdout)
+        self.assertIn("rdfs:subClassOf", result.stdout)
+        self.assertIn(CELLULAR_COMPONENT, result.stdout)
+        self.assertIn("BFO:0000050", result.stdout)
+        self.assertIn(CYTOPLASM, result.stdout)
 
     def test_logical_definitions(self):
         for input_arg in [str(TEST_ONT), f"sqlite:{TEST_DB}"]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -469,8 +469,46 @@ class TestCommandLineInterface(unittest.TestCase):
         path = mock_client.get_json.call_args.args[0]
         self.assertIn("hierarchicalAncestors", path)
 
+    def test_ols_descendants_cli(self):
+        mock_client = MagicMock()
+        mock_client.get_json.return_value = {
+            "_embedded": {
+                "terms": [
+                    {"obo_id": NUCLEUS},
+                    {"obo_id": CYTOPLASM},
+                ]
+            },
+            "page": {"size": 500, "totalPages": 1, "number": 0},
+        }
+        mock_client.get_term.return_value = {"_embedded": {"terms": []}}
+
+        with patch(
+            "oaklib.implementations.ols.ols_implementation.OlsImplementation.ols_client_class",
+            return_value=mock_client,
+        ):
+            result = self.runner.invoke(
+                main,
+                [
+                    "-i",
+                    "ols:go",
+                    "descendants",
+                    "-p",
+                    "i,p",
+                    CELLULAR_COMPONENT,
+                ],
+            )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertIn(CELLULAR_COMPONENT, result.stdout)
+        self.assertIn(NUCLEUS, result.stdout)
+        self.assertIn(CYTOPLASM, result.stdout)
+
+        path = mock_client.get_json.call_args.args[0]
+        self.assertIn("hierarchicalDescendants", path)
+
     def test_ols_relationships_include_entailed_cli(self):
         mock_client = MagicMock()
+        mock_client.get_ontology.return_value = {"config": {"hierarchicalProperties": []}}
 
         def mock_get_json(path, **kwargs):
             if path.endswith("/ancestors"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,9 @@ from oaklib.datamodels.vocabulary import (
     SKOS_CLOSE_MATCH,
     SKOS_EXACT_MATCH,
 )
+from oaklib.implementations.wikidata.wikidata_implementation import (
+    WikidataImplementation,
+)
 from oaklib.utilities.kgcl_utilities import parse_kgcl_files
 from tests import (
     ATOM,
@@ -505,6 +508,40 @@ class TestCommandLineInterface(unittest.TestCase):
 
         path = mock_client.get_json.call_args.args[0]
         self.assertIn("hierarchicalDescendants", path)
+
+    def test_wikidata_ancestors_cli_without_graph_traversal_method(self):
+        clear_cli_settings()
+        with (
+            patch.object(
+                WikidataImplementation, "ancestors", autospec=True, return_value=[]
+            ) as mock_traversal,
+            patch.object(WikidataImplementation, "labels", autospec=True, return_value=[]),
+        ):
+            result = self.runner.invoke(
+                main,
+                ["-i", "wikidata:", "ancestors", "-p", "i", "wikidata:Q1"],
+            )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        mock_traversal.assert_called_once()
+        self.assertNotIn("method", mock_traversal.call_args.kwargs)
+
+    def test_wikidata_descendants_cli_without_graph_traversal_method(self):
+        clear_cli_settings()
+        with (
+            patch.object(
+                WikidataImplementation, "descendants", autospec=True, return_value=[]
+            ) as mock_traversal,
+            patch.object(WikidataImplementation, "labels", autospec=True, return_value=[]),
+        ):
+            result = self.runner.invoke(
+                main,
+                ["-i", "wikidata:", "descendants", "-p", "i", "wikidata:Q1"],
+            )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        mock_traversal.assert_called_once()
+        self.assertNotIn("method", mock_traversal.call_args.kwargs)
 
     def test_ols_relationships_include_entailed_cli(self):
         mock_client = MagicMock()

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -35,6 +35,7 @@ class TestOlsImplementation(unittest.TestCase):
     def setUp(self) -> None:
         # Setup mock client
         mock_client = MagicMock()
+        mock_client.get_ontology.return_value = {"config": {"hierarchicalProperties": []}}
 
         # Create implementation
         with patch.object(OlsImplementation, "ols_client_class", return_value=mock_client):
@@ -198,13 +199,75 @@ class TestOlsImplementation(unittest.TestCase):
         oi = self.oi
         oi.focus_ontology = "go"
         self.assertIsNone(oi.label("GO:9999999"))
+        self.assertIsNone(oi.label("GO:9999999"))
+        self.mock_client.get_term.assert_called_once()
 
     def test_label_missing_iri_http_error(self):
-        """label() should return None when OLS returns 404 for a non-term IRI."""
-        self.mock_client.get_term.side_effect = requests.HTTPError()
+        """label() should cache a 404 for a non-term IRI as a missing label."""
+        response = requests.Response()
+        response.status_code = 404
+        self.mock_client.get_term.side_effect = requests.HTTPError(response=response)
         oi = self.oi
         oi.focus_ontology = "go"
         self.assertIsNone(oi.label(IS_A))
+        self.assertIsNone(oi.label(IS_A))
+        self.assertIn(IS_A, oi.label_cache)
+        self.assertIsNone(oi.label_cache[IS_A])
+        self.mock_client.get_term.assert_called_once()
+
+    def test_definition_missing_iri_http_error(self):
+        """definition() should cache a 404 for a non-term IRI as missing."""
+        response = requests.Response()
+        response.status_code = 404
+        self.mock_client.get_term.side_effect = requests.HTTPError(response=response)
+        oi = self.oi
+        oi.focus_ontology = "go"
+        self.assertIsNone(oi.definition(IS_A))
+        self.assertIsNone(oi.definition(IS_A))
+        self.assertIn(IS_A, oi.definition_cache)
+        self.assertIsNone(oi.definition_cache[IS_A])
+        self.mock_client.get_term.assert_called_once()
+
+    def test_term_lookup_http_error_without_status_is_raised(self):
+        """A response-less HTTPError is not a confirmed missing term."""
+        oi = self.oi
+        oi.focus_ontology = "go"
+        for method_name, cache_name in [
+            ("label", "label_cache"),
+            ("definition", "definition_cache"),
+        ]:
+            with self.subTest(method=method_name):
+                cache = getattr(oi, cache_name)
+                cache.clear()
+                self.mock_client.get_term.reset_mock()
+                error = requests.HTTPError()
+                self.mock_client.get_term.side_effect = error
+                with self.assertRaises(requests.HTTPError) as raised:
+                    getattr(oi, method_name)(IS_A)
+                self.assertIs(error, raised.exception)
+                self.mock_client.get_term.assert_called_once()
+                self.assertNotIn(IS_A, cache)
+
+    def test_term_lookup_non_404_http_errors_are_raised(self):
+        """Authentication, throttling, and server failures must not look missing."""
+        oi = self.oi
+        oi.focus_ontology = "go"
+        for method_name, cache_name in [
+            ("label", "label_cache"),
+            ("definition", "definition_cache"),
+        ]:
+            for status_code in [401, 403, 429, 500]:
+                with self.subTest(method=method_name, status_code=status_code):
+                    cache = getattr(oi, cache_name)
+                    cache.clear()
+                    response = requests.Response()
+                    response.status_code = status_code
+                    error = requests.HTTPError(response=response)
+                    self.mock_client.get_term.side_effect = error
+                    with self.assertRaises(requests.HTTPError) as raised:
+                        getattr(oi, method_name)(IS_A)
+                    self.assertIs(error, raised.exception)
+                    self.assertNotIn(IS_A, cache)
 
     @staticmethod
     def _hal_page(obo_ids, number, total_pages, key="terms"):
@@ -273,6 +336,63 @@ class TestOlsImplementation(unittest.TestCase):
         self.assertIn((VACUOLE, IS_A, VACUOLE), rels)
         self.assertIn((VACUOLE, IS_A, CELLULAR_COMPONENT), rels)
         self.assertIn((VACUOLE, PART_OF, CYTOPLASM), rels)
+
+    def test_entailed_part_of_rejects_additional_hierarchical_predicates(self):
+        """Hierarchy closure differences are ambiguous when OLS configures other predicates."""
+        part_of_iri = "http://purl.obolibrary.org/obo/BFO_0000050"
+        custom_hierarchy_iri = "http://example.org/custom_hierarchy"
+        self.mock_client.get_ontology.return_value = {
+            "config": {
+                "hierarchicalProperties": [
+                    part_of_iri,
+                    custom_hierarchy_iri,
+                ]
+            }
+        }
+
+        def mock_uri_to_curie(uri, *args, **kwargs):
+            if uri == part_of_iri:
+                return PART_OF
+            if kwargs.get("use_uri_fallback"):
+                return uri
+            return None
+
+        self.oi.uri_to_curie.side_effect = mock_uri_to_curie
+
+        with self.assertRaisesRegex(NotImplementedError, "additional hierarchical predicates"):
+            list(
+                self.oi.relationships(
+                    subjects=[VACUOLE],
+                    predicates=[IS_A, PART_OF],
+                    include_entailed=True,
+                )
+            )
+
+        self.mock_client.get_json.assert_not_called()
+        self.assertTrue(
+            all(call.kwargs.get("use_uri_fallback") for call in self.oi.uri_to_curie.call_args_list)
+        )
+
+    def test_entailed_isa_ignores_additional_hierarchical_predicates(self):
+        """An is-a-only closure remains unambiguous for every OLS hierarchy config."""
+        self.mock_client.get_ontology.return_value = {
+            "config": {
+                "hierarchicalProperties": [
+                    "http://purl.obolibrary.org/obo/BFO_0000050",
+                    "http://purl.obolibrary.org/obo/RO_0002202",
+                ]
+            }
+        }
+        self.mock_client.get_json.return_value = self._hal_page(
+            [CELLULAR_COMPONENT], number=0, total_pages=1
+        )
+
+        rels = list(
+            self.oi.relationships(subjects=[VACUOLE], predicates=[IS_A], include_entailed=True)
+        )
+
+        self.assertIn((VACUOLE, IS_A, CELLULAR_COMPONENT), rels)
+        self.mock_client.get_ontology.assert_not_called()
 
     def test_descendants(self):
         oi = self.oi

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -2,6 +2,8 @@ import itertools
 import unittest
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from oaklib.datamodels.search import SearchConfiguration, SearchProperty
 from oaklib.datamodels.vocabulary import IS_A, PART_OF
 from oaklib.implementations.ols.ols_implementation import OlsImplementation
@@ -197,6 +199,13 @@ class TestOlsImplementation(unittest.TestCase):
         oi.focus_ontology = "go"
         self.assertIsNone(oi.label("GO:9999999"))
 
+    def test_label_missing_iri_http_error(self):
+        """label() should return None when OLS returns 404 for a non-term IRI."""
+        self.mock_client.get_term.side_effect = requests.HTTPError()
+        oi = self.oi
+        oi.focus_ontology = "go"
+        self.assertIsNone(oi.label(IS_A))
+
     @staticmethod
     def _hal_page(obo_ids, number, total_pages, key="terms"):
         """Build one page of an OLS4 HAL collection response.
@@ -244,6 +253,26 @@ class TestOlsImplementation(unittest.TestCase):
         )
         ancs = list(oi.ancestors([VACUOLE], predicates=[IS_A], reflexive=False))
         assert CELLULAR_COMPONENT in ancs
+
+    def test_entailed_relationships(self):
+        oi = self.oi
+
+        def mock_get_json(path, **kwargs):
+            if path.endswith("/ancestors"):
+                return self._hal_page([CELLULAR_COMPONENT], number=0, total_pages=1)
+            if path.endswith("/hierarchicalAncestors"):
+                return self._hal_page([CELLULAR_COMPONENT, CYTOPLASM], number=0, total_pages=1)
+            raise AssertionError(f"Unexpected path: {path}")
+
+        self.mock_client.get_json.side_effect = mock_get_json
+
+        rels = list(
+            oi.relationships(subjects=[VACUOLE], predicates=[IS_A, PART_OF], include_entailed=True)
+        )
+
+        self.assertIn((VACUOLE, IS_A, VACUOLE), rels)
+        self.assertIn((VACUOLE, IS_A, CELLULAR_COMPONENT), rels)
+        self.assertIn((VACUOLE, PART_OF, CYTOPLASM), rels)
 
     def test_descendants(self):
         oi = self.oi
@@ -335,13 +364,9 @@ class TestOlsImplementation(unittest.TestCase):
         set (is_a + part_of for GO), so ``[IS_A, PART_OF]`` is served by it.
         """
         self.assertEqual(self._descendants_endpoint([IS_A]), "descendants")
-        self.assertEqual(
-            self._descendants_endpoint([IS_A, PART_OF]), "hierarchicalDescendants"
-        )
+        self.assertEqual(self._descendants_endpoint([IS_A, PART_OF]), "hierarchicalDescendants")
         # order-independent
-        self.assertEqual(
-            self._descendants_endpoint([PART_OF, IS_A]), "hierarchicalDescendants"
-        )
+        self.assertEqual(self._descendants_endpoint([PART_OF, IS_A]), "hierarchicalDescendants")
         # default (no predicates) also traverses is_a + part_of
         self.assertEqual(self._descendants_endpoint(None), "hierarchicalDescendants")
 

--- a/tests/test_implementations/test_ols.py
+++ b/tests/test_implementations/test_ols.py
@@ -337,6 +337,60 @@ class TestOlsImplementation(unittest.TestCase):
         self.assertIn((VACUOLE, IS_A, CELLULAR_COMPONENT), rels)
         self.assertIn((VACUOLE, PART_OF, CYTOPLASM), rels)
 
+    def test_graph_relationships_preserve_unmapped_uris(self):
+        """Direct graph edges should retain URIs that cannot be contracted."""
+        known_source_iri = "http://purl.obolibrary.org/obo/GO_0005773"
+        known_target_iri = "http://purl.obolibrary.org/obo/GO_0005737"
+        unknown_source_iri = "http://example.org/unknown_source"
+        unknown_target_iri = "http://example.org/unknown_target"
+        unknown_predicate_iri = "http://example.org/unknown_predicate"
+        unconvertible_iri = "http://example.org/unconvertible"
+        self.mock_client.get_json.return_value = {
+            "edges": [
+                {
+                    "source": unknown_source_iri,
+                    "uri": unknown_predicate_iri,
+                    "target": known_target_iri,
+                },
+                {
+                    "source": known_source_iri,
+                    "uri": unknown_predicate_iri,
+                    "target": unknown_target_iri,
+                },
+                {
+                    "source": 42,
+                    "uri": unknown_predicate_iri,
+                    "target": known_target_iri,
+                },
+                {
+                    "source": unconvertible_iri,
+                    "uri": unknown_predicate_iri,
+                    "target": known_target_iri,
+                },
+            ]
+        }
+
+        def mock_uri_to_curie(uri, *args, **kwargs):
+            known_curies = {
+                known_source_iri: VACUOLE,
+                known_target_iri: CYTOPLASM,
+            }
+            if uri in known_curies:
+                return known_curies[uri]
+            if uri == unconvertible_iri:
+                return None
+            if kwargs.get("use_uri_fallback"):
+                return uri
+            return None
+
+        self.oi.uri_to_curie.side_effect = mock_uri_to_curie
+
+        incoming = list(self.oi.relationships(objects=[CYTOPLASM]))
+        outgoing = list(self.oi.relationships(subjects=[VACUOLE]))
+
+        self.assertEqual({(unknown_source_iri, unknown_predicate_iri, CYTOPLASM)}, set(incoming))
+        self.assertEqual({(VACUOLE, unknown_predicate_iri, unknown_target_iri)}, set(outgoing))
+
     def test_entailed_part_of_rejects_additional_hierarchical_predicates(self):
         """Hierarchy closure differences are ambiguous when OLS configures other predicates."""
         part_of_iri = "http://purl.obolibrary.org/obo/BFO_0000050"


### PR DESCRIPTION
## Summary

- Allow the `ancestors` CLI command to use OLS adapters that provide an `ancestors()` method without requiring `OboGraphInterface`.
- Add OLS `relationships()` support backed by OLS graph and hierarchy endpoints, including `--include-entailed` support for `-p i,p`.
- Treat missing OLS term lookups for predicate IRIs as absent labels instead of aborting CLI output.
- Add CLI and adapter regression tests for the OLS ancestors and relationships commands.

## Root Cause

The `ancestors` CLI command rejected OLS before dispatch because it was gated on `OboGraphInterface`. The `relationships` command reached the default `BasicOntologyInterface.relationships()` implementation for OLS, which recursively called `outgoing_relationship_map()` and eventually hit a recursion error. After adding OLS relationship support, the CSV writer also exposed that predicate labels such as `rdfs:subClassOf` can 404 in OLS term lookup.

## Validation

- `uv run black --check src/oaklib/cli.py src/oaklib/implementations/ols/ols_implementation.py tests/test_cli.py tests/test_implementations/test_ols.py`
- `uv run ruff check src/oaklib/cli.py src/oaklib/implementations/ols/ols_implementation.py tests/test_cli.py tests/test_implementations/test_ols.py`
- `uv run pytest tests/test_cli.py::TestCommandLineInterface::test_ols_ancestors_cli tests/test_cli.py::TestCommandLineInterface::test_ols_relationships_include_entailed_cli tests/test_implementations/test_ols.py::TestOlsImplementation::test_ancestors tests/test_implementations/test_ols.py::TestOlsImplementation::test_entailed_relationships tests/test_implementations/test_ols.py::TestOlsImplementation::test_label_missing_iri_http_error`
- `uv run runoak --stacktrace -i ols:go ancestors -p i,p GO:0005634`
- `uv run runoak --stacktrace -i ols:go relationships -p i,p GO:0005634`
- `uv run runoak --stacktrace -i ols:go relationships -p i,p GO:0005634 --include-entailed`